### PR TITLE
Let a service start without waiting for the database phase

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -117,6 +117,12 @@ var serviceItems = []CorgiComposeItems{
 		description: "Determines if the service will be run with run cmd.\n\t\t\tIf it is true, that to run you add `--services manual_to_run_service` to run cmd.\n\t\t\tBy default it is false.",
 	},
 	{
+		item:        "waitForDatabases",
+		example:     "false",
+		itemType:    "boolean",
+		description: "Whether this service waits for the database phase before starting. Default true.\n\t\t\tSet false for a service that only needs the databases' env — a bundler that\n\t\t\tspends a minute compiling can do it while the databases come up. Its\n\t\t\tdepends_on_db entries still supply env; only the wait is skipped, so a\n\t\t\tservice whose beforeStart talks to a database must keep the default.",
+	},
+	{
 		item:        "depends_on_db",
 		example:     "- name: db_name_from_db_services\n\t- envAlias: NAME_BEFORE_DB_IN_ENV",
 		itemType:    "[]DependsOnDb",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.20.19"
+var APP_VERSION = "1.20.20"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -643,9 +643,8 @@ func runRun(cmd *cobra.Command, _ []string) {
 	runBeforeStart(corgi)
 
 	CreateDatabaseServices(corgi.DatabaseServices)
-	runDatabaseServices(cmd, corgi.DatabaseServices)
 
-	if err := utils.GenerateEnvForServices(corgi); err != nil {
+	if err := startDatabasePhase(cmd, corgi); err != nil {
 		fmt.Println(art.RedColor, "aborting corgi run:", err, art.WhiteColor)
 		os.Exit(1)
 	}
@@ -817,9 +816,16 @@ func detachAlreadyRunning(statePath string, force bool) bool {
 
 func spawnDetachedServices(corgi *utils.CorgiCompose) []detachedProc {
 	procs := []detachedProc{}
-	for _, svc := range corgi.Services {
+	waited := false
+	for _, svc := range orderedByDatabaseGate(corgi.Services) {
 		if shouldSkipManualRun(svc) {
 			continue
+		}
+		// Detached services start one after another, so the gate is taken once,
+		// at the first service that still wants the databases.
+		if svc.WaitsForDatabases() && !waited {
+			<-dbsReady
+			waited = true
 		}
 		runDetachedBeforeStart(svc)
 
@@ -1114,6 +1120,61 @@ func maybeHintNotifications() {
 		art.CyanColor, art.WhiteColor)
 }
 
+// dbsReady closes once the database phase is done. It starts closed so that any
+// path which never runs that phase — every other command, and tests driving the
+// launchers directly — is not gated by it. Only the concurrent phase installs a
+// fresh, open gate.
+var dbsReady = closedGate()
+
+func closedGate() chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
+
+// startDatabasePhase brings the databases up and writes each service's env.
+//
+// With every service on the default gate this is exactly the old sequence:
+// databases, then env. When a service opted out, the phase moves to the
+// background so that service can start against the databases still coming up.
+// Env is written first either way — corgi derives it from corgi-compose.yml and
+// each driver's config, never from a running container.
+func startDatabasePhase(cmd *cobra.Command, corgi *utils.CorgiCompose) error {
+	if !utils.AnyServiceStartsWithDatabases(corgi) {
+		runDatabaseServices(cmd, corgi.DatabaseServices)
+		return utils.GenerateEnvForServices(corgi)
+	}
+
+	if err := utils.GenerateEnvForServices(corgi); err != nil {
+		return err
+	}
+	gate := make(chan struct{})
+	dbsReady = gate
+	go func() {
+		defer close(gate)
+		runDatabaseServices(cmd, corgi.DatabaseServices)
+	}()
+	return nil
+}
+
+// orderedByDatabaseGate puts the services that opted out of the gate first, so
+// a sequential launcher starts them while the databases are still coming up.
+// Order is otherwise preserved.
+func orderedByDatabaseGate(services []utils.Service) []utils.Service {
+	ordered := make([]utils.Service, 0, len(services))
+	for _, s := range services {
+		if !s.WaitsForDatabases() {
+			ordered = append(ordered, s)
+		}
+	}
+	for _, s := range services {
+		if s.WaitsForDatabases() {
+			ordered = append(ordered, s)
+		}
+	}
+	return ordered
+}
+
 func runDatabaseServices(cmd *cobra.Command, databaseServices []utils.DatabaseService) {
 	if !hasDatabaseToRun(databaseServices) {
 		utils.Info("No database service to run")
@@ -1251,6 +1312,14 @@ func runService(service utils.Service, cobraCmd *cobra.Command, serviceWaitGroup
 	}
 	if shouldSkipManualRun(service) {
 		return
+	}
+
+	if service.WaitsForDatabases() {
+		select {
+		case <-dbsReady:
+		case <-utils.ShutdownCh():
+			return
+		}
 	}
 
 	waitForServiceDeps(service, signals)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -902,5 +903,84 @@ func TestBuildRunSummaryKinds(t *testing.T) {
 	}
 	if kinds["api"] != "service" {
 		t.Errorf("api kind = %q, want service", kinds["api"])
+	}
+}
+
+func TestWaitsForDatabasesDefaultsToWaiting(t *testing.T) {
+	no := false
+	yes := true
+	cases := []struct {
+		name string
+		flag *bool
+		want bool
+	}{
+		{"unset waits", nil, true},
+		{"explicit true waits", &yes, true},
+		{"false opts out", &no, false},
+	}
+	for _, c := range cases {
+		if got := (utils.Service{WaitForDatabases: c.flag}).WaitsForDatabases(); got != c.want {
+			t.Errorf("%s: WaitsForDatabases() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestOrderedByDatabaseGatePutsOptedOutFirst(t *testing.T) {
+	no := false
+	services := []utils.Service{
+		{ServiceName: "api"},
+		{ServiceName: "web", WaitForDatabases: &no},
+		{ServiceName: "worker"},
+	}
+	var got []string
+	for _, s := range orderedByDatabaseGate(services) {
+		got = append(got, s.ServiceName)
+	}
+	want := []string{"web", "api", "worker"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+// Without an opt-out the order must be byte-for-byte what it always was.
+func TestOrderedByDatabaseGateKeepsOrderWhenNobodyOptsOut(t *testing.T) {
+	services := []utils.Service{
+		{ServiceName: "api"},
+		{ServiceName: "web"},
+		{ServiceName: "worker"},
+	}
+	var got []string
+	for _, s := range orderedByDatabaseGate(services) {
+		got = append(got, s.ServiceName)
+	}
+	want := []string{"api", "web", "worker"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestAnyServiceStartsWithDatabases(t *testing.T) {
+	no := false
+	plain := &utils.CorgiCompose{Services: []utils.Service{{ServiceName: "api"}}}
+	if utils.AnyServiceStartsWithDatabases(plain) {
+		t.Fatal("no opt-out must keep the inline database phase")
+	}
+	opted := &utils.CorgiCompose{Services: []utils.Service{
+		{ServiceName: "api"},
+		{ServiceName: "web", WaitForDatabases: &no},
+	}}
+	if !utils.AnyServiceStartsWithDatabases(opted) {
+		t.Fatal("an opt-out must make the phase concurrent")
+	}
+}
+
+// The gate must start open. Anything that never runs the database phase — every
+// other command, and tests driving the launchers directly — would otherwise
+// block on it forever.
+func TestDatabaseGateStartsOpen(t *testing.T) {
+	select {
+	case <-dbsReady:
+	case <-time.After(time.Second):
+		t.Fatal("dbsReady must start closed, or a service with no database phase hangs")
 	}
 }

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.20.19",
+  "version": "1.20.20",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/utils/config.go
+++ b/utils/config.go
@@ -219,14 +219,19 @@ type Service struct {
 	PortAlias              string             `yaml:"portAlias,omitempty"`
 	DependsOnServices      []DependsOnService `yaml:"depends_on_services,omitempty"`
 	DependsOnDb            []DependsOnDb      `yaml:"depends_on_db,omitempty"`
-	Exports                []string           `yaml:"exports,omitempty"`
-	BeforeStart            BeforeStartSteps   `yaml:"beforeStart,omitempty"`
-	Start                  []string           `yaml:"start,omitempty"`
-	AfterStart             []string           `yaml:"afterStart,omitempty"`
-	RestartPolicy          *RestartPolicy     `yaml:"restartPolicy,omitempty"`
-	OpenOnReady            *OpenOnReady       `yaml:"openOnReady,omitempty"`
-	Scripts                []Script           `yaml:"scripts,omitempty"`
-	InteractiveInput       bool               `yaml:"interactiveInput,omitempty"`
+	// WaitForDatabases gates this service on the database phase. nil/true =
+	// wait (the default). false starts it alongside the databases, for a
+	// service that only needs their env — a bundler that spends a minute
+	// compiling before it serves anything should not spend it idle.
+	WaitForDatabases *bool            `yaml:"waitForDatabases,omitempty"`
+	Exports          []string         `yaml:"exports,omitempty"`
+	BeforeStart      BeforeStartSteps `yaml:"beforeStart,omitempty"`
+	Start            []string         `yaml:"start,omitempty"`
+	AfterStart       []string         `yaml:"afterStart,omitempty"`
+	RestartPolicy    *RestartPolicy   `yaml:"restartPolicy,omitempty"`
+	OpenOnReady      *OpenOnReady     `yaml:"openOnReady,omitempty"`
+	Scripts          []Script         `yaml:"scripts,omitempty"`
+	InteractiveInput bool             `yaml:"interactiveInput,omitempty"`
 	// AutoSourceEnv toggles the `set -a; . <envFile>; set +a` prefix corgi
 	// adds to start/beforeStart/afterStart commands. nil/true = on (default),
 	// false = off. Off avoids exporting every var to subprocesses (e.g. when
@@ -1179,4 +1184,21 @@ func CompareCorgiFiles(c1, c2 *CorgiCompose) bool {
 	}
 
 	return true
+}
+
+// WaitsForDatabases reports whether this service must hold until the database
+// phase finishes. Default true; waitForDatabases: false opts a service out.
+func (s Service) WaitsForDatabases() bool {
+	return s.WaitForDatabases == nil || *s.WaitForDatabases
+}
+
+// AnyServiceStartsWithDatabases reports whether any service opted out of the
+// database gate, which is what makes corgi run that phase concurrently.
+func AnyServiceStartsWithDatabases(corgi *CorgiCompose) bool {
+	for _, s := range corgi.Services {
+		if !s.WaitsForDatabases() {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
`corgi run` brings every database up, then starts the services. That is right for a service whose `beforeStart` migrates or seeds, and wrong for one that only needs the databases' **env**: a bundler can spend a minute compiling before it serves anything, and today it spends that minute idle first.

```yaml
services:
  web:
    depends_on_db:
      - name: app-db
    waitForDatabases: false
```

Its `depends_on_db` still supplies env; only the wait is skipped. Default is true, so nothing changes for anyone who does not set it.

### How

`startDatabasePhase` keeps the old sequence exactly — databases, then env — unless some service opted out. Then it writes env first and runs the phase in a goroutine. Env can be written first because corgi derives it from corgi-compose.yml and each driver's config, never from a running container.

Two launchers, so two gates:

- attached: `runService` blocks on `dbsReady`, selecting on `ShutdownCh()` too, so Ctrl+C during a slow database phase still exits
- detached: services start sequentially with `beforeStart` inline, so opted-out ones are ordered first and the gate is taken once, at the first service that still wants databases

The gate **starts closed**. Every other command, and tests driving the launchers directly, never run the database phase — an open gate would hang them. `TestDatabaseGateStartsOpen` pins that; I hit it for real, as a 9m22s hang in `TestSpawnDetachedServices_StartsServiceViaSeam`, before fixing it.

### Verified

- full suite green, plus `-race` on `cmd` and `utils` (`cmd` 58.6s, no data races)
- order is byte-for-byte unchanged when nobody opts out — covered by its own test
- ignoring whitespace, `config.go` is additions only; the rest is gofmt realigning the struct
- an older corgi reports `W_UNKNOWN_FIELD … it was ignored` and keeps waiting, so a config using this is safe on both