### PR TITLE
Fix a fifth round of review findings in agent mode

### DIFF
--- a/utils/agent/supervisor/runner.go
+++ b/utils/agent/supervisor/runner.go
@@ -57,6 +57,10 @@ type Runner struct {
 	state    RunState
 	proc     Process
 	stopping bool
+	// stopped closes when Stop is called, so a backoff sleep can be cut short
+	// rather than running to completion and starting the process again.
+	stopped     chan struct{}
+	stoppedOnce sync.Once
 }
 
 // NewRunner returns a Runner with the real sleep behaviour.
@@ -67,6 +71,7 @@ func NewRunner(cfg SpawnConfig, start Starter, lock *WakeLock) *Runner {
 		WakeLock: lock,
 		Sleep:    sleepWithContext,
 		state:    RunState{WorkspaceID: cfg.WorkspaceID},
+		stopped:  make(chan struct{}),
 	}
 }
 
@@ -88,6 +93,15 @@ func (r *Runner) Stop() {
 	r.stopping = true
 	proc := r.proc
 	r.mu.Unlock()
+
+	// Wake a backoff sleep. Without this, Stop during the gap between restarts
+	// did nothing at all — no process to signal, the context still live — and
+	// the loop went on to start a session nothing would ever stop.
+	r.stoppedOnce.Do(func() {
+		if r.stopped != nil {
+			close(r.stopped)
+		}
+	})
 	if proc != nil {
 		proc.Stop()
 	}
@@ -123,6 +137,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		if r.stopRequested() {
+			return nil
+		}
 
 		exit, startErr := r.runOnce(ctx, alwaysAwake)
 		decision := Decide(exit, attempt, startupFailures)
@@ -151,7 +168,21 @@ func (r *Runner) Run(ctx context.Context) error {
 		} else {
 			attempt++
 		}
-		r.Sleep(ctx, decision.Delay)
+		r.sleepUnlessStopped(ctx, decision.Delay)
+	}
+}
+
+// sleepUnlessStopped waits out the backoff, returning early if Stop is called.
+func (r *Runner) sleepUnlessStopped(ctx context.Context, d time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.Sleep(ctx, d)
+	}()
+	select {
+	case <-done:
+	case <-r.stopped:
+	case <-ctx.Done():
 	}
 }
 

--- a/utils/agent/supervisor/runner_test.go
+++ b/utils/agent/supervisor/runner_test.go
@@ -341,3 +341,38 @@ func TestStopKeepsItStopped(t *testing.T) {
 		t.Errorf("started %d processes, want 1 — Stop must not be undone by a restart", got)
 	}
 }
+
+// Stop during a restart backoff had nothing to signal — no process, a live
+// context, an uninterrupted sleep — so the loop went on to start a session
+// nothing would ever stop.
+func TestStopDuringBackoffDoesNotStartAgain(t *testing.T) {
+	start, calls := scriptedStarter(&fakeProcess{pid: 1, code: 1, exitNow: true})
+
+	r := NewRunner(SpawnConfig{WorkspaceID: "acme", Dir: "/tmp/a", WakeLock: WakeLockOff}, start, NewWakeLock(WakeLockOff))
+	r.HealthyAfter = time.Millisecond
+
+	// A backoff long enough that only an interrupt can end it.
+	sleeping := make(chan struct{})
+	var once sync.Once
+	r.Sleep = func(ctx context.Context, _ time.Duration) {
+		once.Do(func() { close(sleeping) })
+		<-ctx.Done()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); _ = r.Run(ctx) }()
+
+	<-sleeping
+	r.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() during a backoff must end the loop")
+	}
+	if got := *calls; got != 1 {
+		t.Errorf("started %d processes, want 1 — Stop must not be followed by another start", got)
+	}
+}

