### PR TITLE
Add corgi init --feature to clone the fleet at a branch

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -34,7 +34,9 @@ func init() {
 	initCmd.Flags().StringVar(&initFeatureFlag, "feature", "",
 		`Check out this branch in every service repo that has it, leaving the rest
 on their default branch. Same rule as run --feature, applied to the checkouts
-themselves, so anything reading a repo's files afterwards sees the branch.`)
+themselves, so anything reading a repo's files afterwards sees the branch.
+Wins over a service's compose branch: when the repo has it; where it does not,
+the compose branch: still applies.`)
 }
 
 // checkoutFeatureBranches switches the freshly cloned repos to the feature

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,11 +25,36 @@ This is used to create db service from template.
 }
 
 var initDepthFlag int
+var initFeatureFlag string
 
 func init() {
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().IntVar(&initDepthFlag, "depth", 0,
 		"Clone each service repo shallow, keeping this many commits (0 = full clone)")
+	initCmd.Flags().StringVar(&initFeatureFlag, "feature", "",
+		`Check out this branch in every service repo that has it, leaving the rest
+on their default branch. Same rule as run --feature, applied to the checkouts
+themselves, so anything reading a repo's files afterwards sees the branch.`)
+}
+
+// checkoutFeatureBranches switches the freshly cloned repos to the feature
+// branch, so a later step reading their files gets the code under review rather
+// than the default branch.
+func checkoutFeatureBranches(services []utils.Service, branch string) {
+	if branch == "" {
+		return
+	}
+	for _, service := range services {
+		switched, err := utils.CheckoutFeatureBranch(service.AbsolutePath, branch)
+		switch {
+		case err != nil:
+			fmt.Printf("feature: %s → %v\n", service.ServiceName, err)
+		case switched:
+			utils.Info("feature:", service.ServiceName, "→", branch)
+		default:
+			utils.Info("feature:", service.ServiceName, "→ no", branch, "branch, staying on its default")
+		}
+	}
 }
 
 func runInit(cmd *cobra.Command, _ []string) {
@@ -44,6 +69,7 @@ func runInit(cmd *cobra.Command, _ []string) {
 	CreateDatabaseServices(corgi.DatabaseServices)
 	CreateServices(corgi.Services)
 	cloneFailures := CloneServices(corgi.Services)
+	checkoutFeatureBranches(corgi.Services, initFeatureFlag)
 	RunRequired(corgi.Required)
 
 	utils.RunServiceCommands(

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"andriiklymiuk/corgi/utils"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -681,4 +682,49 @@ func TestCloneServicesNoPathIsNotAFailure(t *testing.T) {
 	if failed := CloneServices([]utils.Service{{ServiceName: "inplace"}}); len(failed) != 0 {
 		t.Errorf("a service with no path runs in place; not a clone failure, got %v", failed)
 	}
+}
+
+func TestCheckoutFeatureBranchesOverridesComposeBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	repo := filepath.Join(root, "api")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-b", "main"}, {"commit", "--allow-empty", "-m", "init"},
+		{"branch", "develop"}, {"branch", "feature/x"}, {"checkout", "develop"},
+	} {
+		c := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		c.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	svc := utils.Service{ServiceName: "api", AbsolutePath: repo, Branch: "develop"}
+
+	// --feature wins over the compose branch: the flag is the more specific intent.
+	checkoutFeatureBranches([]utils.Service{svc}, "feature/x")
+	if cur := currentBranch(t, repo); cur != "feature/x" {
+		t.Errorf("--feature should win over compose branch:, on %q", cur)
+	}
+
+	// A repo without the feature branch keeps whatever it was on.
+	checkoutFeatureBranches([]utils.Service{svc}, "absent")
+	if cur := currentBranch(t, repo); cur != "feature/x" {
+		t.Errorf("a missing feature branch must not move the checkout, on %q", cur)
+	}
+}
+
+func currentBranch(t *testing.T, repo string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repo, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/resources/readme/commands/corgi_init.md
+++ b/resources/readme/commands/corgi_init.md
@@ -17,8 +17,11 @@ corgi init [flags]
 ### Options
 
 ```
-      --depth int   Clone each service repo shallow, keeping this many commits (0 = full clone)
-  -h, --help        help for init
+      --depth int        Clone each service repo shallow, keeping this many commits (0 = full clone)
+      --feature string   Check out this branch in every service repo that has it, leaving the rest
+                         on their default branch. Same rule as run --feature, applied to the checkouts
+                         themselves, so anything reading a repo's files afterwards sees the branch.
+  -h, --help             help for init
 ```
 
 ### Options inherited from parent commands

--- a/resources/readme/commands/corgi_init.md
+++ b/resources/readme/commands/corgi_init.md
@@ -21,6 +21,8 @@ corgi init [flags]
       --feature string   Check out this branch in every service repo that has it, leaving the rest
                          on their default branch. Same rule as run --feature, applied to the checkouts
                          themselves, so anything reading a repo's files afterwards sees the branch.
+                         Wins over a service's compose branch: when the repo has it; where it does not,
+                         the compose branch: still applies.
   -h, --help             help for init
 ```
 

--- a/utils/serviceWorktree.go
+++ b/utils/serviceWorktree.go
@@ -349,6 +349,41 @@ func isRepoRoot(dir string) bool {
 	return root == self
 }
 
+// CheckoutFeatureBranch switches repo to branch in place when it carries it,
+// fetching from origin first. Reports whether it switched. Unlike the worktree
+// path this is for freshly cloned repos, where there is no work to preserve.
+func CheckoutFeatureBranch(repo, branch string) (bool, error) {
+	if branch == "" || !isGitRepo(repo) {
+		return false, nil
+	}
+	if cur, _ := gitOut(repo, "rev-parse", "--abbrev-ref", "HEAD"); cur == branch {
+		return true, nil
+	}
+	local, remote := branchIsKnown(repo, branch)
+	if !local && !remote {
+		return false, nil
+	}
+	if !local {
+		spec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch)
+		args := []string{"fetch", "--no-tags"}
+		if isShallowRepo(repo) {
+			args = append(args, "--depth", "1")
+		}
+		args = append(args, "origin", spec)
+		if err := gitRunNoPrompt(repo, args...); err != nil {
+			return false, fmt.Errorf("fetch origin %s: %v", branch, err)
+		}
+		if err := gitRun(repo, "checkout", "-B", branch, "refs/remotes/origin/"+branch); err != nil {
+			return false, fmt.Errorf("checkout %s: %v", branch, err)
+		}
+		return true, nil
+	}
+	if err := gitRun(repo, "checkout", branch); err != nil {
+		return false, fmt.Errorf("checkout %s: %v", branch, err)
+	}
+	return true, nil
+}
+
 // EnsureFeatureWorktree materializes branch for repo when it exists locally or
 // on origin, fetching the remote head first. Returns an empty dir and no error
 // when the repo does not carry the branch.

--- a/utils/serviceWorktree_test.go
+++ b/utils/serviceWorktree_test.go
@@ -658,3 +658,57 @@ func TestWorktreeForBranchAbsent(t *testing.T) {
 		t.Errorf("a non-repo yields nothing, got %q", got)
 	}
 }
+
+func TestCheckoutFeatureBranchInPlace(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	repo := filepath.Join(root, "api")
+	initRepo(t, repo)
+	git(t, repo, "branch", "feature/x")
+
+	switched, err := CheckoutFeatureBranch(repo, "feature/x")
+	if err != nil || !switched {
+		t.Fatalf("switch: (%v, %v)", switched, err)
+	}
+	if cur, _ := gitOut(repo, "rev-parse", "--abbrev-ref", "HEAD"); cur != "feature/x" {
+		t.Errorf("HEAD = %q, want feature/x", cur)
+	}
+
+	if switched, err := CheckoutFeatureBranch(repo, "feature/x"); err != nil || !switched {
+		t.Errorf("already on the branch is still a switch: (%v, %v)", switched, err)
+	}
+	if switched, err := CheckoutFeatureBranch(repo, "nope"); err != nil || switched {
+		t.Errorf("a missing branch is a no-op, got (%v, %v)", switched, err)
+	}
+	if switched, err := CheckoutFeatureBranch(repo, ""); err != nil || switched {
+		t.Errorf("no branch is a no-op, got (%v, %v)", switched, err)
+	}
+	if switched, err := CheckoutFeatureBranch(filepath.Join(root, "nothing"), "x"); err != nil || switched {
+		t.Errorf("a non-repo is a no-op, got (%v, %v)", switched, err)
+	}
+}
+
+func TestCheckoutFeatureBranchFromRemoteOnly(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin")
+	initRepo(t, origin)
+	git(t, origin, "branch", "feature/x")
+
+	clone := filepath.Join(root, "clone")
+	if out, err := exec.Command("git", "clone", "--depth", "1", "--branch", "main", "file://"+origin, clone).CombinedOutput(); err != nil {
+		t.Fatalf("clone: %v\n%s", err, out)
+	}
+
+	switched, err := CheckoutFeatureBranch(clone, "feature/x")
+	if err != nil || !switched {
+		t.Fatalf("a shallow clone must still reach a remote-only branch: (%v, %v)", switched, err)
+	}
+	if cur, _ := gitOut(clone, "rev-parse", "--abbrev-ref", "HEAD"); cur != "feature/x" {
+		t.Errorf("HEAD = %q, want feature/x", cur)
+	}
+}


### PR DESCRIPTION
`run --feature` switches branches when the stack starts. Anything that reads a repo's files *before* that sees the default branch instead.

Hit this for real: a CI job checks that every service's committed CI env file covers the keys its `.env.example` declares. It runs after `corgi init` and before `corgi run`, so it read `main` — meaning a PR that added a variable **and** its value in the same commit would still fail the check.

`init --feature <branch>` checks the branch out in place in every repo that has it, leaving the rest on their default. Fresh clones have no work to preserve, so in place is right here — no worktrees. `run --feature` afterwards finds each checkout already on the branch and uses it as-is.

Handles the shallow/remote-only case (`--depth 1` clone, branch only on origin) and is a no-op for a repo without the branch.