### PR TITLE
Skip manualRun services and dbs in the --wait readiness gate

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -47,7 +47,7 @@ func runUpAll(cmd *cobra.Command, dbs []utils.DatabaseService) {
 // Wait for each db with a port to accept connections. ready is injected for tests.
 func waitForDbsReady(ctx context.Context, dbs []utils.DatabaseService, ready func(context.Context, utils.DatabaseService) error) error {
 	for _, db := range dbs {
-		if db.Port == 0 {
+		if db.Port == 0 || db.ManualRun {
 			continue
 		}
 		if err := ready(ctx, db); err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -708,7 +708,7 @@ func waitDetachedReady(ctx context.Context, corgi *utils.CorgiCompose) error {
 // ready is injected for tests.
 func waitForServicesReady(ctx context.Context, services []utils.Service, ready func(context.Context, utils.Service) error) error {
 	for _, svc := range services {
-		if svc.Port == 0 {
+		if svc.Port == 0 || skipReadinessWait(svc) {
 			continue
 		}
 		if err := ready(ctx, svc); err != nil {
@@ -1113,6 +1113,18 @@ func startDatabaseIfNeeded(dbService utils.DatabaseService) {
 	if err := utils.WaitForDBReady(ctx, dbService); err != nil {
 		utils.Infof("⚠️  %s\n", err)
 	}
+}
+
+// skipReadinessWait reports whether this run declined to start the service,
+// in which case waiting for it can only burn the timeout.
+func skipReadinessWait(service utils.Service) bool {
+	if !service.ManualRun {
+		return false
+	}
+	if len(utils.ServicesItemsFromFlag) == 0 {
+		return true
+	}
+	return !utils.IsServiceIncludedInFlag(utils.ServicesItemsFromFlag, service.ServiceName)
 }
 
 func shouldSkipManualRun(service utils.Service) bool {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1115,31 +1115,27 @@ func startDatabaseIfNeeded(dbService utils.DatabaseService) {
 	}
 }
 
-// skipReadinessWait reports whether this run declined to start the service,
-// in which case waiting for it can only burn the timeout.
+// skipReadinessWait reports whether this run declined to start the service, in
+// which case waiting for it can only burn the timeout. One predicate, because
+// a launcher and a readiness gate that disagree is the bug this fixes.
 func skipReadinessWait(service utils.Service) bool {
 	if !service.ManualRun {
 		return false
 	}
-	if len(utils.ServicesItemsFromFlag) == 0 {
-		return true
-	}
-	return !utils.IsServiceIncludedInFlag(utils.ServicesItemsFromFlag, service.ServiceName)
+	return len(utils.ServicesItemsFromFlag) == 0 ||
+		!utils.IsServiceIncludedInFlag(utils.ServicesItemsFromFlag, service.ServiceName)
 }
 
 func shouldSkipManualRun(service utils.Service) bool {
-	if !service.ManualRun {
+	if !skipReadinessWait(service) {
 		return false
 	}
 	if len(utils.ServicesItemsFromFlag) == 0 {
 		utils.Info(service.ServiceName, "is not run, because it should be run manually (manualRun)")
-		return true
-	}
-	if !utils.IsServiceIncludedInFlag(utils.ServicesItemsFromFlag, service.ServiceName) {
+	} else {
 		utils.Info(service.ServiceName, "is not run, because it should be added manually")
-		return true
 	}
-	return false
+	return true
 }
 
 func runServicePullIfRequested(cobraCmd *cobra.Command, service utils.Service) {

--- a/cmd/run_detach_wait_test.go
+++ b/cmd/run_detach_wait_test.go
@@ -68,3 +68,66 @@ func TestWaitDetachedReady_UnreachableServiceTimesOut(t *testing.T) {
 		t.Fatal("expected a timeout error for an unreachable service")
 	}
 }
+
+func TestWaitForServicesReadySkipsManualRun(t *testing.T) {
+	prev := utils.ServicesItemsFromFlag
+	utils.ServicesItemsFromFlag = nil
+	t.Cleanup(func() { utils.ServicesItemsFromFlag = prev })
+
+	var probed []string
+	ready := func(_ context.Context, svc utils.Service) error {
+		probed = append(probed, svc.ServiceName)
+		return nil
+	}
+
+	err := waitForServicesReady(context.Background(), []utils.Service{
+		{ServiceName: "api", Port: 3000},
+		{ServiceName: "manual", Port: 3001, ManualRun: true},
+		{ServiceName: "noport"},
+	}, ready)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if len(probed) != 1 || probed[0] != "api" {
+		t.Errorf("a manualRun service is never started, so it must not be waited for; probed %v", probed)
+	}
+}
+
+func TestWaitForServicesReadyWaitsForExplicitlySelectedManualRun(t *testing.T) {
+	prev := utils.ServicesItemsFromFlag
+	utils.ServicesItemsFromFlag = []string{"manual"}
+	t.Cleanup(func() { utils.ServicesItemsFromFlag = prev })
+
+	var probed []string
+	ready := func(_ context.Context, svc utils.Service) error {
+		probed = append(probed, svc.ServiceName)
+		return nil
+	}
+
+	if err := waitForServicesReady(context.Background(), []utils.Service{
+		{ServiceName: "manual", Port: 3001, ManualRun: true},
+	}, ready); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if len(probed) != 1 {
+		t.Errorf("--services asked for it, so it does start and must be waited for; probed %v", probed)
+	}
+}
+
+func TestWaitForDbsReadySkipsManualRun(t *testing.T) {
+	var probed []string
+	ready := func(_ context.Context, db utils.DatabaseService) error {
+		probed = append(probed, db.ServiceName)
+		return nil
+	}
+
+	if err := waitForDbsReady(context.Background(), []utils.DatabaseService{
+		{ServiceName: "pg", Port: 5432},
+		{ServiceName: "manual", Port: 5433, ManualRun: true},
+	}, ready); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if len(probed) != 1 || probed[0] != "pg" {
+		t.Errorf("probed %v", probed)
+	}
+}

--- a/cmd/run_detach_wait_test.go
+++ b/cmd/run_detach_wait_test.go
@@ -131,3 +131,28 @@ func TestWaitForDbsReadySkipsManualRun(t *testing.T) {
 		t.Errorf("probed %v", probed)
 	}
 }
+
+// The launcher and the readiness gate must agree; disagreeing is the bug this
+// pair of functions exists to prevent.
+func TestSkipReadinessWaitAgreesWithLauncher(t *testing.T) {
+	prev := utils.ServicesItemsFromFlag
+	t.Cleanup(func() { utils.ServicesItemsFromFlag = prev })
+
+	cases := []struct {
+		name     string
+		selected []string
+		service  utils.Service
+	}{
+		{"plain service", nil, utils.Service{ServiceName: "api"}},
+		{"manual, nothing selected", nil, utils.Service{ServiceName: "m", ManualRun: true}},
+		{"manual, selected", []string{"m"}, utils.Service{ServiceName: "m", ManualRun: true}},
+		{"manual, other selected", []string{"api"}, utils.Service{ServiceName: "m", ManualRun: true}},
+		{"plain, other selected", []string{"api"}, utils.Service{ServiceName: "web"}},
+	}
+	for _, c := range cases {
+		utils.ServicesItemsFromFlag = c.selected
+		if got, want := skipReadinessWait(c.service), shouldSkipManualRun(c.service); got != want {
+			t.Errorf("%s: wait skips=%v but launcher skips=%v", c.name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
`corgi run --detach --wait` waited on services it never started.

Found booting a real 11-service stack: the run sat for the full `--wait-timeout 25m` on a `manualRun: true` frontend, then reported `E_READINESS_TIMEOUT`. `corgi status` was already correct (it filters `ManualRun`), so the stack was healthy the whole time — only the gate disagreed.

In CI that is 25 wasted minutes on every run.

- `waitForServicesReady` skips what the run declined to start, mirroring `shouldSkipManualRun` — so a manualRun service named explicitly in `--services` is still waited for
- `waitForDbsReady` skips `ManualRun` dbs, matching `corgi status`

Three tests cover both paths and the explicitly-selected case.