### PR TITLE
Run service commands with bash when it is available

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.20.8"
+var APP_VERSION = "1.20.9"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/utils/execute.go
+++ b/utils/execute.go
@@ -44,6 +44,31 @@ func withEnvSource(command, envFile string) string {
 // SkipAutoSourceEnv disables auto-sourcing for a single command.
 const SkipAutoSourceEnv = "<<corgi:no-env-source>>"
 
+var (
+	serviceShellOnce sync.Once
+	serviceShellPath string
+)
+
+// ServiceShell is the shell corgi runs compose commands with. It prefers bash,
+// because people write these commands in their own shell and reach for `source`
+// and `[[ ]]` without thinking about it: /bin/sh is bash on macOS but dash on
+// most Linux, so a command that works on a laptop exits 127 in CI. $CORGI_SHELL
+// overrides; /bin/sh is the fallback where bash is absent.
+func ServiceShell() string {
+	serviceShellOnce.Do(func() {
+		if override := os.Getenv("CORGI_SHELL"); override != "" {
+			serviceShellPath = override
+			return
+		}
+		if bash, err := exec.LookPath("bash"); err == nil {
+			serviceShellPath = bash
+			return
+		}
+		serviceShellPath = "/bin/sh"
+	})
+	return serviceShellPath
+}
+
 func resolveEnvFile(path string, envFileOverride []string) string {
 	if path == "" {
 		return ""
@@ -219,7 +244,7 @@ func executeShellLine(serviceName, finalCommand, path string, interactive bool, 
 		return nil
 	}
 	shellCommand := withEnvSource(finalCommand, resolvedEnvFile)
-	cmd := exec.Command("/bin/sh", "-c", shellCommand)
+	cmd := exec.Command(ServiceShell(), "-c", shellCommand)
 	cmd.Dir = path
 
 	if interactive {
@@ -280,7 +305,7 @@ func RunServiceCommandExitCode(
 ) (int, error) {
 	resolvedEnvFile := resolveEnvFile(path, envFile)
 	shellCommand := withEnvSource(command, resolvedEnvFile)
-	cmd := exec.Command("/bin/sh", "-c", shellCommand)
+	cmd := exec.Command(ServiceShell(), "-c", shellCommand)
 	cmd.Dir = path
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -308,7 +333,7 @@ func RunServiceCommandExitCode(
 func StartDetached(serviceName, command, path string, envFile ...string) (*os.Process, error) {
 	resolvedEnvFile := resolveEnvFile(path, envFile)
 	shellCommand := withEnvSource(command, resolvedEnvFile)
-	cmd := exec.Command("/bin/sh", "-c", shellCommand)
+	cmd := exec.Command(ServiceShell(), "-c", shellCommand)
 	cmd.Dir = path
 	// Direct *os.File so the detached child keeps logging after corgi exits.
 	if f := logWriterFile(getLogWriter(serviceName)); f != nil {
@@ -422,7 +447,7 @@ func runCleanupCommand(commandsName, serviceName, command, path, resolvedEnvFile
 	ctx, cancel := context.WithTimeout(context.Background(), AfterStartTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", shellCommand)
+	cmd := exec.CommandContext(ctx, ServiceShell(), "-c", shellCommand)
 	cmd.Dir = path
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/utils/execute_test.go
+++ b/utils/execute_test.go
@@ -1012,3 +1012,46 @@ func TestStartDetached_WritesDirectlyToLogFile(t *testing.T) {
 		t.Errorf("expected raw lines without timestamp prefix, got %q", got)
 	}
 }
+
+func TestServiceShellPrefersBash(t *testing.T) {
+	resetServiceShell()
+	t.Cleanup(resetServiceShell)
+
+	got := ServiceShell()
+	if bash, err := exec.LookPath("bash"); err == nil {
+		if got != bash {
+			t.Errorf("bash is available, so it should be used: got %q want %q", got, bash)
+		}
+		return
+	}
+	if got != "/bin/sh" {
+		t.Errorf("without bash it must fall back to /bin/sh, got %q", got)
+	}
+}
+
+func TestServiceShellRespectsOverride(t *testing.T) {
+	resetServiceShell()
+	t.Setenv("CORGI_SHELL", "/some/other/shell")
+	t.Cleanup(resetServiceShell)
+
+	if got := ServiceShell(); got != "/some/other/shell" {
+		t.Errorf("CORGI_SHELL must win, got %q", got)
+	}
+}
+
+// The resolved shell must actually run a bash-ism; that is the whole point.
+func TestServiceShellRunsBashBuiltins(t *testing.T) {
+	resetServiceShell()
+	t.Cleanup(resetServiceShell)
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	out, err := exec.Command(ServiceShell(), "-c", "[[ 1 == 1 ]] && echo works").CombinedOutput()
+	if err != nil {
+		t.Fatalf("a bash-only construct must run: %v (%s)", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "works" {
+		t.Errorf("got %q", out)
+	}
+}

--- a/utils/exports_test.go
+++ b/utils/exports_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -437,4 +438,10 @@ func TestSubstituteCrossServiceRefs_OwnVarUnchanged(t *testing.T) {
 	if got != "X=${PORT}" {
 		t.Fatalf("own ${VAR} must not be touched, got %q", got)
 	}
+}
+
+// resetServiceShell clears the once-cached shell so each test resolves fresh.
+func resetServiceShell() {
+	serviceShellOnce = sync.Once{}
+	serviceShellPath = ""
 }


### PR DESCRIPTION
corgi runs every compose command through `/bin/sh -c`. On macOS that is bash; on most Linux it is dash. So a command written and tested on a laptop can exit 127 on a runner.

Hit this for real. A service whose `beforeStart` was:

```yaml
- source .venv/bin/activate && alembic upgrade head
```

worked locally and produced `/bin/sh: 1: source: not found` in CI. corgi logged `aborting beforeStart` and carried on, so the run looked like a slow boot until the readiness timeout rather than a failure — the actual cause was 20 minutes earlier in the log.

People write these commands in their own shell and reach for `source`, `[[ ]]` and arrays without thinking about it. Matching that expectation is less surprising than requiring POSIX.

- prefers `bash` from $PATH, falls back to `/bin/sh`
- `CORGI_SHELL` overrides for anyone wanting something else
- resolved once and cached
- corgi's own env sourcing already used POSIX `.` and is untouched

Includes the patch version bump to 1.20.9.

1570 tests pass, vet and gofmt clean.