### PR TITLE
chore: drop orphan corgi_vscode_extension gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ corgi_services/*
 
 # local planning docs (not tracked)
 docs/plans/
+
+# local-only vscode extension (not a tracked submodule)
+corgi_vscode_extension/


### PR DESCRIPTION
Was a submodule pointer with no .gitmodules entry (no fetchable URL). Remove the gitlink and keep the directory local-only; ignore it so it isn't re-added.