### PR TITLE
Read the supabase mail port from [local_smtp] as well as [inbucket]

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -291,7 +291,7 @@ var dbServiceItems = []CorgiComposeItems{
 		item:        "inbucketPort",
 		example:     "54324",
 		itemType:    "int",
-		description: "supabase driver only. Override [inbucket].port (local email capture). Patched on every up. Default 54324.",
+		description: "supabase driver only. Override the local email capture port — [local_smtp].port, or [inbucket].port on CLI older than 2.109. Patched on every up. Default 54324.",
 	},
 	{
 		item:        "healthCheck",

--- a/templates/supabaseTemplate.go
+++ b/templates/supabaseTemplate.go
@@ -62,7 +62,9 @@ func ReadSupabasePorts(pathOrRoot string) SupabasePorts {
 				got.DB = p
 			case "studio":
 				got.Studio = p
-			case "inbucket":
+			// supabase renamed [inbucket] to [local_smtp] in CLI 2.109; both
+			// still parse, so read whichever the project uses.
+			case "inbucket", "local_smtp":
 				got.Inbucket = p
 			}
 		}
@@ -152,6 +154,7 @@ up:
 	$(call _patch_supabase_port,db,$(DESIRED_DB_PORT))
 	$(call _patch_supabase_port,studio,$(DESIRED_STUDIO_PORT))
 	$(call _patch_supabase_port,inbucket,$(DESIRED_INBUCKET_PORT))
+	$(call _patch_supabase_port,local_smtp,$(DESIRED_INBUCKET_PORT))
 	@cd "$(WORKDIR)" && if supabase status >/dev/null 2>&1; then \
 		echo "✓ supabase already running"; \
 	else \

--- a/templates/supabaseTemplate_test.go
+++ b/templates/supabaseTemplate_test.go
@@ -112,3 +112,21 @@ func TestSignSupabaseJWTSecretMatters(t *testing.T) {
 		t.Error("different secrets must produce different sigs")
 	}
 }
+
+// supabase CLI 2.109 renamed [inbucket] to [local_smtp]. Reading only the old
+// name would silently hand back the default port for a project that moved.
+func TestReadSupabasePortsAcceptsLocalSmtp(t *testing.T) {
+	dir := t.TempDir()
+	toml := filepath.Join(dir, "config.toml")
+	body := "[api]\nport = 64321\n\n[local_smtp]\nenabled = true\nport = 64324\nsmtp_port = 64325\n"
+	if err := os.WriteFile(toml, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := ReadSupabasePorts(toml)
+	if got.Inbucket != 64324 {
+		t.Fatalf("[local_smtp].port = %d, want 64324", got.Inbucket)
+	}
+	if got.API != 64321 {
+		t.Fatalf("API port = %d, want 64321", got.API)
+	}
+}


### PR DESCRIPTION
supabase CLI 2.109 renamed the local mail section:

```
WARN: config section [inbucket] is deprecated. Please use [local_smtp] instead.
```

corgi read `[inbucket].port` only, so a project that took the rename got the **default** 54324 back instead of its configured port — no error, just quietly wrong env for anything reading mail. The Makefile's port patching missed it the same way, leaving the section unpatched.

Both names are now accepted, and `up` patches whichever section the project has (the call is a no-op for the one that is absent). Nothing to change for projects still on `[inbucket]`.

`TestReadSupabasePortsAcceptsLocalSmtp` covers it, and fails without the fix with `[local_smtp].port = 54324, want 64324` — the silent-default case exactly.

Verified against a real 2.109.1 stack: starts clean with `[local_smtp]`, Mailpit answers on 54324, SMTP open on 54325.