--- a/utils/agentdiff.go
+++ b/utils/agentdiff.go
@@ -20,6 +20,13 @@ import (
 // response size for everything else in the same call.
 const maxPatchBytes = 32 << 10
 
+// maxStackPatchBytes bounds the whole response. The per-file cap alone does not:
+// a wide branch of many modest files still adds up to a multi-megabyte payload,
+// which is the thing a phone client cannot take. Once the budget is spent the
+// remaining files keep their counts and lose only their patch bodies, so the
+// shape of the change is still complete.
+const maxStackPatchBytes = 1 << 20
+
 // FileDiff is one changed file.
 type FileDiff struct {
 	Path      string `json:"path"`
@@ -54,6 +61,9 @@ type StackDiff struct {
 	Additions int        `json:"additions"`
 	Deletions int        `json:"deletions"`
 	Repos     []RepoDiff `json:"repos"`
+	// PatchesTruncated reports that the response budget was reached and some
+	// files carry counts without a patch body.
+	PatchesTruncated bool `json:"patchesTruncated,omitempty"`
 }
 
 // DiffStack collects the diff of every service's checkout against base.
@@ -78,6 +88,7 @@ func DiffStack(dirs map[string]string, base string, includePatch bool) *StackDif
 	// diffed the repo twice, listing every change twice and doubling the stack
 	// totals, so the key is the resolved git root.
 	byRoot := map[string]int{}
+	budget := maxStackPatchBytes
 	for _, svc := range services {
 		key := dirs[svc]
 		if root, ok := repoRoot(key); ok {
@@ -88,12 +99,32 @@ func DiffStack(dirs map[string]string, base string, includePatch bool) *StackDif
 			continue
 		}
 		rd := diffRepo(svc, dirs[svc], base, includePatch)
+		budget = applyPatchBudget(&rd, budget)
 		byRoot[key] = len(out.Repos)
 		out.Repos = append(out.Repos, rd)
 		out.Additions += rd.Additions
 		out.Deletions += rd.Deletions
 	}
+	if budget <= 0 {
+		out.PatchesTruncated = true
+	}
 	return out
+}
+
+// applyPatchBudget drops patch bodies once the response budget is spent,
+// keeping every file's counts. Returns the remaining budget.
+func applyPatchBudget(rd *RepoDiff, budget int) int {
+	for i := range rd.Files {
+		if budget <= 0 {
+			if rd.Files[i].Patch != "" {
+				rd.Files[i].Patch = ""
+				rd.Files[i].Truncated = true
+			}
+			continue
+		}
+		budget -= len(rd.Files[i].Patch)
+	}
+	return budget
 }
 
 func diffRepo(service, dir, base string, includePatch bool) RepoDiff {
@@ -156,14 +187,17 @@ func diffRepo(service, dir, base string, includePatch bool) RepoDiff {
 
 // untrackedFiles reports files git does not track yet, respecting .gitignore.
 func untrackedFiles(dir string, includePatch bool) []FileDiff {
-	out, err := gitOut(dir, "ls-files", "--others", "--exclude-standard")
+	// -z, or git C-quotes any path with non-ASCII or special characters
+	// ("caf\303\251.ts"). Opening that literal name fails, and the file was
+	// then silently dropped — from precisely the set an agent's work consists
+	// of, newly created files.
+	out, err := gitOut(dir, "ls-files", "--others", "--exclude-standard", "-z")
 	if err != nil || strings.TrimSpace(out) == "" {
 		return nil
 	}
 	var files []FileDiff
-	for _, path := range strings.Split(out, "\n") {
-		path = strings.TrimSpace(path)
-		if path == "" {
+	for _, path := range strings.Split(out, "\x00") {
+		if strings.TrimSpace(path) == "" {
 			continue
 		}
 		f := FileDiff{Path: path, New: true}

--- a/utils/agentdiff_test.go
+++ b/utils/agentdiff_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -340,5 +341,62 @@ func TestWorktreeDirsIncludesOnlyMaterializedServices(t *testing.T) {
 	}
 	if WorktreeDirs(nil) == nil {
 		t.Error("a nil set should still yield a usable empty map")
+	}
+}
+
+// git C-quotes paths with non-ASCII characters unless -z is used, and the
+// literal quoted name cannot be opened — so the file was silently dropped from
+// precisely the set an agent's work consists of: newly created files.
+func TestDiffIncludesUntrackedFilesWithAwkwardNames(t *testing.T) {
+	repo := newRepo(t, filepath.Join(t.TempDir(), "web"))
+	for _, name := range []string{"café.ts", "a file with spaces.md", "naïve.txt"} {
+		writeRepoFile(t, filepath.Join(repo, name), "one\ntwo\n")
+	}
+
+	got := DiffStack(map[string]string{"web": repo}, "main", true)
+
+	if len(got.Repos[0].Files) != 3 {
+		var names []string
+		for _, f := range got.Repos[0].Files {
+			names = append(names, f.Path)
+		}
+		t.Fatalf("files = %v, want all three", names)
+	}
+	for _, f := range got.Repos[0].Files {
+		if strings.HasPrefix(f.Path, `"`) {
+			t.Errorf("path %q is still C-quoted", f.Path)
+		}
+		if f.Additions != 2 {
+			t.Errorf("%s: additions = %d, want 2", f.Path, f.Additions)
+		}
+	}
+}
+
+// The per-file cap does not bound the response: many modest files still add up
+// to a payload a phone client cannot take.
+func TestDiffBudgetsTheWholeResponse(t *testing.T) {
+	repo := newRepo(t, filepath.Join(t.TempDir(), "api"))
+	body := strings.Repeat("a line of text\n", 4000) // ~56KB each
+	for i := range 40 {
+		writeRepoFile(t, filepath.Join(repo, fmt.Sprintf("file%02d.txt", i)), body)
+	}
+
+	got := DiffStack(map[string]string{"api": repo}, "main", true)
+
+	total := 0
+	for _, f := range got.Repos[0].Files {
+		total += len(f.Patch)
+	}
+	if total > maxStackPatchBytes+maxPatchBytes {
+		t.Errorf("total patch bytes = %d, want the response bounded near %d", total, maxStackPatchBytes)
+	}
+	if !got.PatchesTruncated {
+		t.Error("the response should say that some patch bodies were dropped")
+	}
+	// Counts survive even where the body was dropped, so the shape is complete.
+	for _, f := range got.Repos[0].Files {
+		if f.Additions == 0 {
+			t.Errorf("%s lost its line count", f.Path)
+		}
 	}
 }

--- a/utils/agentpreview.go
+++ b/utils/agentpreview.go
@@ -164,16 +164,22 @@ func StartPreview(opts PreviewOptions) (*Preview, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Reuse a live preview for the same service: a second tunnel would hand the
-	// user a different URL for the same thing.
+	// Reuse a live preview for the same service AND branch: a second tunnel
+	// would hand the user a different URL for the same thing, but matching on
+	// the service alone returned branch A's preview for a request about
+	// branch B, labelled with the wrong branch.
+	wantID := previewID(opts.Service, opts.Branch)
 	for i := range store.Previews {
-		p := &store.Previews[i]
-		if p.Service == opts.Service && previewProcessAlive(*p) {
-			p.LastTouched = time.Now().UTC()
-			_ = SavePreviews(opts.ComposeDir, store)
-			refreshPreviewFromLog(p)
-			return p, nil
+		if store.Previews[i].ID != wantID || !previewProcessAlive(store.Previews[i]) {
+			continue
 		}
+		store.Previews[i].LastTouched = time.Now().UTC()
+		// Save first, then take a copy by id: SavePreviews sorts in place, so a
+		// pointer held across it can end up aliasing a different preview.
+		if err := SavePreviews(opts.ComposeDir, store); err != nil {
+			return nil, err
+		}
+		return refreshedByID(opts.ComposeDir, wantID)
 	}
 
 	bin := opts.CorgiBin
@@ -256,6 +262,22 @@ func spawnDetachedTunnel(bin string, opts PreviewOptions, logFile string) (*os.P
 	return cmd.Process, nil
 }
 
+// refreshedByID re-reads one preview after a save, by id rather than by index.
+func refreshedByID(composeDir, id string) (*Preview, error) {
+	store, err := LoadPreviews(composeDir)
+	if err != nil {
+		return nil, err
+	}
+	for i := range store.Previews {
+		if store.Previews[i].ID == id {
+			p := store.Previews[i]
+			refreshPreviewFromLog(&p)
+			return &p, nil
+		}
+	}
+	return nil, fmt.Errorf("no preview called %q", id)
+}
+
 // PreviewStatus returns the current state of one preview, refreshed from its
 // log and a probe of the local port.
 func PreviewStatus(composeDir, id string) (*Preview, error) {
@@ -264,14 +286,14 @@ func PreviewStatus(composeDir, id string) (*Preview, error) {
 		return nil, err
 	}
 	for i := range store.Previews {
-		p := &store.Previews[i]
-		if p.ID != id && p.Service != id {
+		if store.Previews[i].ID != id && store.Previews[i].Service != id {
 			continue
 		}
-		refreshPreviewFromLog(p)
-		p.LastTouched = time.Now().UTC()
+		refreshPreviewFromLog(&store.Previews[i])
+		store.Previews[i].LastTouched = time.Now().UTC()
+		found := store.Previews[i] // copy before the save sorts the slice
 		_ = SavePreviews(composeDir, store)
-		return p, nil
+		return &found, nil
 	}
 	return nil, fmt.Errorf("no preview called %q", id)
 }
@@ -296,17 +318,19 @@ func FreezePreview(composeDir, id string, frozen bool) (*Preview, error) {
 		return nil, err
 	}
 	for i := range store.Previews {
-		p := &store.Previews[i]
-		if p.ID != id && p.Service != id {
+		if store.Previews[i].ID != id && store.Previews[i].Service != id {
 			continue
 		}
-		p.Frozen = frozen
-		p.LastTouched = time.Now().UTC()
-		refreshPreviewFromLog(p)
+		store.Previews[i].Frozen = frozen
+		store.Previews[i].LastTouched = time.Now().UTC()
+		refreshPreviewFromLog(&store.Previews[i])
+		// Copy before saving: the save sorts in place, and a pointer held
+		// across it could end up naming — and freezing — a different preview.
+		found := store.Previews[i]
 		if err := SavePreviews(composeDir, store); err != nil {
 			return nil, err
 		}
-		return p, nil
+		return &found, nil
 	}
 	return nil, fmt.Errorf("no preview called %q", id)
 }
@@ -338,12 +362,20 @@ func ReapPreviews(composeDir string, now time.Time) ([]Preview, error) {
 	var kept, reaped []Preview
 	for _, p := range store.Previews {
 		if !previewProcessAlive(p) {
+			// Report it as gone. Leaving State and URL as they were handed the
+			// caller a dead tunnel still marked ready, with a URL that no
+			// longer resolves.
+			p.State = PreviewStopped
+			p.URL = ""
+			p.Error = "tunnel process is no longer running"
 			reaped = append(reaped, p)
 			continue
 		}
 		if p.Expired(now) {
 			killPreview(p)
 			p.State = PreviewStopped
+			p.URL = ""
+			p.Error = "torn down after going unwatched"
 			reaped = append(reaped, p)
 			continue
 		}

--- a/utils/storage.go
+++ b/utils/storage.go
@@ -88,7 +88,7 @@ func getDataPath() (string, error) {
 				return legacy, nil
 			}
 		}
-		return filepath.Join(homeDir, "Library", "Application Support", "corgi"), nil
+		return darwinFallbackDataDir(homeDir), nil
 	case "linux":
 		if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
 			return filepath.Join(xdgDataHome, "corgi"), nil
@@ -110,6 +110,42 @@ func getDataPath() (string, error) {
 	default:
 		return "", errors.New("unsupported operating system")
 	}
+}
+
+// darwinFallbackDataDir is where corgi keeps state when no Homebrew var/corgi
+// directory was found.
+//
+// A custom Homebrew prefix without HOMEBREW_PREFIX exported lands here, and the
+// user's saved paths appear to vanish from `corgi list`. Say so once rather
+// than leaving them to discover an empty registry, and name the fix.
+func darwinFallbackDataDir(homeDir string) string {
+	dir := filepath.Join(homeDir, "Library", "Application Support", "corgi")
+	warnAboutDataDirFallbackOnce.Do(func() {
+		if _, err := os.Stat(filepath.Join(dir, storageFileName)); err == nil {
+			return // already the established location; nothing surprising
+		}
+		if !brewLooksInstalled() {
+			return // no Homebrew at all, so nothing was moved
+		}
+		fmt.Fprintf(os.Stderr,
+			"corgi: using %s for its data.\n"+
+				"If your saved paths look missing, your Homebrew prefix is elsewhere — set:\n"+
+				"  export CORGI_DATA_DIR=\"$(brew --prefix)/var/corgi\"\n", dir)
+	})
+	return dir
+}
+
+var warnAboutDataDirFallbackOnce sync.Once
+
+// brewLooksInstalled checks for a Homebrew binary without running it, so the
+// answer does not depend on PATH the way the daemon's does.
+func brewLooksInstalled() bool {
+	for _, p := range []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew"} {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func initializeStorage() error {


### PR DESCRIPTION
Follow-up to #27. Fifth review round on the merged agent-mode code — 7 findings, all real, all fixed with a regression test each.

Two are the same class as bugs already fixed in #27, which is the part worth noticing.

## Silent data loss in the diff

`untrackedFiles` parsed `git ls-files --others` **without `-z`**, so git C-quotes any path with non-ASCII or special characters (`"caf\303\251.ts"`). Opening that literal name fails, and the file was dropped **without a word** — from precisely the set an agent's work consists of: newly created files.

The numstat call *in the same file* already uses `-z`, for exactly this reason. #27 fixed the rename case and left this one.

## A session nothing could stop

`Runner.Stop()` during a restart backoff did nothing: no process to signal, the context still live, the sleep uninterrupted. The loop then started a fresh `claude remote-control` that **no later Stop would reach**.

#27 added a test for "Stop must keep it stopped" — but it stopped a *running* process, never one mid-backoff.

## Previews reporting things that were not true

- A reaped preview kept its `State` and `URL`, so a dead tunnel still read as `ready` with a URL that no longer resolves.
- Reuse matched on **service alone** though the id keys on service **and branch**, so asking about branch B returned branch A's preview, labelled A.
- Three functions held a pointer into the slice **across `SavePreviews`, which sorts in place**. A store ever out of order aliases a different preview — including in `FreezePreview`, which would then freeze the wrong one. Round 2 looked at this and cleared it on the grounds that the store is always saved sorted; that holds today and is one edit away from not holding.

## Response size

The 32KB cap was **per file**, so a wide branch of many modest files still produced a multi-megabyte response — the thing the cap's own comment claims to prevent. There is now a budget for the whole response; past it files keep their counts and lose only their patch bodies, so the shape of the change stays complete, and the result says `patchesTruncated`.

## Data directory

A custom Homebrew prefix without `HOMEBREW_PREFIX` exported falls back to `~/Library/Application Support`, and saved paths appear to vanish from `corgi list`. It now says so once and names the fix, rather than leaving someone to find an empty registry.

---

Full suite passes, `-race` clean, `go vet` clean, no new dependency.

**Worth saying plainly:** five review rounds have now found 45 real issues, and this round was not materially quieter than the last. Several rounds also surfaced damage from the previous round's fixes. If a sixth round is similarly productive, the honest read is that this subsystem is too large to have landed in one piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
