### PR TITLE
Re-run a cached beforeStart step when its output is missing

### DIFF
--- a/utils/cachepaths.go
+++ b/utils/cachepaths.go
@@ -129,6 +129,19 @@ func CachePathsFor(corgi *CorgiCompose) CachePlan {
 	return CachePlan{Paths: sortedPathSet(paths), Key: aggregate, Groups: groups}
 }
 
+// serviceOutputDirs returns the directories installing this lockfile produces
+// inside the service. Nil when the key is not a lockfile corgi knows, or when
+// the ecosystem installs only into a shared home cache.
+func serviceOutputDirs(cacheKey string) []string {
+	name := filepath.Base(cacheKey)
+	for _, eco := range ecosystems {
+		if name == eco.lockfile {
+			return eco.serviceDirs
+		}
+	}
+	return nil
+}
+
 func groupFor(cacheKey string) string {
 	name := filepath.Base(cacheKey)
 	for _, eco := range ecosystems {

--- a/utils/stepcache.go
+++ b/utils/stepcache.go
@@ -77,10 +77,25 @@ func StepNeedsRun(service Service, stepIndex int, step BeforeStartStep, noCache 
 	if noCache {
 		return true, hash
 	}
-	if readStepHash(stepCachePath(service, stepIndex)) == hash {
+	if readStepHash(stepCachePath(service, stepIndex)) == hash && stepOutputPresent(service, step) {
 		return false, hash
 	}
 	return true, hash
+}
+
+// A marker only proves the step ran once, on some machine. CI stores the
+// markers and the dependency directories as separate cache entries that expire
+// independently, so the marker can come back while node_modules does not —
+// skipping the install then leaves nothing to run against.
+func stepOutputPresent(service Service, step BeforeStartStep) bool {
+	for _, key := range step.CacheKey {
+		for _, dir := range serviceOutputDirs(key) {
+			if _, err := os.Stat(filepath.Join(service.AbsolutePath, dir)); err != nil {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // PersistStepHash records a step's hash so an unchanged future run can skip it.

--- a/utils/stepcache_test.go
+++ b/utils/stepcache_test.go
@@ -183,3 +183,36 @@ func TestActiveRequiredSkipInCi(t *testing.T) {
 		t.Errorf("in CI skipInCi tools must drop out, got %v", got)
 	}
 }
+
+func TestStepNeedsRunWhenCachedOutputIsGone(t *testing.T) {
+	prev := CorgiComposePathDir
+	CorgiComposePathDir = t.TempDir()
+	t.Cleanup(func() { CorgiComposePathDir = prev })
+
+	svcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(svcDir, "package-lock.json"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nodeModules := filepath.Join(svcDir, "node_modules")
+	if err := os.Mkdir(nodeModules, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := Service{ServiceName: "api", AbsolutePath: svcDir + "/"}
+	step := BeforeStartStep{Run: "npm ci", CacheKey: []string{"package-lock.json"}}
+
+	_, hash := StepNeedsRun(svc, 0, step, false)
+	PersistStepHash(svc, 0, hash)
+
+	if run, _ := StepNeedsRun(svc, 0, step, false); run {
+		t.Fatal("marker plus node_modules present should skip")
+	}
+
+	// The markers cache restored, the node cache did not.
+	if err := os.RemoveAll(nodeModules); err != nil {
+		t.Fatal(err)
+	}
+	if run, _ := StepNeedsRun(svc, 0, step, false); !run {
+		t.Fatal("a marker without its node_modules must not skip the install")
+	}
+}


### PR DESCRIPTION
`StepNeedsRun` skipped a step whenever its cacheKey hash matched the stored marker, without ever checking that what the step produced is still there.

That is fine on a laptop, where the marker and `node_modules` live or die together. In CI they are separate cache entries with independent lifetimes — different keys, and GitHub evicts by age and by repo size. Restore the markers without the node cache and corgi reports

```
⏭️  beforeStart skipped (cacheKey unchanged): npm install
```

onto a directory that is not there, and the boot fails on a missing dependency rather than installing it.

A skip now also requires the step's output directories to exist. corgi already knows them: the ecosystem table maps `package-lock.json` → `node_modules`, `requirements.txt` → `.venv`, and so on, which is the same mapping that decides what to cache.

Erring toward running is deliberate. A needless re-install costs time; a wrongly skipped one breaks the run.

Unaffected: steps with no cacheKey (already always run), `--no-cache`, and ecosystems that install only into a shared home cache (`go.sum`, `pubspec.lock`) — those declare no service directory, so there is nothing to verify.

`TestStepNeedsRunWhenCachedOutputIsGone` covers it, and fails without the guard.