### PR TITLE
fix: mcp stale compose-path bug + raise new-code coverage >80%

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -61,6 +61,48 @@ func TestRunConfigShow_DefaultsToOff(t *testing.T) {
 	}
 }
 
+func TestRunConfigShow_JSON(t *testing.T) {
+	prev := utils.JSONOutput
+	utils.JSONOutput = true
+	t.Cleanup(func() { utils.JSONOutput = prev })
+
+	dir := withTempHome(t)
+	if err := utils.SaveUserConfig(&utils.UserConfig{Notifications: true}); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() { runConfigShow(&cobra.Command{}, nil) })
+
+	var got configView
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if !got.Notifications {
+		t.Error("notifications should be true")
+	}
+	wantPath := filepath.Join(dir, ".corgi", "config.yml")
+	if got.Path != wantPath {
+		t.Errorf("path got %q want %q", got.Path, wantPath)
+	}
+}
+
+func TestConfigPathSubcommand_JSON(t *testing.T) {
+	prev := utils.JSONOutput
+	utils.JSONOutput = true
+	t.Cleanup(func() { utils.JSONOutput = prev })
+
+	dir := withTempHome(t)
+	out := captureStdout(t, func() { configPathCmd.Run(configPathCmd, nil) })
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	want := filepath.Join(dir, ".corgi", "config.yml")
+	if got["path"] != want {
+		t.Errorf("path got %q want %q", got["path"], want)
+	}
+}
+
 func TestConfigPathSubcommand_PrintsPath(t *testing.T) {
 	dir := withTempHome(t)
 	out := captureStdout(t, func() { configPathCmd.Run(configPathCmd, nil) })

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -308,8 +308,10 @@ func loadComposeCtx(composePath string) (composeContext, error) {
 	tmp.Flags().Bool("seed", false, "")
 
 	cleanup := func() {
+		// Reset on rootCmd directly: after RemoveCommand, tmp.Root() is tmp, not
+		// rootCmd, so the stale filename would leak into the next tool call.
+		_ = rootCmd.PersistentFlags().Set("filename", "")
 		rootCmd.RemoveCommand(tmp)
-		_ = tmp.Root().PersistentFlags().Set("filename", "")
 	}
 
 	if composePath != "" {

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -457,5 +458,40 @@ func TestMCPWithStdoutToStderr(t *testing.T) {
 	}
 	if len(data) != 0 {
 		t.Errorf("expected nothing on real stdout during swap, got %q", string(data))
+	}
+}
+
+// TestLoadComposeCtxResetsFilenameFlag guards the just-fixed leak: a first call
+// with an explicit composePath must not leak that path into a later call with
+// composePath="". cleanup() resets rootCmd's filename persistent flag, so the
+// second load resolves the compose in the current working dir, not the first.
+func TestLoadComposeCtxResetsFilenameFlag(t *testing.T) {
+	// Explicit-path load: a compose file in a dedicated dir.
+	dirA := t.TempDir()
+	pathA := filepath.Join(dirA, "corgi-compose.yml")
+	if err := os.WriteFile(pathA, []byte("name: explicit-a\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := loadComposeForMCP(pathA)
+	if err != nil {
+		t.Fatalf("first load (explicit path): %v", err)
+	}
+	if first.Name != "explicit-a" {
+		t.Fatalf("first load name got %q want explicit-a", first.Name)
+	}
+
+	if got := rootCmd.PersistentFlags().Lookup("filename").Value.String(); got != "" {
+		t.Fatalf("filename flag leaked after explicit-path load: %q", got)
+	}
+
+	// Second load with "" must resolve cwd's compose, not pathA.
+	chdirToTempCompose(t, "name: cwd-b\n")
+	second, err := loadComposeForMCP("")
+	if err != nil {
+		t.Fatalf("second load (cwd): %v", err)
+	}
+	if second.Name != "cwd-b" {
+		t.Fatalf("second load inherited stale filename; got %q want cwd-b", second.Name)
 	}
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -30,10 +30,14 @@ func init() {
 	restartCmd.Flags().String("host", "", "IP to use instead of localhost in service URL env vars")
 }
 
+func restartUnsupportedMessage(service string) string {
+	return "restart --service is not supported yet; use: corgi stop --service " +
+		service + " && corgi run --detach"
+}
+
 func runRestart(cmd *cobra.Command, args []string) {
 	if restartService != "" {
-		msg := "restart --service is not supported yet; use: corgi stop --service " +
-			restartService + " && corgi run --detach"
+		msg := restartUnsupportedMessage(restartService)
 		if utils.JSONOutput {
 			utils.JSONError(utils.ErrUnsupported, msg)
 		} else {

--- a/cmd/restart_test.go
+++ b/cmd/restart_test.go
@@ -1,6 +1,22 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestRestartUnsupportedMessage(t *testing.T) {
+	msg := restartUnsupportedMessage("api")
+	if !strings.Contains(msg, "not supported yet") {
+		t.Errorf("expected unsupported notice, got %q", msg)
+	}
+	if !strings.Contains(msg, "corgi stop --service api") {
+		t.Errorf("expected stop hint with service name, got %q", msg)
+	}
+	if !strings.Contains(msg, "corgi run --detach") {
+		t.Errorf("expected run --detach hint, got %q", msg)
+	}
+}
 
 func TestRestartCmdRegistered(t *testing.T) {
 	c, _, err := rootCmd.Find([]string{"restart"})

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -541,3 +541,42 @@ func stopWatch(t *testing.T, cancel context.CancelFunc, done <-chan struct{}) {
 		t.Fatal("watch goroutine did not stop after cancel")
 	}
 }
+
+func TestFinalizeTimeoutHuman(t *testing.T) {
+	// down + !healthy + human -> the timeout branch plus renderProbeResults.
+	rows := []statusRow{{Label: "down", Kind: "tcp", Port: 1}}
+	out := captureStdout(t, func() { finalize(rows, false, false, false) })
+	if !strings.Contains(out, "timeout") {
+		t.Errorf("expected timeout summary, got %q", out)
+	}
+}
+
+func TestRunStatusUntilHealthyImmediate(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+	rows := []statusRow{{Label: "svc", Kind: "tcp", Port: port}}
+
+	// Already healthy: returns on the first check without entering the ticker
+	// loop or calling os.Exit.
+	out := captureStdout(t, func() {
+		runStatusUntilHealthy(rows, 50*time.Millisecond, 2*time.Second, false, false)
+	})
+	if !strings.Contains(out, "healthy") {
+		t.Errorf("expected healthy finalize, got %q", out)
+	}
+}
+
+func TestProbeHTTPDownReason(t *testing.T) {
+	// Unreachable host: code==0 so the reason branch (not the HTTP-code branch).
+	ok, detail := probe(statusRow{Kind: "http", URL: "http://127.0.0.1:1/health", Port: 1})
+	if ok {
+		t.Fatal("expected down")
+	}
+	if !strings.Contains(detail, "(") {
+		t.Errorf("expected reason detail, got %q", detail)
+	}
+}

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -47,6 +47,66 @@ func TestRemoveStateEntry(t *testing.T) {
 	}
 }
 
+func TestEmitStopSummary_HumanNothingToStop(t *testing.T) {
+	orig := utils.JSONOutput
+	defer func() { utils.JSONOutput = orig }()
+	utils.JSONOutput = false
+
+	out := captureStdout(t, func() {
+		emitStopSummary(stopSummary{Stopped: []string{}, Failed: []stopFailure{}})
+	})
+	if !strings.Contains(out, "nothing to stop") {
+		t.Errorf("expected 'nothing to stop', got %q", out)
+	}
+}
+
+func TestEmitStopSummary_HumanStoppedAndFailed(t *testing.T) {
+	orig := utils.JSONOutput
+	defer func() { utils.JSONOutput = orig }()
+	utils.JSONOutput = false
+
+	out := captureStdout(t, func() {
+		emitStopSummary(stopSummary{
+			Stopped: []string{"api"},
+			Failed:  []stopFailure{{Name: "web", Error: "boom"}},
+		})
+	})
+	if !strings.Contains(out, "stopped") || !strings.Contains(out, "api") {
+		t.Errorf("expected stopped api, got %q", out)
+	}
+	if !strings.Contains(out, "failed to stop") || !strings.Contains(out, "web") || !strings.Contains(out, "boom") {
+		t.Errorf("expected failed web with reason, got %q", out)
+	}
+}
+
+func TestEmitStopSummary_JSONToStderr(t *testing.T) {
+	origJSON, origStderr := utils.JSONOutput, stopSummaryToStderr
+	defer func() { utils.JSONOutput, stopSummaryToStderr = origJSON, origStderr }()
+	utils.JSONOutput = true
+	stopSummaryToStderr = true
+
+	out := captureStderr(t, func() {
+		emitStopSummary(stopSummary{Stopped: []string{"api"}, Failed: []stopFailure{}})
+	})
+	if !strings.Contains(out, `"api"`) {
+		t.Errorf("expected JSON summary on stderr with api, got %q", out)
+	}
+}
+
+func TestStopProcessGroup_NoPidRecorded(t *testing.T) {
+	err := stopProcessGroup(utils.RunStateEntry{PID: 0, PGID: 0})
+	if err == nil || !strings.Contains(err.Error(), "no pid recorded") {
+		t.Errorf("expected 'no pid recorded', got %v", err)
+	}
+}
+
+func TestStopProcessGroup_NegativePid(t *testing.T) {
+	err := stopProcessGroup(utils.RunStateEntry{PID: -5})
+	if err == nil || !strings.Contains(err.Error(), "no pid recorded") {
+		t.Errorf("expected 'no pid recorded' for negative pid, got %v", err)
+	}
+}
+
 func TestEmitStopSummary_JSON(t *testing.T) {
 	origJSON, origStderr := utils.JSONOutput, stopSummaryToStderr
 	defer func() { utils.JSONOutput, stopSummaryToStderr = origJSON, origStderr }()

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -44,6 +44,10 @@ func TestPrintValidateHuman_Branches(t *testing.T) {
 			[]string{"⚠ [W_X] soft", "valid — 1 warning(s)"}},
 		{"strict-warnings", nil, []utils.ValidationIssue{warnItem}, true,
 			[]string{"failing under --strict"}},
+		{"errors-and-warnings", []utils.ValidationIssue{errItem}, []utils.ValidationIssue{warnItem}, false,
+			[]string{"✗ [E_X] broken", "⚠ [W_X] soft", "1 error(s), 1 warning(s)"}},
+		{"error-no-field", []utils.ValidationIssue{{Code: "E_Y", Message: "nofield"}}, nil, false,
+			[]string{"✗ [E_Y] nofield"}},
 	}
 
 	for _, tc := range cases {

--- a/utils/execute_test.go
+++ b/utils/execute_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -622,6 +623,268 @@ func TestRunCleanupCommandsSurvivesKillAll(t *testing.T) {
 	<-done
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("cleanup was killed by KillAllStoredProcesses: %v", err)
+	}
+}
+
+// fakeLogWriter implements the optional interfaces runManaged/markServiceLogStatus
+// probe (SetStatus/CurrentStatus/Path) without touching the filesystem. Writes
+// can come from a detached child process goroutine, so access is mutex-guarded.
+type fakeLogWriter struct {
+	mu     sync.Mutex
+	buf    strings.Builder
+	status LogStatus
+	path   string
+	closed bool
+}
+
+func (f *fakeLogWriter) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.buf.Write(p)
+}
+func (f *fakeLogWriter) written() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.buf.String()
+}
+func (f *fakeLogWriter) SetStatus(s LogStatus)    { f.status = s }
+func (f *fakeLogWriter) CurrentStatus() LogStatus { return f.status }
+func (f *fakeLogWriter) Path() string             { return f.path }
+func (f *fakeLogWriter) Close() error             { f.closed = true; return nil }
+
+func TestSetAndCloseLogWriters(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	CloseAllLogWriters()
+
+	first := &fakeLogWriter{path: "/tmp/a.log"}
+	SetLogWriter("svc", first)
+	if got := LogFilePath("svc"); got != "/tmp/a.log" {
+		t.Fatalf("LogFilePath got %q", got)
+	}
+
+	// Replacing closes the previous writer (fd-leak guard).
+	second := &fakeLogWriter{path: "/tmp/b.log"}
+	SetLogWriter("svc", second)
+	if !first.closed {
+		t.Error("previous writer should be closed on replace")
+	}
+	if got := LogFilePath("svc"); got != "/tmp/b.log" {
+		t.Fatalf("LogFilePath after replace got %q", got)
+	}
+
+	CloseAllLogWriters()
+	if !second.closed {
+		t.Error("CloseAllLogWriters should close registered writer")
+	}
+	if got := LogFilePath("svc"); got != "" {
+		t.Errorf("expected empty path after CloseAll, got %q", got)
+	}
+}
+
+func TestLogFilePathNoWriter(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	CloseAllLogWriters()
+	if got := LogFilePath("absent"); got != "" {
+		t.Errorf("expected empty for unregistered service, got %q", got)
+	}
+}
+
+func TestMarkServiceLogStatus(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	w := &fakeLogWriter{}
+	SetLogWriter("svc", w)
+
+	markServiceLogStatus("svc", LogStatusOK)
+	if w.status != LogStatusOK {
+		t.Fatalf("status got %v", w.status)
+	}
+}
+
+func TestMarkServiceLogStatusIfNotCrashed_DoesNotDowngrade(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	w := &fakeLogWriter{status: LogStatusCrashed}
+	SetLogWriter("svc", w)
+
+	// A later success must not overwrite an earlier crash.
+	markServiceLogStatusIfNotCrashed("svc", LogStatusOK)
+	if w.status != LogStatusCrashed {
+		t.Fatalf("crashed status was downgraded to %v", w.status)
+	}
+}
+
+func TestMarkServiceLogStatusIfNotCrashed_SetsWhenClean(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	w := &fakeLogWriter{status: LogStatusUnknown}
+	SetLogWriter("svc", w)
+
+	markServiceLogStatusIfNotCrashed("svc", LogStatusOK)
+	if w.status != LogStatusOK {
+		t.Fatalf("expected OK, got %v", w.status)
+	}
+}
+
+func TestSetOnServiceCrashStoreAndClear(t *testing.T) {
+	t.Cleanup(func() { SetOnServiceCrash(nil) })
+	called := make(chan string, 1)
+	SetOnServiceCrash(func(name string) { called <- name })
+	if fn := onServiceCrash.Load(); fn == nil {
+		t.Fatal("callback not stored")
+	} else {
+		(*fn)("svc")
+	}
+	if got := <-called; got != "svc" {
+		t.Errorf("callback got %q", got)
+	}
+	SetOnServiceCrash(nil)
+	if onServiceCrash.Load() != nil {
+		t.Error("callback not cleared")
+	}
+}
+
+func TestRunServiceCommandExitCode_Zero(t *testing.T) {
+	prev := ProcessHandles
+	ProcessHandles = nil
+	t.Cleanup(func() { ProcessHandles = prev })
+
+	var out, errBuf strings.Builder
+	code, err := RunServiceCommandExitCode("exit 0", t.TempDir(), false, &out, &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code got %d", code)
+	}
+	if len(ProcessHandles) != 0 {
+		t.Errorf("process not deregistered, got %d", len(ProcessHandles))
+	}
+}
+
+func TestRunServiceCommandExitCode_NonZero(t *testing.T) {
+	var out, errBuf strings.Builder
+	code, err := RunServiceCommandExitCode("exit 7", t.TempDir(), false, &out, &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if code != 7 {
+		t.Fatalf("exit code got %d want 7", code)
+	}
+}
+
+func TestRunServiceCommandExitCode_CapturesOutput(t *testing.T) {
+	var out, errBuf strings.Builder
+	code, err := RunServiceCommandExitCode("echo hi; echo boom 1>&2", t.TempDir(), false, &out, &errBuf)
+	if err != nil || code != 0 {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	if !strings.Contains(out.String(), "hi") {
+		t.Errorf("stdout got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "boom") {
+		t.Errorf("stderr got %q", errBuf.String())
+	}
+}
+
+func TestRunServiceCommandExitCode_SourcesEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("MYVAR=present\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf strings.Builder
+	code, err := RunServiceCommandExitCode("echo $MYVAR", dir, false, &out, &errBuf)
+	if err != nil || code != 0 {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	if strings.TrimSpace(out.String()) != "present" {
+		t.Errorf("env not sourced, got %q", out.String())
+	}
+}
+
+func TestStartDetached(t *testing.T) {
+	prev := ProcessHandles
+	ProcessHandles = nil
+	t.Cleanup(func() { ProcessHandles = prev })
+
+	proc, err := StartDetached("svc", "sleep 0.2", t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if proc == nil {
+		t.Fatal("expected a process handle")
+	}
+	if len(ProcessHandles) == 0 {
+		t.Error("detached process should be tracked")
+	}
+	t.Cleanup(func() {
+		_, _ = proc.Wait()
+		removeProcess(proc)
+	})
+}
+
+func TestStartDetachedWritesToLogWriter(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	prev := ProcessHandles
+	ProcessHandles = nil
+	t.Cleanup(func() { ProcessHandles = prev })
+
+	w := &fakeLogWriter{}
+	SetLogWriter("svc", w)
+	proc, err := StartDetached("svc", "echo detached-out", t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	_, _ = proc.Wait()
+	removeProcess(proc)
+	if got := w.written(); !strings.Contains(got, "detached-out") {
+		t.Errorf("detached output not written to log writer, got %q", got)
+	}
+}
+
+func TestStopDockerRunnerServicesNonexistent(t *testing.T) {
+	prevTimeout := AfterStartTimeout
+	AfterStartTimeout = 2 * time.Second
+	t.Cleanup(func() { AfterStartTimeout = prevTimeout })
+
+	prev := CorgiComposePathDir
+	CorgiComposePathDir = t.TempDir()
+	t.Cleanup(func() { CorgiComposePathDir = prev })
+
+	// No service dir / no Makefile: make fails but the call must be non-fatal.
+	StopDockerRunnerServices([]string{"absent-svc"})
+}
+
+func TestStopDockerRunnerServicesEmpty(t *testing.T) {
+	StopDockerRunnerServices(nil)
+	StopDockerRunnerServices([]string{})
+}
+
+func TestRunManagedCrashFiresCallback(t *testing.T) {
+	t.Cleanup(CloseAllLogWriters)
+	prev := ProcessHandles
+	ProcessHandles = nil
+	t.Cleanup(func() { ProcessHandles = prev })
+
+	w := &fakeLogWriter{}
+	SetLogWriter("crashy", w)
+
+	crashed := make(chan string, 1)
+	SetOnServiceCrash(func(name string) { crashed <- name })
+	t.Cleanup(func() { SetOnServiceCrash(nil) })
+
+	// Non-zero exit (not a missing executable) → crash path, callback fires.
+	err := RunServiceCmd("crashy", "exit 3", t.TempDir(), false)
+	if err == nil {
+		t.Fatal("expected error from non-zero exit")
+	}
+	select {
+	case name := <-crashed:
+		if name != "crashy" {
+			t.Errorf("callback got %q", name)
+		}
+	default:
+		t.Fatal("crash callback was not fired")
+	}
+	if w.status != LogStatusCrashed {
+		t.Errorf("log status got %v want Crashed", w.status)
 	}
 }
 


### PR DESCRIPTION
## Bug fix (Critical)
`loadComposeCtx` cleanup ran `RemoveCommand(tmp)` before `Set("filename","")`, so `tmp.Root()` was no longer `rootCmd` and the filename flag never reset. After any MCP tool call with an explicit `composePath`, later calls that omit it silently resolved to the **stale path** (wrong project). Fixed by resetting on `rootCmd` before removal. Also fixes the `-count=2` MCP test flakiness. Regression test added (`TestLoadComposeCtxResetsFilenameFlag`).

## Coverage
SonarCloud new-code line coverage was 79.2% (gate ≥80%). Added real tests (no docker/daemon/TTY faking), +84 covered statements on the biggest uncovered non-excluded files:
- utils/execute.go 49.1% → ~86% (RunServiceCommandExitCode, StartDetached, StopDockerRunnerServices, log-writer lifecycle, runManaged crash path)
- cmd/stop.go, cmd/config.go, cmd/restart.go, cmd/status.go, cmd/validate.go — builder/JSON/error-path coverage
- One behavior-preserving extraction: `restartUnsupportedMessage`

## Test plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `go test ./...` — 1155 passing
- [x] `go test -race -count=1` on touched packages — clean
- [x] MCP `-count=2` now passes (was flaky)

Follow-up to #6. Found via a 4-agent bug-hunt over the full feature diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)