### PR TITLE
Agent mode: other agent CLIs, session handover briefs, tunnel exposure tiers

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -397,6 +397,12 @@ var agentWorkspacesRelocateCmd = &cobra.Command{
 		if err := workspace.Save(path, registry); err != nil {
 			exitWithError("agent_registry_write", err, 1)
 		}
+		// Same reason `forget` drops it: the brief holds the old stack's repo
+		// paths and branches, and keeping it would have `corgi agent brief`
+		// describe a directory this id no longer points at.
+		if dir, dirErr := agentDir(); dirErr == nil {
+			_ = brief.Clear(dir, existing.ID)
+		}
 		utils.Infof("%s now points at %s\n", existing.ID, abs)
 	},
 }

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/brief"
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/supervisor"
@@ -80,6 +81,7 @@ func runAgentServe(cmd *cobra.Command, _ []string) {
 	}
 
 	d := daemon.New(APP_VERSION, dir)
+	d.CaptureBrief = captureWorkspaceBrief
 	printStartupDiagnostics(configs)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -138,17 +140,15 @@ func spawnConfigForWorkspace(w workspace.Workspace, user *config.UserConfig, for
 }
 
 func spawnConfigFrom(w workspace.Workspace, r config.Resolved, foreground bool) supervisor.SpawnConfig {
-	spawn := r.Spawn
-	if spawn == "" {
-		// Isolate each on-demand session, so two remote sessions in one
-		// workspace do not fight over a single checkout.
-		spawn = "worktree"
-	}
-	return supervisor.SpawnConfig{
+	cfg := supervisor.SpawnConfig{
 		WorkspaceID:       r.ID,
 		Dir:               w.AbsPath,
+		Kind:              r.Kind,
 		Bin:               r.Bin,
-		Spawn:             spawn,
+		Args:              r.Args,
+		ConfigDirEnv:      r.ConfigDirEnv,
+		CredentialEnv:     r.CredentialEnv,
+		Spawn:             r.Spawn,
 		Capacity:          r.Capacity,
 		PermissionMode:    r.PermissionMode,
 		ConfigDir:         r.ConfigDir,
@@ -158,6 +158,15 @@ func spawnConfigFrom(w workspace.Workspace, r config.Resolved, foreground bool) 
 		WakeLock:          supervisor.WakeLockMode(r.WakeLock),
 		MirrorOutput:      foreground,
 	}
+	if cfg.Spawn == "" {
+		// Isolate each on-demand session, so two remote sessions in one
+		// workspace do not fight over a single checkout. Only for a kind that
+		// has the concept — for any other, setting it is a validation error.
+		if kind, err := supervisor.KindFor(cfg); err == nil && kind.SupportsSpawn {
+			cfg.Spawn = "worktree"
+		}
+	}
+	return cfg
 }
 
 // dirHasComposeFile reports whether dir is a corgi stack.
@@ -186,7 +195,11 @@ func printStartupDiagnostics(configs []supervisor.SpawnConfig) {
 		if configDir == "" {
 			configDir = "<default>"
 		}
-		utils.Infof("agent: %-20s dir=%s configDir=%s spawn=%s\n", c.WorkspaceID, c.Dir, configDir, c.Spawn)
+		kind := c.Kind
+		if kind == "" {
+			kind = supervisor.DefaultKind
+		}
+		utils.Infof("agent: %-20s dir=%s kind=%s configDir=%s spawn=%s\n", c.WorkspaceID, c.Dir, kind, configDir, c.Spawn)
 		if stripped := supervisor.StrippedCredentials(c, env); len(stripped) > 0 {
 			utils.Infof("agent: %-20s stripped from child env: %v\n", c.WorkspaceID, stripped)
 		}
@@ -348,6 +361,11 @@ var agentWorkspacesForgetCmd = &cobra.Command{
 		if err := workspace.Save(path, registry); err != nil {
 			exitWithError("agent_registry_write", err, 1)
 		}
+		// Drop the handover note too. Reusing an id for a different stack later
+		// would otherwise surface branches belonging to something else.
+		if dir, dirErr := agentDir(); dirErr == nil {
+			_ = brief.Clear(dir, args[0])
+		}
 		utils.Infof("forgot %s\n", args[0])
 	},
 }
@@ -424,6 +442,8 @@ func init() {
 	agentServeCmd.Flags().Bool("foreground", false,
 		"Run in this terminal and mirror the supervised process's output. Off by default: that output can contain env values and tokens, and in serve mode corgi's stderr is a log file.")
 
+	agentBriefCmd.Flags().Bool("json", false, "Machine-readable output")
+
 	agentWorkspacesCmd.AddCommand(agentWorkspacesListCmd, agentWorkspacesForgetCmd, agentWorkspacesRelocateCmd)
 	agentCmd.AddCommand(
 		agentServeCmd,
@@ -431,6 +451,7 @@ func init() {
 		agentStopCmd,
 		agentWorkspacesCmd,
 		agentResolveCmd,
+		agentBriefCmd,
 	)
 	rootCmd.AddCommand(agentCmd)
 }

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -154,17 +154,24 @@ func spawnConfigFrom(w workspace.Workspace, r config.Resolved, foreground bool) 
 		ConfigDir:         r.ConfigDir,
 		InheritAPIKey:     r.InheritAPIKey,
 		InheritOAuthToken: r.InheritOAuthToken,
-		Name:              r.ID,
 		WakeLock:          supervisor.WakeLockMode(r.WakeLock),
 		MirrorOutput:      foreground,
 	}
-	if cfg.Spawn == "" {
+	kind, err := supervisor.KindFor(cfg)
+	if err != nil {
+		// An unknown kind is reported by ValidateSpawnConfig with the valid
+		// names; filling in defaults for it here would only mask that.
+		return cfg
+	}
+	if kind.BuildsArgvFromSettings {
+		// The session name shown in claude.ai/code. Meaningless to a kind handed
+		// a complete argv, where it would be a setting that never takes effect.
+		cfg.Name = r.ID
+	}
+	if cfg.Spawn == "" && kind.SupportsSpawn {
 		// Isolate each on-demand session, so two remote sessions in one
-		// workspace do not fight over a single checkout. Only for a kind that
-		// has the concept — for any other, setting it is a validation error.
-		if kind, err := supervisor.KindFor(cfg); err == nil && kind.SupportsSpawn {
-			cfg.Spawn = "worktree"
-		}
+		// workspace do not fight over a single checkout.
+		cfg.Spawn = "worktree"
 	}
 	return cfg
 }

--- a/cmd/agent_brief.go
+++ b/cmd/agent_brief.go
@@ -199,18 +199,27 @@ func printBriefs(briefs []brief.Brief, asJSON bool) {
 		printJSON(briefs)
 		return
 	}
+	utils.Infof("%s", formatBriefs(briefs))
+}
+
+// formatBriefs renders briefs for a person.
+//
+// Kept pure and separate from printing so what a restart actually reports can
+// be asserted on directly. This is the text someone reads to decide where they
+// left off, so getting it wrong is not cosmetic.
+func formatBriefs(briefs []brief.Brief) string {
 	if len(briefs) == 0 {
-		utils.Infof("no briefs yet — nothing has restarted\n")
-		return
+		return "no briefs yet — nothing has restarted\n"
 	}
+	var out strings.Builder
 	for _, b := range briefs {
-		utils.Info(art.BlueColor, b.WorkspaceID, art.WhiteColor)
-		utils.Infof("  ended   %s (%s)\n", b.EndedAt.Local().Format("2006-01-02 15:04"), b.Cause)
+		fmt.Fprintf(&out, "%s%s%s\n", art.BlueColor, b.WorkspaceID, art.WhiteColor)
+		fmt.Fprintf(&out, "  ended   %s (%s)\n", b.EndedAt.Local().Format("2006-01-02 15:04"), b.Cause)
 		if b.Reason != "" {
-			utils.Infof("  reason  %s\n", b.Reason)
+			fmt.Fprintf(&out, "  reason  %s\n", b.Reason)
 		}
 		if summary := b.Summary(); summary != "" {
-			utils.Infof("  state   %s\n", summary)
+			fmt.Fprintf(&out, "  state   %s\n", summary)
 		}
 		for _, r := range b.Repos {
 			marker := ""
@@ -221,9 +230,10 @@ func printBriefs(briefs []brief.Brief, asJSON bool) {
 			if r.Dirty {
 				dirty = " · uncommitted changes"
 			}
-			utils.Infof("    %-16s %s%s%s\n", r.Service, orDash(r.Branch), dirty, marker)
+			fmt.Fprintf(&out, "    %-16s %s%s%s\n", r.Service, orDash(r.Branch), dirty, marker)
 		}
 	}
+	return out.String()
 }
 
 func orDash(s string) string {

--- a/cmd/agent_brief.go
+++ b/cmd/agent_brief.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"andriiklymiuk/corgi/utils"
@@ -36,20 +37,36 @@ func probeWorkspaceRepos(dir string) []brief.RepoState {
 		return nil
 	}
 
+	// Parsing a compose file mutates process-wide state (root command flags,
+	// utils.CorgiComposePath*), which is why every MCP handler is serialized
+	// behind this same lock. Briefs are captured from one goroutine per
+	// workspace, so without it two workspaces restarting together can hand each
+	// other's services back.
+	mcpHandlerMu.Lock()
+	corgi, err := loadComposeAtDir(dir)
+	mcpHandlerMu.Unlock()
+
+	byPrefix := map[string]string{}
 	var out []brief.RepoState
-	if corgi, err := loadComposeAtDir(dir); err == nil && corgi != nil {
+	if err == nil && corgi != nil {
 		for service, path := range utils.ServiceDirs(corgi, nil) {
+			byPrefix[utils.WorktreeDirPrefix(path)] = service
 			if state, ok := repoState(service, path, false); ok {
 				out = append(out, state)
 			}
 		}
 	}
-	return append(out, probeWorktreeRepos(dir)...)
+	return append(out, probeWorktreeRepos(dir, byPrefix)...)
 }
 
 // probeWorktreeRepos scans the agent worktree directory rather than asking for
 // a branch, because the point is to report a branch nobody remembered.
-func probeWorktreeRepos(dir string) []brief.RepoState {
+//
+// byPrefix maps a worktree directory's prefix back to the service that owns it.
+// The prefix is "<repo-basename>-<hash>", so splitting the name on "@" would
+// label every service "api-3f2a1b"; when the compose file cannot be read the
+// hash is trimmed instead, which at least yields the repository's name.
+func probeWorktreeRepos(dir string, byPrefix map[string]string) []brief.RepoState {
 	base := utils.AgentWorktreeBase(dir)
 	entries, err := os.ReadDir(base)
 	if err != nil {
@@ -60,11 +77,13 @@ func probeWorktreeRepos(dir string) []brief.RepoState {
 		if !e.IsDir() {
 			continue
 		}
-		// Directories are named <service>@<branch-with-slashes-flattened>. The
-		// branch is read from git rather than parsed back out of the name.
-		service, _, _ := strings.Cut(e.Name(), "@")
+		prefix, _, ok := strings.Cut(e.Name(), "@")
+		if !ok {
+			continue // not a worktree this scheme created
+		}
+		service := byPrefix[prefix]
 		if service == "" {
-			service = e.Name()
+			service = trimWorktreeHash(prefix)
 		}
 		if state, ok := repoState(service, filepath.Join(base, e.Name()), true); ok {
 			out = append(out, state)
@@ -73,28 +92,32 @@ func probeWorktreeRepos(dir string) []brief.RepoState {
 	return out
 }
 
+// worktreeHashSuffix matches the "-<6 hex>" that WorktreeDirPrefix appends.
+var worktreeHashSuffix = regexp.MustCompile(`-[0-9a-f]{6}$`)
+
+func trimWorktreeHash(prefix string) string {
+	return worktreeHashSuffix.ReplaceAllString(prefix, "")
+}
+
 func repoState(service, path string, worktree bool) (brief.RepoState, bool) {
-	work := utils.ProbeAgentWork(path)
-	if work == nil {
+	// ProbeAgentWork would additionally shell out to gh/glab with no timeout.
+	// A restart caused by the network going away must not then block on GitHub
+	// once per repository.
+	st, ok := utils.ProbeRepoState(path)
+	if !ok {
 		return brief.RepoState{}, false
 	}
-	branch := work.Branch
-	if branch == "HEAD" {
-		branch = "" // detached; a name here would be a lie
-	}
 	return brief.RepoState{
-		Service: service,
-		Dir:     path,
-		Branch:  branch,
-		// Not work.Dirty: that one ignores untracked files, and a session's
-		// newly created files are the work most easily lost.
-		Dirty:    utils.HasUncommittedWork(path),
+		Service:  service,
+		Dir:      path,
+		Branch:   st.Branch,
+		Dirty:    st.Dirty,
 		Worktree: worktree,
 	}, true
 }
 
-// loadComposeAtDir parses the compose file in dir without disturbing the
-// caller's compose context.
+// loadComposeAtDir parses the compose file in dir. Callers must hold
+// mcpHandlerMu: the loader underneath mutates process-wide state.
 func loadComposeAtDir(dir string) (*utils.CorgiCompose, error) {
 	for _, name := range []string{"corgi-compose.yml", "corgi-compose.yaml"} {
 		path := filepath.Join(dir, name)
@@ -158,6 +181,11 @@ func runAgentBrief(cmd *cobra.Command, args []string) {
 
 func printBriefs(briefs []brief.Brief, asJSON bool) {
 	if asJSON {
+		// Never nil: docs/agents.md promises an array, and a `null` here makes
+		// every consumer that iterates the result special-case the empty case.
+		if briefs == nil {
+			briefs = []brief.Brief{}
+		}
 		printJSON(briefs)
 		return
 	}

--- a/cmd/agent_brief.go
+++ b/cmd/agent_brief.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/brief"
+	"andriiklymiuk/corgi/utils/art"
+
+	"github.com/spf13/cobra"
+)
+
+// captureWorkspaceBrief is the daemon's probe: what did the session that just
+// ended leave on disk?
+//
+// Best-effort throughout. A workspace whose compose file has been moved or
+// broken still gets a brief saying the session restarted — losing the note is
+// never a reason to hold up a restart.
+func captureWorkspaceBrief(p brief.Params) *brief.Brief {
+	b := brief.Capture(p, probeWorkspaceRepos(p.Dir))
+	return &b
+}
+
+// probeWorkspaceRepos reads every checkout in a stack: the services' own
+// directories, plus any worktrees a cross-repo branch materialized.
+//
+// The worktrees matter most. They are the thing Remote Control cannot make and
+// the thing a restarted session has no way to discover — a branch spread across
+// four repositories looks like nothing at all from a fresh session's cwd.
+func probeWorkspaceRepos(dir string) []brief.RepoState {
+	if dir == "" {
+		return nil
+	}
+
+	var out []brief.RepoState
+	if corgi, err := loadComposeAtDir(dir); err == nil && corgi != nil {
+		for service, path := range utils.ServiceDirs(corgi, nil) {
+			if state, ok := repoState(service, path, false); ok {
+				out = append(out, state)
+			}
+		}
+	}
+	return append(out, probeWorktreeRepos(dir)...)
+}
+
+// probeWorktreeRepos scans the agent worktree directory rather than asking for
+// a branch, because the point is to report a branch nobody remembered.
+func probeWorktreeRepos(dir string) []brief.RepoState {
+	base := utils.AgentWorktreeBase(dir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return nil
+	}
+	var out []brief.RepoState
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Directories are named <service>@<branch-with-slashes-flattened>. The
+		// branch is read from git rather than parsed back out of the name.
+		service, _, _ := strings.Cut(e.Name(), "@")
+		if service == "" {
+			service = e.Name()
+		}
+		if state, ok := repoState(service, filepath.Join(base, e.Name()), true); ok {
+			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func repoState(service, path string, worktree bool) (brief.RepoState, bool) {
+	work := utils.ProbeAgentWork(path)
+	if work == nil {
+		return brief.RepoState{}, false
+	}
+	branch := work.Branch
+	if branch == "HEAD" {
+		branch = "" // detached; a name here would be a lie
+	}
+	return brief.RepoState{
+		Service: service,
+		Dir:     path,
+		Branch:  branch,
+		// Not work.Dirty: that one ignores untracked files, and a session's
+		// newly created files are the work most easily lost.
+		Dirty:    utils.HasUncommittedWork(path),
+		Worktree: worktree,
+	}, true
+}
+
+// loadComposeAtDir parses the compose file in dir without disturbing the
+// caller's compose context.
+func loadComposeAtDir(dir string) (*utils.CorgiCompose, error) {
+	for _, name := range []string{"corgi-compose.yml", "corgi-compose.yaml"} {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		corgi, _, err := loadComposeForAgent(path)
+		return corgi, err
+	}
+	return nil, fmt.Errorf("no compose file in %s", dir)
+}
+
+// ---------------------------------------------------------------- brief
+
+var agentBriefCmd = &cobra.Command{
+	Use:   "brief [workspace]",
+	Short: "What the last supervised session was working on before it restarted",
+	Long: `A restarted session is a NEW session: the previous conversation, and
+everything it had worked out, is gone.
+
+corgi cannot restore that. What it does keep is the part that survives on disk —
+which branch each repository is on, which hold uncommitted work, and which
+worktrees a cross-repo branch left behind — captured at the moment the old
+session ended.
+
+With no argument, every workspace that has one, newest first.`,
+	Args: cobra.MaximumNArgs(1),
+	Run:  runAgentBrief,
+}
+
+func runAgentBrief(cmd *cobra.Command, args []string) {
+	dir, err := agentDir()
+	if err != nil {
+		exitWithError("agent_data_dir", err, 1)
+	}
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	if len(args) == 1 {
+		b, readErr := brief.Read(dir, args[0])
+		if readErr != nil {
+			exitWithError("agent_brief", readErr, 1)
+		}
+		if b == nil {
+			if asJSON {
+				printJSON(nil)
+				return
+			}
+			utils.Infof("no brief for %s — it has not restarted since the daemon started\n", args[0])
+			return
+		}
+		printBriefs([]brief.Brief{*b}, asJSON)
+		return
+	}
+
+	briefs, err := brief.List(dir)
+	if err != nil {
+		exitWithError("agent_brief", err, 1)
+	}
+	printBriefs(briefs, asJSON)
+}
+
+func printBriefs(briefs []brief.Brief, asJSON bool) {
+	if asJSON {
+		printJSON(briefs)
+		return
+	}
+	if len(briefs) == 0 {
+		utils.Infof("no briefs yet — nothing has restarted\n")
+		return
+	}
+	for _, b := range briefs {
+		utils.Info(art.BlueColor, b.WorkspaceID, art.WhiteColor)
+		utils.Infof("  ended   %s (%s)\n", b.EndedAt.Local().Format("2006-01-02 15:04"), b.Cause)
+		if b.Reason != "" {
+			utils.Infof("  reason  %s\n", b.Reason)
+		}
+		if summary := b.Summary(); summary != "" {
+			utils.Infof("  state   %s\n", summary)
+		}
+		for _, r := range b.Repos {
+			marker := ""
+			if r.Worktree {
+				marker = " (worktree)"
+			}
+			dirty := ""
+			if r.Dirty {
+				dirty = " · uncommitted changes"
+			}
+			utils.Infof("    %-16s %s%s%s\n", r.Service, orDash(r.Branch), dirty, marker)
+		}
+	}
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// printJSON writes a value as pure JSON on stdout, matching the --json contract
+// the rest of the agent commands follow.
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}

--- a/cmd/agent_brief.go
+++ b/cmd/agent_brief.go
@@ -50,7 +50,14 @@ func probeWorkspaceRepos(dir string) []brief.RepoState {
 	var out []brief.RepoState
 	if err == nil && corgi != nil {
 		for service, path := range utils.ServiceDirs(corgi, nil) {
-			byPrefix[utils.WorktreeDirPrefix(path)] = service
+			// Worktree directories are named from the repository ROOT, not the
+			// service path — those differ for `path: .`, for a service in a
+			// monorepo subdirectory, and wherever the project dir is a symlink.
+			// Hashing the service path instead would never match, so every
+			// worktree would quietly fall back to the repo's basename.
+			if root, ok := utils.RepoRootOf(path); ok {
+				byPrefix[utils.WorktreeDirPrefix(root)] = service
+			}
 			if state, ok := repoState(service, path, false); ok {
 				out = append(out, state)
 			}
@@ -160,15 +167,18 @@ func runAgentBrief(cmd *cobra.Command, args []string) {
 		if readErr != nil {
 			exitWithError("agent_brief", readErr, 1)
 		}
+		if asJSON {
+			// One id asked for, one object or null returned — never an array.
+			// docs/agents.md documents both shapes, and a command that switches
+			// between them makes every consumer branch on the shape first.
+			printJSON(b)
+			return
+		}
 		if b == nil {
-			if asJSON {
-				printJSON(nil)
-				return
-			}
 			utils.Infof("no brief for %s — it has not restarted since the daemon started\n", args[0])
 			return
 		}
-		printBriefs([]brief.Brief{*b}, asJSON)
+		printBriefs([]brief.Brief{*b}, false)
 		return
 	}
 

--- a/cmd/agent_brief_test.go
+++ b/cmd/agent_brief_test.go
@@ -6,9 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/brief"
+
+	"github.com/spf13/cobra"
 )
 
 // gitRepo makes a repository with one commit, on a named branch.
@@ -167,5 +170,164 @@ func TestCaptureWorkspaceBriefAlwaysReturnsABrief(t *testing.T) {
 	}
 	if !got.Empty() {
 		t.Error("a brief with no readable repos must report itself empty so the notification stays one line")
+	}
+}
+
+func TestFormatBriefsShowsWhereTheSessionLeftOff(t *testing.T) {
+	// This is the text someone reads to decide where they were, so what it
+	// contains is behaviour, not decoration.
+	ended := time.Date(2026, 8, 14, 14, 32, 0, 0, time.Local)
+	got := formatBriefs([]brief.Brief{{
+		WorkspaceID: "acme-stack",
+		EndedAt:     ended,
+		Cause:       "network-timeout",
+		Reason:      "remote control restarted",
+		Repos: []brief.RepoState{
+			{Service: "api", Branch: "feature/referral", Worktree: true},
+			{Service: "web", Branch: "feature/referral", Dirty: true, Worktree: true},
+		},
+	}})
+
+	for _, want := range []string{
+		"acme-stack",
+		"network-timeout",
+		"remote control restarted",
+		"2026-08-14 14:32",
+		"feature/referral",
+		"uncommitted changes",
+		"(worktree)",
+		"api",
+		"web",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatBriefsOmitsWhatItDoesNotKnow(t *testing.T) {
+	// Empty lines labelled "reason" and "state" would suggest corgi looked and
+	// found nothing, rather than that there was nothing to look at.
+	got := formatBriefs([]brief.Brief{{
+		WorkspaceID: "acme",
+		EndedAt:     time.Now(),
+		Cause:       "crash",
+	}})
+
+	if strings.Contains(got, "reason") {
+		t.Errorf("a brief with no reason must not print the label:\n%s", got)
+	}
+	if strings.Contains(got, "state") {
+		t.Errorf("a brief with nothing to summarize must not print the label:\n%s", got)
+	}
+}
+
+func TestFormatBriefsMarksADetachedCheckout(t *testing.T) {
+	// An empty branch renders as a dash, never as a blank column that reads
+	// like the value was lost.
+	got := formatBriefs([]brief.Brief{{
+		WorkspaceID: "acme",
+		EndedAt:     time.Now(),
+		Repos:       []brief.RepoState{{Service: "api"}},
+	}})
+
+	if !strings.Contains(got, "-") {
+		t.Errorf("a repo with no branch should render a dash:\n%s", got)
+	}
+}
+
+func TestFormatBriefsSaysSoWhenThereAreNone(t *testing.T) {
+	got := formatBriefs(nil)
+
+	if !strings.Contains(got, "nothing has restarted") {
+		t.Errorf("empty output = %q, want it to explain the absence", got)
+	}
+}
+
+func TestAgentBriefJSONShapes(t *testing.T) {
+	// docs/agents.md promises an array for the list form and one object or null
+	// for a single id. A command that switches shapes makes every consumer
+	// branch on the shape before it can read the data.
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+
+	agentPath, err := agentDir()
+	if err != nil {
+		t.Fatalf("agentDir() error = %v", err)
+	}
+	if err := brief.Write(agentPath, brief.Capture(brief.Params{
+		WorkspaceID: "acme",
+		Cause:       "network-timeout",
+	}, []brief.RepoState{{Service: "api", Branch: "feature/referral"}})); err != nil {
+		t.Fatalf("brief.Write() error = %v", err)
+	}
+
+	if out := captureStdout(t, func() { runAgentBrief(briefCmdWithJSON(t), nil) }); !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Errorf("list form = %s, want a JSON array", out)
+	}
+	if out := captureStdout(t, func() { runAgentBrief(briefCmdWithJSON(t), []string{"acme"}) }); !strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Errorf("single form = %s, want one JSON object", out)
+	}
+	if out := captureStdout(t, func() { runAgentBrief(briefCmdWithJSON(t), []string{"nonesuch"}) }); strings.TrimSpace(out) != "null" {
+		t.Errorf("missing brief = %s, want null", out)
+	}
+}
+
+// briefCmdWithJSON returns the brief command with --json set, so the handler
+// can be driven without going through the root command.
+func briefCmdWithJSON(t *testing.T) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{}
+	c.Flags().Bool("json", true, "")
+	return c
+}
+
+func TestProbeWorkspaceReposNamesServicesFromTheComposeFile(t *testing.T) {
+	// End to end over the bug this file's naming logic exists for: worktree
+	// directories are named from the git repository ROOT, so a map keyed on the
+	// service path silently never matches and every worktree gets labelled with
+	// the repository basename instead of its service name.
+	//
+	// The service therefore lives in a SUBDIRECTORY of its repository — a
+	// monorepo, which is exactly the layout where the two paths diverge. With
+	// the service path as the key this test reports "mono" instead of "api".
+	dir := t.TempDir()
+	repo := gitRepo(t, filepath.Join(dir, "mono"), "main")
+	servicePath := filepath.Join(repo, "services", "api")
+	if err := os.MkdirAll(servicePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	compose := "services:\n  api:\n    path: ./mono/services/api\n"
+	if err := os.WriteFile(filepath.Join(dir, "corgi-compose.yml"), []byte(compose), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	root, ok := utils.RepoRootOf(servicePath)
+	if !ok {
+		t.Fatalf("RepoRootOf(%s) reported no repository", servicePath)
+	}
+	if root == servicePath {
+		t.Fatal("the service path and its repository root must differ for this test to discriminate")
+	}
+	// Named from the repository root, the way corgi names it.
+	worktreeDir(t, dir, root, "feature/referral")
+
+	got := probeWorkspaceRepos(dir)
+
+	var worktrees int
+	for _, r := range got {
+		if r.Service != "api" {
+			t.Errorf("service = %q, want api — the compose file names it", r.Service)
+		}
+		if r.Worktree {
+			worktrees++
+			if r.Branch != "feature/referral" {
+				t.Errorf("worktree branch = %q, want feature/referral", r.Branch)
+			}
+		}
+	}
+	if worktrees != 1 {
+		t.Errorf("probed %+v, want exactly one worktree", got)
 	}
 }

--- a/cmd/agent_brief_test.go
+++ b/cmd/agent_brief_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"andriiklymiuk/corgi/utils"
@@ -40,16 +41,30 @@ func gitRepo(t *testing.T, dir, branch string) string {
 	return dir
 }
 
+// worktreeDir creates a worktree checkout under dir using the real naming
+// scheme, so these tests exercise the names corgi actually produces rather than
+// a convenient invention.
+func worktreeDir(t *testing.T, dir, repoPath, branch string) string {
+	t.Helper()
+	name := utils.WorktreeDirPrefix(repoPath) + "@" + strings.ReplaceAll(branch, "/", "-")
+	return gitRepo(t, filepath.Join(utils.AgentWorktreeBase(dir), name), branch)
+}
+
 func TestProbeWorktreeReposReportsBranchesNobodyRemembers(t *testing.T) {
 	// A cross-repo branch is exactly what a restarted session cannot discover:
 	// from a fresh session's cwd, four worktrees on one branch look like
 	// nothing at all.
 	dir := t.TempDir()
-	base := utils.AgentWorktreeBase(dir)
-	gitRepo(t, filepath.Join(base, "api@feature-referral"), "feature/referral")
-	gitRepo(t, filepath.Join(base, "web@feature-referral"), "feature/referral")
+	apiRepo, webRepo := "/dev/acme/api", "/dev/acme/web"
+	worktreeDir(t, dir, apiRepo, "feature/referral")
+	worktreeDir(t, dir, webRepo, "feature/referral")
 
-	got := probeWorktreeRepos(dir)
+	byPrefix := map[string]string{
+		utils.WorktreeDirPrefix(apiRepo): "api",
+		utils.WorktreeDirPrefix(webRepo): "web",
+	}
+
+	got := probeWorktreeRepos(dir, byPrefix)
 
 	if len(got) != 2 {
 		t.Fatalf("probed %d worktrees, want 2: %+v", len(got), got)
@@ -62,8 +77,8 @@ func TestProbeWorktreeReposReportsBranchesNobodyRemembers(t *testing.T) {
 			t.Errorf("%s must be marked as a worktree, not a main checkout", r.Service)
 		}
 	}
-	// The service name comes from the directory prefix, so the note names the
-	// service rather than a flattened directory.
+	// The compose file maps the directory back to the service. Splitting the
+	// name on "@" would yield "api-3f2a1b", labelling every repo with a hash.
 	services := map[string]bool{got[0].Service: true, got[1].Service: true}
 	for _, want := range []string{"api", "web"} {
 		if !services[want] {
@@ -72,16 +87,32 @@ func TestProbeWorktreeReposReportsBranchesNobodyRemembers(t *testing.T) {
 	}
 }
 
+func TestProbeWorktreeReposFallsBackToTheRepoName(t *testing.T) {
+	// With no readable compose file there is no service map, and a name with
+	// the hash still attached would be worse than the repository's own name.
+	dir := t.TempDir()
+	worktreeDir(t, dir, "/dev/acme/api", "feature/referral")
+
+	got := probeWorktreeRepos(dir, map[string]string{})
+
+	if len(got) != 1 {
+		t.Fatalf("probed %d worktrees, want 1", len(got))
+	}
+	if got[0].Service != "api" {
+		t.Errorf("service = %q, want the hash trimmed back to api", got[0].Service)
+	}
+}
+
 func TestProbeWorktreeReposReportsUncommittedWork(t *testing.T) {
 	// Uncommitted work is the part that is genuinely lost if nobody mentions
 	// it, because the next session has no reason to look.
 	dir := t.TempDir()
-	repo := gitRepo(t, filepath.Join(utils.AgentWorktreeBase(dir), "api@feature-x"), "feature/x")
+	repo := worktreeDir(t, dir, "/dev/acme/api", "feature/x")
 	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("wip\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	got := probeWorktreeRepos(dir)
+	got := probeWorktreeRepos(dir, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("probed %d worktrees, want 1", len(got))
@@ -101,7 +132,7 @@ func TestProbeWorktreeReposIgnoresNonRepositories(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	if got := probeWorktreeRepos(dir); len(got) != 0 {
+	if got := probeWorktreeRepos(dir, nil); len(got) != 0 {
 		t.Errorf("probed %+v, want nothing — only git checkouts belong in a brief", got)
 	}
 }

--- a/cmd/agent_brief_test.go
+++ b/cmd/agent_brief_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/brief"
+)
+
+// gitRepo makes a repository with one commit, on a named branch.
+func gitRepo(t *testing.T, dir, branch string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", "-b", branch)
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	run("add", ".")
+	run("commit", "-qm", "initial")
+	return dir
+}
+
+func TestProbeWorktreeReposReportsBranchesNobodyRemembers(t *testing.T) {
+	// A cross-repo branch is exactly what a restarted session cannot discover:
+	// from a fresh session's cwd, four worktrees on one branch look like
+	// nothing at all.
+	dir := t.TempDir()
+	base := utils.AgentWorktreeBase(dir)
+	gitRepo(t, filepath.Join(base, "api@feature-referral"), "feature/referral")
+	gitRepo(t, filepath.Join(base, "web@feature-referral"), "feature/referral")
+
+	got := probeWorktreeRepos(dir)
+
+	if len(got) != 2 {
+		t.Fatalf("probed %d worktrees, want 2: %+v", len(got), got)
+	}
+	for _, r := range got {
+		if r.Branch != "feature/referral" {
+			t.Errorf("%s: branch = %q, want feature/referral", r.Service, r.Branch)
+		}
+		if !r.Worktree {
+			t.Errorf("%s must be marked as a worktree, not a main checkout", r.Service)
+		}
+	}
+	// The service name comes from the directory prefix, so the note names the
+	// service rather than a flattened directory.
+	services := map[string]bool{got[0].Service: true, got[1].Service: true}
+	for _, want := range []string{"api", "web"} {
+		if !services[want] {
+			t.Errorf("service %q missing from %+v", want, got)
+		}
+	}
+}
+
+func TestProbeWorktreeReposReportsUncommittedWork(t *testing.T) {
+	// Uncommitted work is the part that is genuinely lost if nobody mentions
+	// it, because the next session has no reason to look.
+	dir := t.TempDir()
+	repo := gitRepo(t, filepath.Join(utils.AgentWorktreeBase(dir), "api@feature-x"), "feature/x")
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("wip\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got := probeWorktreeRepos(dir)
+
+	if len(got) != 1 {
+		t.Fatalf("probed %d worktrees, want 1", len(got))
+	}
+	if !got[0].Dirty {
+		t.Error("a worktree with an untracked file must be reported as dirty")
+	}
+}
+
+func TestProbeWorktreeReposIgnoresNonRepositories(t *testing.T) {
+	dir := t.TempDir()
+	base := utils.AgentWorktreeBase(dir)
+	if err := os.MkdirAll(filepath.Join(base, "not-a-repo"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "stray.log"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if got := probeWorktreeRepos(dir); len(got) != 0 {
+		t.Errorf("probed %+v, want nothing — only git checkouts belong in a brief", got)
+	}
+}
+
+func TestProbeWorkspaceReposOnAMissingDirectoryIsEmpty(t *testing.T) {
+	// A workspace on an unmounted drive must produce a brief saying the session
+	// restarted, not a crash inside the supervisor's restart path.
+	if got := probeWorkspaceRepos(filepath.Join(t.TempDir(), "gone")); len(got) != 0 {
+		t.Errorf("probed %+v, want nothing", got)
+	}
+	if got := probeWorkspaceRepos(""); len(got) != 0 {
+		t.Errorf("probed %+v for an empty dir, want nothing", got)
+	}
+}
+
+func TestCaptureWorkspaceBriefAlwaysReturnsABrief(t *testing.T) {
+	// The daemon calls this on every restart. Returning nil for a workspace it
+	// could not read would lose the cause and reason too, which are the parts
+	// that always apply.
+	got := captureWorkspaceBrief(brief.Params{
+		WorkspaceID: "acme",
+		Dir:         filepath.Join(t.TempDir(), "gone"),
+		Cause:       "network-timeout",
+		Reason:      "remote control restarted",
+	})
+
+	if got == nil {
+		t.Fatal("captureWorkspaceBrief() = nil")
+	}
+	if got.WorkspaceID != "acme" || got.Cause != "network-timeout" {
+		t.Errorf("brief = %+v, want the params carried through", got)
+	}
+	if !got.Empty() {
+		t.Error("a brief with no readable repos must report itself empty so the notification stays one line")
+	}
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -399,7 +399,9 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 				fmt.Fprintf(os.Stderr, "🌐 ✗ tunnel: %s\n", ev.Err)
 			case ev.URL != "":
 				mcpPublicTunnelActive.Store(true)
-				go probeTunnelExposure(ctx, ev.URL)
+				// Probe the route the tools are actually served on, not the
+				// root — see probeTunnelExposure.
+				go probeTunnelExposure(ctx, mcpProbeTarget(ev.URL))
 				fmt.Fprintf(os.Stderr, "🌐 ✓ public MCP endpoint: %s/mcp\n", ev.URL)
 				// Don't reprint the bearer token in a pasteable block on the
 				// public side — the local config (printed earlier) already has it.
@@ -416,11 +418,18 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 // probeTunnelExposure checks whether the published tunnel is behind an identity
 // proxy, and says so either way.
 //
+// The url must be the endpoint the tools are served on (`/mcp`), never the
+// tunnel root. Making a non-browser MCP client work behind Cloudflare Access
+// means giving `/mcp` a service-token or bypass policy while `/` keeps
+// redirecting to the login page — so probing the root would see that redirect,
+// call the whole tunnel private, and re-enable corgi_exec on a route anyone
+// with the URL can reach. The gate has to be measured where it applies.
+//
 // Runs in the background: nothing may wait on it, because the endpoint is
 // already serving by the time the URL is printed, and a gate that starts closed
 // and opens on evidence is the safe direction to be wrong in.
 func probeTunnelExposure(ctx context.Context, url string) {
-	result := tunnel.ProbeAccess(ctx, url)
+	result := exposureProbe(ctx, url)
 	if !result.Protected {
 		// Not a warning: this is the documented default. The block message
 		// already told them how to change it.
@@ -431,6 +440,16 @@ func probeTunnelExposure(ctx context.Context, url string) {
 	fmt.Fprintf(os.Stderr,
 		"🌐 exposure: private — %s (%s). corgi_exec/corgi_db_query stay enabled; no CORGI_MCP_ALLOW_DANGEROUS_TUNNEL needed.\n",
 		result.Provider, result.Detail)
+}
+
+// exposureProbe is the access check, swappable so a test can assert which URL
+// the gate is measured against without needing a trusted certificate.
+var exposureProbe = tunnel.ProbeAccess
+
+// mcpProbeTarget is the URL the exposure probe must measure: the route the
+// tools are served on, never the tunnel root.
+func mcpProbeTarget(tunnelURL string) string {
+	return strings.TrimSuffix(tunnelURL, "/") + "/mcp"
 }
 
 // mcpAddrPort extracts the numeric port from a listen addr like ":8765" or

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -70,16 +70,45 @@ var mcpHandlerMu sync.Mutex
 // atomic to stay race-free.
 var mcpPublicTunnelActive atomic.Bool
 
+// mcpTunnelPrivate is set when the published tunnel URL was observed to be
+// behind an identity proxy, so an unauthenticated request never reaches corgi.
+//
+// It is only ever set from a probe that saw the interception happen — never
+// from configuration. A gate that relaxes because a config file claimed
+// protection is a gate that fails open on a typo.
+var mcpTunnelPrivate atomic.Bool
+
 // dangerousToolBlockedMsg is returned by corgi_exec / corgi_db_query when they
 // are reachable over a public tunnel without the explicit opt-in.
-const dangerousToolBlockedMsg = "corgi_exec/corgi_db_query are disabled over a public tunnel; set CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1 to allow"
+const dangerousToolBlockedMsg = "corgi_exec/corgi_db_query are disabled over a public tunnel; put the tunnel behind an identity proxy, or set CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1 to allow"
+
+// mcpExposure reports which tier the endpoint currently sits in.
+func mcpExposure() tunnel.Exposure {
+	if !mcpPublicTunnelActive.Load() {
+		return tunnel.ExposureLocal
+	}
+	if mcpTunnelPrivate.Load() {
+		return tunnel.ExposurePrivate
+	}
+	return tunnel.ExposurePublic
+}
 
 // dangerousTunnelToolsAllowed reports whether corgi_exec / corgi_db_query may
-// run. They are always allowed over stdio or a plain (non-tunneled) HTTP
-// endpoint; over a public tunnel they require an explicit opt-in so arbitrary
-// command + DB execution isn't exposed to anyone with the URL.
+// run.
+//
+// Always allowed over stdio or a plain (non-tunneled) HTTP endpoint. Over a
+// tunnel it depends on who can reach it: a tunnel behind an identity proxy is
+// not open to the internet, so the tools stay usable from a phone that has
+// signed in. A tunnel anyone holding the URL can reach still requires the
+// explicit opt-in, because that is arbitrary command and DB execution.
 func dangerousTunnelToolsAllowed(publicTunnel bool) bool {
-	return !publicTunnel || os.Getenv("CORGI_MCP_ALLOW_DANGEROUS_TUNNEL") == "1"
+	if !publicTunnel {
+		return true
+	}
+	if mcpTunnelPrivate.Load() {
+		return true
+	}
+	return os.Getenv("CORGI_MCP_ALLOW_DANGEROUS_TUNNEL") == "1"
 }
 
 func runMCP(cmd *cobra.Command, _ []string) {
@@ -370,6 +399,7 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 				fmt.Fprintf(os.Stderr, "🌐 ✗ tunnel: %s\n", ev.Err)
 			case ev.URL != "":
 				mcpPublicTunnelActive.Store(true)
+				go probeTunnelExposure(ctx, ev.URL)
 				fmt.Fprintf(os.Stderr, "🌐 ✓ public MCP endpoint: %s/mcp\n", ev.URL)
 				// Don't reprint the bearer token in a pasteable block on the
 				// public side — the local config (printed earlier) already has it.
@@ -381,6 +411,26 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 		}
 	}()
 	return done
+}
+
+// probeTunnelExposure checks whether the published tunnel is behind an identity
+// proxy, and says so either way.
+//
+// Runs in the background: nothing may wait on it, because the endpoint is
+// already serving by the time the URL is printed, and a gate that starts closed
+// and opens on evidence is the safe direction to be wrong in.
+func probeTunnelExposure(ctx context.Context, url string) {
+	result := tunnel.ProbeAccess(ctx, url)
+	if !result.Protected {
+		// Not a warning: this is the documented default. The block message
+		// already told them how to change it.
+		fmt.Fprintf(os.Stderr, "🌐 exposure: public — %s\n", result.Detail)
+		return
+	}
+	mcpTunnelPrivate.Store(true)
+	fmt.Fprintf(os.Stderr,
+		"🌐 exposure: private — %s (%s). corgi_exec/corgi_db_query stay enabled; no CORGI_MCP_ALLOW_DANGEROUS_TUNNEL needed.\n",
+		result.Provider, result.Detail)
 }
 
 // mcpAddrPort extracts the numeric port from a listen addr like ":8765" or

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/brief"
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/workspace"
@@ -40,6 +41,18 @@ func registerAgentMCPTools(s *server.MCPServer) {
 				"Use this to answer \"is it up\" and \"why did my session die\"."),
 	), jsonHandler(func(mcp.CallToolRequest) (any, error) {
 		return mcpAgentStatus()
+	}))
+
+	s.AddTool(mcp.NewTool("corgi_session_brief",
+		mcp.WithDescription(
+			"What the previous supervised session in this workspace was working on before it was restarted. "+
+				"Read-only. A restart produces a NEW session with none of the earlier conversation, so call this "+
+				"first when the user picks up where they left off: it reports the branch each repository is on, "+
+				"which hold uncommitted changes, and which cross-repo worktrees exist. "+
+				"Returns null when nothing has restarted, which is the ordinary case."),
+		mcp.WithString("workspace", mcp.Description("Workspace id; omit for every workspace that has one")),
+	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
+		return mcpSessionBrief(r.GetString("workspace", ""))
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_workspaces",
@@ -187,6 +200,34 @@ func mcpAgentStatus() (any, error) {
 		}, nil
 	}
 	return status, nil
+}
+
+func mcpSessionBrief(workspace string) (any, error) {
+	dir, err := agentDir()
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(workspace) != "" {
+		b, readErr := brief.Read(dir, workspace)
+		if readErr != nil {
+			return nil, readErr
+		}
+		if b == nil {
+			// Explicitly not an error: "nothing has restarted" is the good case,
+			// and an error here would read as a fault to whoever is holding the
+			// phone.
+			return map[string]any{
+				"brief": nil,
+				"note":  "no restart recorded for this workspace since the daemon started",
+			}, nil
+		}
+		return map[string]any{"brief": b, "summary": b.Summary()}, nil
+	}
+	briefs, err := brief.List(dir)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"briefs": briefs}, nil
 }
 
 func mcpWorkspaces() (any, error) {

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -227,6 +227,11 @@ func mcpSessionBrief(workspace string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if briefs == nil {
+		// Never null: a client that iterates the field should not have to
+		// special-case "no restarts yet", which is the ordinary state.
+		briefs = []brief.Brief{}
+	}
 	return map[string]any{"briefs": briefs}, nil
 }
 

--- a/cmd/mcp_dangerous_test.go
+++ b/cmd/mcp_dangerous_test.go
@@ -96,3 +96,79 @@ func TestProbeTunnelExposureLeavesTheGateClosedOnAPublicEndpoint(t *testing.T) {
 		t.Fatal("probing a public endpoint must not mark the tunnel private")
 	}
 }
+
+func TestExposureIsMeasuredOnTheRouteTheToolsAreServedOn(t *testing.T) {
+	// Making a non-browser MCP client work behind an identity proxy means
+	// giving /mcp a service-token or bypass policy while / keeps redirecting to
+	// the login page. Probing the root would see that redirect, call the whole
+	// tunnel private, and re-enable corgi_exec on a route anyone with the URL
+	// can reach.
+	if got := mcpProbeTarget("https://kind-zebra-42.trycloudflare.com"); got != "https://kind-zebra-42.trycloudflare.com/mcp" {
+		t.Errorf("mcpProbeTarget() = %q, want the /mcp route", got)
+	}
+	if got := mcpProbeTarget("https://corgi.example/"); got != "https://corgi.example/mcp" {
+		t.Errorf("mcpProbeTarget() = %q, want no doubled slash", got)
+	}
+}
+
+func TestExposureProbeUsesTheURLItIsGiven(t *testing.T) {
+	var probed string
+	mcpTunnelPrivate.Store(false)
+	original := exposureProbe
+	exposureProbe = func(_ context.Context, url string) tunnel.AccessResult {
+		probed = url
+		return tunnel.AccessResult{}
+	}
+	t.Cleanup(func() {
+		exposureProbe = original
+		mcpTunnelPrivate.Store(false)
+	})
+
+	probeTunnelExposure(context.Background(), mcpProbeTarget("https://corgi.example"))
+
+	if probed != "https://corgi.example/mcp" {
+		t.Errorf("probed %q, want the gated route", probed)
+	}
+	if mcpTunnelPrivate.Load() {
+		t.Error("an unprotected result must leave the endpoint public")
+	}
+}
+
+func TestAnUnauthenticatedRequestReachingMCPStaysPublic(t *testing.T) {
+	// The bypassed-/mcp case, end to end: / redirects to the Access login but
+	// /mcp answers, so the endpoint is reachable and must not be called private.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/mcp" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/cdn-cgi/access/login", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	root := tunnel.ProbeAccessWith(context.Background(), srv.URL, srv.Client())
+	if !root.Protected {
+		t.Fatal("the root is protected in this setup; the test server is not set up as intended")
+	}
+
+	got := tunnel.ProbeAccessWith(context.Background(), mcpProbeTarget(srv.URL), srv.Client())
+	if got.Protected {
+		t.Error("an unauthenticated request that reaches /mcp must leave the endpoint public")
+	}
+}
+
+func TestCorgisOwn401DoesNotMarkTheEndpointPrivate(t *testing.T) {
+	// corgi's bearer check writes 401 with no WWW-Authenticate at all, which is
+	// exactly what probing an unprotected /mcp sees.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	got := tunnel.ProbeAccessWith(context.Background(), mcpProbeTarget(srv.URL), srv.Client())
+
+	if got.Protected {
+		t.Errorf("corgi's own 401 must never count as an identity proxy (detail: %s)", got.Detail)
+	}
+}

--- a/cmd/mcp_dangerous_test.go
+++ b/cmd/mcp_dangerous_test.go
@@ -2,8 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"andriiklymiuk/corgi/utils/tunnel"
 )
 
 func TestDangerousToolGate_ClosedByDefault(t *testing.T) {
@@ -35,5 +40,59 @@ func TestStartMCPTunnel_NoPasteableTokenBlock(t *testing.T) {
 	printMCPClientConfig(&local, "http://127.0.0.1:8765/mcp", token)
 	if !strings.Contains(local.String(), token) {
 		t.Fatalf("local client config should include the token: %s", local.String())
+	}
+}
+
+func TestDangerousToolGate_OpensForAVerifiedPrivateTunnel(t *testing.T) {
+	// A tunnel behind an identity proxy is not open to the internet, so the
+	// tools that make agent mode useful from a phone stay usable without
+	// anyone setting a blanket "allow dangerous" variable and forgetting it.
+	t.Setenv("CORGI_MCP_ALLOW_DANGEROUS_TUNNEL", "")
+	mcpTunnelPrivate.Store(true)
+	t.Cleanup(func() { mcpTunnelPrivate.Store(false) })
+
+	if !dangerousTunnelToolsAllowed(true /* publicTunnel */) {
+		t.Fatal("a tunnel verified to be behind an identity proxy must not block the tools")
+	}
+}
+
+func TestExposureTiers(t *testing.T) {
+	t.Cleanup(func() {
+		mcpPublicTunnelActive.Store(false)
+		mcpTunnelPrivate.Store(false)
+	})
+
+	mcpPublicTunnelActive.Store(false)
+	mcpTunnelPrivate.Store(false)
+	if got := mcpExposure(); got != tunnel.ExposureLocal {
+		t.Errorf("no tunnel: exposure = %q, want %q", got, tunnel.ExposureLocal)
+	}
+
+	mcpPublicTunnelActive.Store(true)
+	if got := mcpExposure(); got != tunnel.ExposurePublic {
+		t.Errorf("unverified tunnel: exposure = %q, want %q", got, tunnel.ExposurePublic)
+	}
+
+	mcpTunnelPrivate.Store(true)
+	if got := mcpExposure(); got != tunnel.ExposurePrivate {
+		t.Errorf("verified tunnel: exposure = %q, want %q", got, tunnel.ExposurePrivate)
+	}
+}
+
+func TestProbeTunnelExposureLeavesTheGateClosedOnAPublicEndpoint(t *testing.T) {
+	// The probe is the only thing that may open the gate, so a public endpoint
+	// running through it must leave the flag exactly as it found it.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	mcpTunnelPrivate.Store(false)
+	t.Cleanup(func() { mcpTunnelPrivate.Store(false) })
+
+	probeTunnelExposure(context.Background(), srv.URL)
+
+	if mcpTunnelPrivate.Load() {
+		t.Fatal("probing a public endpoint must not mark the tunnel private")
 	}
 }

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -73,6 +73,7 @@ corgi agent serve --foreground   # run it in this terminal and watch
 | `corgi agent doctor [--json]` | can this work here, and what to fix |
 | `corgi agent workspaces` | list, `forget`, `relocate` |
 | `corgi agent resolve <name>` | what "the recipe app" resolves to |
+| `corgi agent brief [id]` | what the last session was working on before it restarted |
 | `corgi agent stop` | stop the daemon |
 
 ## Restarts, and being told about them
@@ -85,6 +86,40 @@ reboot. corgi restarts it with capped backoff and **says so**:
 The notification matters. A relaunched Remote Control starts a **new** session,
 so the previous conversation's context is gone. Restarting silently would look
 like continuity and cost you an hour of confusion.
+
+### The handover brief
+
+corgi cannot restore the conversation. What it can keep is the half that
+survives on disk, captured in the gap between the old process exiting and the
+new one starting — the only moment that state is both final and current:
+
+```bash
+$ corgi agent brief acme-stack
+acme-stack
+  ended   2026-08-14 14:32 (network-timeout)
+  reason  remote control restarted — the previous session ended (network timeout)
+  state   was on feature/referral · 1 repo has uncommitted changes
+    api              feature/referral (worktree)
+    web              feature/referral · uncommitted changes (worktree)
+```
+
+The worktrees are the part worth having. A branch spread across four
+repositories is invisible from a fresh session's working directory, and nothing
+else would tell the new session it exists. The summary line is appended to the
+restart notification, so the lock screen says *where* as well as *that*.
+
+Uncommitted work counts untracked files, unlike the check that guards worktree
+removal. Creating files is the most common thing an agent does, and a note
+calling that "clean" would be worse than no note. `.gitignore` is respected, so
+build output does not inflate the count.
+
+A session that ends because you asked it to gets no brief — you do not need a
+handover note for something you just closed. Only the most recent is kept per
+workspace, and `corgi agent workspaces forget` drops it, so a reused id cannot
+surface another stack's branches.
+
+From a phone, the same thing is `corgi_session_brief`. Call it first when
+picking work back up.
 
 Not every exit is worth retrying:
 
@@ -111,6 +146,52 @@ to forever, because an always-awake laptop is a flat battery.
 **Honest limit:** on macOS, closing the lid on battery sleeps the machine no
 matter what `caffeinate` does. "Lid closed on the train" only works plugged in.
 If that is your workflow, supervise from a machine that stays on.
+
+## Supervising an agent other than Claude Code
+
+Everything the supervisor actually does — restart after the ways a session dies,
+hold a wake lock, scope credentials and config directory per workspace — is the
+same whichever agent CLI is running. Only the launch details differ, so those
+are a `kind`:
+
+```yaml
+workspaces:
+  acme-stack:
+    autostart: true
+    kind: custom
+    bin: some-agent            # a command name on PATH, never a path
+    args: [serve, --headless]  # the argv, in full
+    configDirEnv: SOME_AGENT_HOME
+    credentialEnv: [SOME_AGENT_API_KEY, SOME_AGENT_OAUTH_TOKEN]
+```
+
+| kind | what it launches |
+|---|---|
+| `claude` | `claude remote-control …`, built from `spawn`, `capacity`, `permissionMode`. The default, so an existing config is unchanged. |
+| `custom` | exactly the `args` you wrote, after `bin`. |
+
+**Why `custom` takes the whole argv rather than corgi guessing flags.** A
+supervised process runs unattended, and a flag corgi invented for a CLI whose
+interface it cannot verify would fail at 3am with a message nobody sees. Writing
+the command out means what runs is what you tested in a terminal. Built-in kinds
+exist for CLIs whose flags corgi can be sure of; adding one is a map entry in
+`utils/agent/supervisor/kind.go`.
+
+Three rules carry over unchanged, because they are what makes supervision safe
+rather than merely convenient:
+
+- **`args` is trusted config only.** An argv is a choice of what code runs, so
+  there is deliberately no field in the committed `.corgi/agent.yml` that
+  reaches it. A cloned repository cannot choose the command.
+- **Nothing may disarm the permission prompts.** `--dangerously-*` and `--yolo`
+  in `args` are rejected, the same rule that already rejects
+  `permissionMode: bypassPermissions`. Those prompts are what you answer from
+  your phone.
+- **A setting that cannot take effect is an error.** `spawn` and
+  `permissionMode` on a `custom` kind are rejected rather than dropped, and so
+  is a `configDir` with no `configDirEnv` to put it in — silently ignoring the
+  last one would leave the workspace on the default account, which looks exactly
+  like being on the right one.
 
 ## Running more than one Claude account
 
@@ -173,6 +254,7 @@ defaults:
 workspaces:
   acme-stack:
     autostart: true          # supervise this one; `corgi agent init` sets it
+    kind: claude             # which agent CLI; default, see below
     configDir: ~/.claude-work
     wakeLock: session
     permissionMode: default
@@ -195,11 +277,12 @@ session acting on injected instructions from a file it read.
 
 ## The MCP tools
 
-`corgi mcp` gains nine tools. A Remote Control session calls them from your
+`corgi mcp` gains ten tools. A Remote Control session calls them from your
 phone; they also work from any other MCP client.
 
 | tool | what it does |
 |---|---|
+| `corgi_session_brief` | what the previous session was working on before it restarted |
 | `corgi_workspaces` | every stack registered on this machine |
 | `corgi_workspace_resolve` | "the recipe app" → one stack, or candidates |
 | `corgi_worktrees_materialize` | a worktree per repo, all on one branch |
@@ -210,9 +293,9 @@ phone; they also work from any other MCP client.
 | `corgi_preview_freeze` | pin it so idle reaping leaves it alone |
 | `corgi_preview_stop` | tear it down |
 
-`corgi_worktrees_*` mutate, so they join the same public-tunnel gate that
-already covers `corgi_exec` and `corgi_db_query`: over a tunnel they need
-`CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1`.
+`corgi_worktrees_*` mutate, so they join the same tunnel gate that already
+covers `corgi_exec` and `corgi_db_query` — see [exposure
+tiers](#exposure-local-private-public) for when that gate is closed.
 
 ### Resolution never guesses
 
@@ -315,6 +398,50 @@ using for your stack:
 Try it by hand before relying on it. `corgi_diff` needs none of this and is the
 better answer to "what changed".
 
+## Exposure: local, private, public
+
+"Is there a tunnel" is the wrong question to gate on. A tunnel behind an
+identity proxy is not open to the internet; a quick tunnel is open to anyone who
+has the URL. Those deserve different answers, so `corgi mcp --http --tunnel`
+sorts the endpoint into a tier:
+
+| tier | what it means | `corgi_exec`, `corgi_db_query`, `corgi_worktrees_*` |
+|---|---|---|
+| `local` | loopback or LAN, no tunnel | allowed |
+| `private` | a tunnel an identity proxy stands in front of | allowed |
+| `public` | anyone holding the URL can reach it | blocked unless `CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1` |
+
+`private` is **only ever reached by observing it**. When the tunnel URL is
+published, corgi makes one unauthenticated request and looks at what comes back
+— a redirect to an Access login, a `cf-access-*` header, a challenge naming a
+realm. Nothing in any config file can assert protection, because a gate that
+relaxes on a claim is a gate that fails open on a typo.
+
+```
+🌐 ✓ public MCP endpoint: https://corgi.example/mcp
+🌐 exposure: private — cloudflare-access (unauthenticated request redirected to the Access login).
+   corgi_exec/corgi_db_query stay enabled; no CORGI_MCP_ALLOW_DANGEROUS_TUNNEL needed.
+```
+
+corgi's own bearer check answers 401 too, and is deliberately **not** counted:
+treating it as protection would let the endpoint declare itself private on the
+strength of the very token the gate exists to protect. Anything unrecognised —
+including a probe that could not connect — stays `public`. The gate starts
+closed and opens only on evidence.
+
+The practical result is that `CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1`, which is set
+once and then forgotten about forever, stops being the only way to use these
+tools from a phone. Put a named tunnel behind an access policy and the gate
+opens for the right reason.
+
+Two things this does **not** do. It does not check previews: `corgi_preview_*`
+opens a tunnel onto a dev server, and probing it would mean a network call
+inside an MCP handler, which must never block. A preview is public, `sensitive`
+workspaces refuse one, and idle reaping still tears it down. And it is a
+reachability check, not an authorization model — it tells you an unauthenticated
+request does not reach corgi, nothing about who is on the other side once it
+does.
+
 ## Pairing a phone
 
 A phone reaches corgi over the MCP HTTP endpoint, and should never be handed the
@@ -358,7 +485,11 @@ export CORGI_DATA_DIR="$(brew --prefix)/var/corgi"
 - `bin` must be a command name on PATH, never a path.
 - `bypassPermissions` rejected; `--dangerously-skip-permissions` never passed.
 - Ambient credentials stripped from supervised processes and reported.
-- The user config must be `0600` or corgi refuses to read it.
+- The user config must be `0600` or corgi refuses to read it; briefs are written
+  `0600` for the same reason — they name repository paths and branches.
+- A custom kind's `args` cannot carry `--dangerously-*` or `--yolo`.
+- Exposure is downgraded to `private` only on an observed interception, never on
+  a config claim, and corgi's own 401 does not count as one.
 - No secret material in the launchd plist or systemd unit — those are
   world-readable and land in backups.
 - Supervised output is not mirrored to the daemon's log unless you pass

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -412,10 +412,16 @@ sorts the endpoint into a tier:
 | `public` | anyone holding the URL can reach it | blocked unless `CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1` |
 
 `private` is **only ever reached by observing it**. When the tunnel URL is
-published, corgi makes one unauthenticated request and looks at what comes back
-— a redirect to an Access login, a `cf-access-*` header, a challenge naming a
-realm. Nothing in any config file can assert protection, because a gate that
-relaxes on a claim is a gate that fails open on a typo.
+published, corgi makes one unauthenticated request to **`/mcp`** — the route the
+tools are actually served on — and looks at what comes back: a redirect to an
+Access login, a `cf-access-*` header, a challenge naming a realm. Nothing in any
+config file can assert protection, because a gate that relaxes on a claim is a
+gate that fails open on a typo.
+
+The route matters. Making a non-browser MCP client work behind Access usually
+means giving `/mcp` a service-token or bypass policy while `/` keeps redirecting
+to the login page. Probing the root would see that redirect, call the tunnel
+private, and re-enable `corgi_exec` on a route anyone with the URL can reach.
 
 ```
 🌐 ✓ public MCP endpoint: https://corgi.example/mcp

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -37,6 +37,7 @@ stderr. Commands that emit pure-JSON stdout:
 - `restart --service <name> --json` → updated run-state object
 - `mission-control --json` (one MissionSnapshot object; `--watch`: one object per refresh)
 - `autopilot status/pause/resume/stop/heartbeat --json` → the autopilot loop state object (`{mode, iteration, lastHeartbeat, lastSummary}`); `mode` ∈ `uninitialized` (no state file yet — a first run, distinct from a stop) · `running` · `paused` · `stopped`
+- `agent brief --json` (array of briefs, newest first; `agent brief <id> --json` → one brief, or `null` when that workspace has not restarted)
 - `memory list --json` (array of facts), `memory lint --json` (`{"ok":bool,"errors":[...],"warnings":[...]}`), `memory add --json` / `memory index --json` (created/index summary)
 - `suggest-history list --json` (`{"version","entries":[...]}`), `suggest-history check --slug <s> --json` (`{"skip":bool,"reason":"filed|dismissed|proposed|rate-limit|...","slug":...}`), `suggest-history record --json` (echoes the written entry), `suggest-history config --json` (`{"autoFileDrafts":bool,"maxPerWeek":n}`)
 - `docs --json-schema`

--- a/utils/agent/brief/brief.go
+++ b/utils/agent/brief/brief.go
@@ -1,0 +1,242 @@
+// Package brief records what a supervised session was working on, so the one
+// that replaces it can be told.
+//
+// The supervisor restarts a session after a network timeout, a crash, or a
+// reboot. What comes back is a NEW session: the conversation, and everything it
+// had worked out, is gone. corgi cannot restore that — but it does know the
+// part that survives on disk, which is the part worth having. Which branch was
+// checked out in each repository, which of them hold uncommitted work, and
+// which worktrees a cross-repo branch left behind.
+//
+// That is the difference between "your session restarted" and "your session
+// restarted, and here is where it was".
+package brief
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Brief is one ended session's leftovers.
+type Brief struct {
+	WorkspaceID string    `json:"workspaceId"`
+	Dir         string    `json:"dir,omitempty"`
+	EndedAt     time.Time `json:"endedAt"`
+	// Cause and Reason are the supervisor's classification, carried verbatim so
+	// the brief answers "why am I a new session" without a second lookup.
+	Cause  string `json:"cause,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	// Restarts is how many times this workspace has been restarted. A brief
+	// that keeps reappearing means something is wrong beyond a flaky network.
+	Restarts int `json:"restarts,omitempty"`
+	// Repos is one entry per service checkout, including worktrees.
+	Repos []RepoState `json:"repos,omitempty"`
+}
+
+// RepoState is what one repository looked like when the session ended.
+type RepoState struct {
+	Service string `json:"service"`
+	Dir     string `json:"dir,omitempty"`
+	Branch  string `json:"branch,omitempty"`
+	Dirty   bool   `json:"dirty,omitempty"`
+	// Worktree marks a checkout materialized for a cross-repo branch rather
+	// than the service's main one.
+	Worktree bool `json:"worktree,omitempty"`
+}
+
+// Params is everything the supervisor knows at the moment a session ends.
+type Params struct {
+	WorkspaceID string
+	Dir         string
+	Cause       string
+	Reason      string
+	Restarts    int
+	EndedAt     time.Time
+}
+
+// Capture builds a brief. repos comes from the caller because enumerating a
+// stack's services means parsing a compose file, which this package
+// deliberately knows nothing about — that keeps it testable without git, a
+// compose file, or a workspace on disk.
+func Capture(p Params, repos []RepoState) Brief {
+	endedAt := p.EndedAt
+	if endedAt.IsZero() {
+		endedAt = time.Now()
+	}
+	sorted := append([]RepoState(nil), repos...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Service < sorted[j].Service })
+	return Brief{
+		WorkspaceID: p.WorkspaceID,
+		Dir:         p.Dir,
+		EndedAt:     endedAt.UTC(),
+		Cause:       p.Cause,
+		Reason:      p.Reason,
+		Restarts:    p.Restarts,
+		Repos:       sorted,
+	}
+}
+
+// Empty reports whether there is nothing worth telling anyone. A brief with no
+// repository state says only "it restarted", which the notification already
+// said.
+func (b Brief) Empty() bool {
+	for _, r := range b.Repos {
+		if r.Branch != "" || r.Dirty {
+			return false
+		}
+	}
+	return true
+}
+
+// Summary is the one line that goes in a restart notification.
+//
+// It has to be readable on a lock screen, so it names the branches and counts
+// the rest rather than listing every repository.
+func (b Brief) Summary() string {
+	if b.Empty() {
+		return ""
+	}
+
+	var branches []string
+	seen := map[string]bool{}
+	dirty := 0
+	for _, r := range b.Repos {
+		if r.Branch != "" && !seen[r.Branch] {
+			seen[r.Branch] = true
+			branches = append(branches, r.Branch)
+		}
+		if r.Dirty {
+			dirty++
+		}
+	}
+	sort.Strings(branches)
+
+	var parts []string
+	switch len(branches) {
+	case 0:
+	case 1:
+		parts = append(parts, "was on "+branches[0])
+	default:
+		parts = append(parts, "was on "+strings.Join(branches, ", "))
+	}
+	if dirty == 1 {
+		parts = append(parts, "1 repo has uncommitted changes")
+	} else if dirty > 1 {
+		parts = append(parts, fmt.Sprintf("%d repos have uncommitted changes", dirty))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// dirName is where briefs live under the agent data directory.
+const dirName = "briefs"
+
+// Path is the file backing one workspace's brief. Only the most recent is kept:
+// a brief is a handover note, and yesterday's is noise.
+func Path(agentDir, workspaceID string) string {
+	return filepath.Join(agentDir, dirName, sanitize(workspaceID)+".json")
+}
+
+// Write stores a brief, replacing any earlier one for that workspace.
+//
+// Written 0600 in the agent data directory: it names repository paths and
+// branch names, which is more than a passer-by on a shared machine should get.
+func Write(agentDir string, b Brief) error {
+	if b.WorkspaceID == "" {
+		return fmt.Errorf("brief: workspace id is required")
+	}
+	path := Path(agentDir, b.WorkspaceID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return err
+	}
+	// Write-then-rename, so a daemon killed mid-write cannot leave a truncated
+	// brief that fails to parse for the session that needed it.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// Read returns a workspace's brief, or nil when there is none — which is the
+// ordinary case for a session that has not restarted.
+func Read(agentDir, workspaceID string) (*Brief, error) {
+	data, err := os.ReadFile(Path(agentDir, workspaceID))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var b Brief
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("%s: %w", Path(agentDir, workspaceID), err)
+	}
+	return &b, nil
+}
+
+// List returns every stored brief, newest first.
+func List(agentDir string) ([]Brief, error) {
+	entries, err := os.ReadDir(filepath.Join(agentDir, dirName))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var out []Brief
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(agentDir, dirName, e.Name()))
+		if readErr != nil {
+			continue // one unreadable brief must not hide the rest
+		}
+		var b Brief
+		if json.Unmarshal(data, &b) == nil {
+			out = append(out, b)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].EndedAt.After(out[j].EndedAt) })
+	return out, nil
+}
+
+// Clear removes a workspace's brief. Used when a workspace is forgotten, so a
+// stale note cannot resurface against a different stack at the same id.
+func Clear(agentDir, workspaceID string) error {
+	err := os.Remove(Path(agentDir, workspaceID))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// sanitize keeps a workspace id from escaping the briefs directory. Ids come
+// from a registry corgi writes, but this is a filename built from a name, and
+// that pattern is worth closing wherever it appears.
+func sanitize(id string) string {
+	replaced := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}, id)
+	// A name of only dots would still resolve to a directory entry.
+	if strings.Trim(replaced, ".") == "" {
+		return "workspace"
+	}
+	return replaced
+}

--- a/utils/agent/brief/brief.go
+++ b/utils/agent/brief/brief.go
@@ -13,6 +13,7 @@
 package brief
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -220,23 +221,41 @@ func Clear(agentDir, workspaceID string) error {
 	return err
 }
 
-// sanitize keeps a workspace id from escaping the briefs directory. Ids come
-// from a registry corgi writes, but this is a filename built from a name, and
-// that pattern is worth closing wherever it appears.
+// sanitize turns a workspace id into a filename that is safe, collision-free,
+// and case-insensitive.
+//
+// Three things it has to get right, each of which serves the wrong workspace's
+// branches to someone if it does not:
+//
+//   - It must not escape the briefs directory. Ids come from a registry corgi
+//     writes, but this builds a filename from a name, and that pattern is worth
+//     closing wherever it appears.
+//   - Distinct ids must not collapse together. Replacing unsafe runes alone
+//     maps "acme/stack" and "acme-stack" onto one file, so a short hash of the
+//     original is appended whenever the mapping actually changed anything.
+//   - It must match the registry's own comparison, which is case-insensitive
+//     (workspace.Registry.Forget uses EqualFold). Without lowercasing here,
+//     `workspaces forget ACME` drops the row and leaves briefs/acme.json behind.
 func sanitize(id string) string {
+	lower := strings.ToLower(id)
 	replaced := strings.Map(func(r rune) rune {
 		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
 			return r
-		case r == '-', r == '_', r == '.':
+		case r == '-', r == '_':
 			return r
 		default:
 			return '-'
 		}
-	}, id)
-	// A name of only dots would still resolve to a directory entry.
-	if strings.Trim(replaced, ".") == "" {
-		return "workspace"
+	}, lower)
+
+	if replaced == lower && replaced != "" {
+		return replaced
 	}
-	return replaced
+	// Something was rewritten, so the safe form is no longer unique on its own.
+	sum := sha256.Sum256([]byte(lower))
+	if replaced == "" {
+		return fmt.Sprintf("workspace-%x", sum[:4])
+	}
+	return fmt.Sprintf("%s-%x", replaced, sum[:4])
 }

--- a/utils/agent/brief/brief_test.go
+++ b/utils/agent/brief/brief_test.go
@@ -1,0 +1,311 @@
+package brief
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleRepos() []RepoState {
+	return []RepoState{
+		{Service: "web", Dir: "/s/web", Branch: "feature/referral", Dirty: true, Worktree: true},
+		{Service: "api", Dir: "/s/api", Branch: "feature/referral", Worktree: true},
+	}
+}
+
+func TestCaptureSortsReposForAStableRender(t *testing.T) {
+	// Map iteration produces these in a random order, and a note that reshuffles
+	// itself between reads is hard to trust.
+	b := Capture(Params{WorkspaceID: "acme"}, sampleRepos())
+
+	if len(b.Repos) != 2 || b.Repos[0].Service != "api" {
+		t.Fatalf("repos = %+v, want them sorted by service", b.Repos)
+	}
+}
+
+func TestCaptureDefaultsTheTimestamp(t *testing.T) {
+	b := Capture(Params{WorkspaceID: "acme"}, nil)
+
+	if b.EndedAt.IsZero() {
+		t.Error("a brief with no end time cannot be ordered against any other")
+	}
+	if b.EndedAt.Location() != time.UTC {
+		t.Error("stored time must be UTC — a brief outlives the timezone the daemon started in")
+	}
+}
+
+func TestEmptyIsTrueWhenThereIsNothingToSay(t *testing.T) {
+	// "It restarted" is already in the notification. A brief that adds nothing
+	// must say so, or every restart gains a second empty line of noise.
+	tests := []struct {
+		name  string
+		repos []RepoState
+		want  bool
+	}{
+		{"no repos", nil, true},
+		{"repos with no branch or changes", []RepoState{{Service: "api", Dir: "/s/api"}}, true},
+		{"a branch", []RepoState{{Service: "api", Branch: "main"}}, false},
+		{"uncommitted work", []RepoState{{Service: "api", Dirty: true}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Capture(Params{WorkspaceID: "acme"}, tt.repos).Empty(); got != tt.want {
+				t.Errorf("Empty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummaryNamesTheBranchAndCountsTheRest(t *testing.T) {
+	b := Capture(Params{WorkspaceID: "acme"}, sampleRepos())
+
+	got := b.Summary()
+	if !strings.Contains(got, "feature/referral") {
+		t.Errorf("summary %q must name the branch — that is the whole point of it", got)
+	}
+	if !strings.Contains(got, "1 repo has uncommitted changes") {
+		t.Errorf("summary %q must count uncommitted work", got)
+	}
+	// One branch shared by two repos is one fact, not two.
+	if strings.Count(got, "feature/referral") != 1 {
+		t.Errorf("summary %q repeats a shared branch", got)
+	}
+}
+
+func TestSummaryListsEveryDistinctBranch(t *testing.T) {
+	// A stack half-materialized onto a branch is exactly the state worth
+	// reporting, so both names have to appear.
+	b := Capture(Params{WorkspaceID: "acme"}, []RepoState{
+		{Service: "api", Branch: "feature/referral"},
+		{Service: "web", Branch: "main"},
+	})
+
+	got := b.Summary()
+	for _, want := range []string{"feature/referral", "main"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q missing branch %q", got, want)
+		}
+	}
+}
+
+func TestSummaryPluralizesTheDirtyCount(t *testing.T) {
+	b := Capture(Params{WorkspaceID: "acme"}, []RepoState{
+		{Service: "api", Branch: "main", Dirty: true},
+		{Service: "web", Branch: "main", Dirty: true},
+	})
+
+	if got := b.Summary(); !strings.Contains(got, "2 repos have uncommitted changes") {
+		t.Errorf("summary = %q, want a plural count", got)
+	}
+}
+
+func TestSummaryIsEmptyWhenTheBriefIs(t *testing.T) {
+	if got := Capture(Params{WorkspaceID: "acme"}, nil).Summary(); got != "" {
+		t.Errorf("Summary() = %q, want empty so the notification stays one line", got)
+	}
+}
+
+func TestWriteThenRead(t *testing.T) {
+	dir := t.TempDir()
+	want := Capture(Params{
+		WorkspaceID: "acme",
+		Dir:         "/dev/acme",
+		Cause:       "network-timeout",
+		Reason:      "remote control restarted",
+		Restarts:    3,
+	}, sampleRepos())
+
+	if err := Write(dir, want); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	got, err := Read(dir, "acme")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Read() = nil after a successful write")
+	}
+	if got.Cause != want.Cause || got.Restarts != 3 || len(got.Repos) != 2 {
+		t.Errorf("Read() = %+v, want the written brief back", got)
+	}
+}
+
+func TestReadMissingIsNotAnError(t *testing.T) {
+	// The ordinary case is a session that has never restarted. Treating that as
+	// an error would make every first call look like a fault.
+	got, err := Read(t.TempDir(), "acme")
+	if err != nil {
+		t.Fatalf("Read() error = %v, want nil for a workspace with no brief", err)
+	}
+	if got != nil {
+		t.Errorf("Read() = %+v, want nil", got)
+	}
+}
+
+func TestWriteReplacesTheEarlierBrief(t *testing.T) {
+	// Only the latest is a handover note; an older one is a different session's
+	// state wearing the same name.
+	dir := t.TempDir()
+	first := Capture(Params{WorkspaceID: "acme", Cause: "crash"}, sampleRepos())
+	if err := Write(dir, first); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	second := Capture(Params{WorkspaceID: "acme", Cause: "network-timeout"}, sampleRepos())
+	if err := Write(dir, second); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(dir, "acme")
+	if err != nil || got == nil {
+		t.Fatalf("Read() = %v, %v", got, err)
+	}
+	if got.Cause != "network-timeout" {
+		t.Errorf("cause = %q, want the most recent one", got.Cause)
+	}
+}
+
+func TestWriteLeavesNoTempFileBehind(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Capture(Params{WorkspaceID: "acme"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, dirName))
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("left %s behind; List would skip it but it accumulates", e.Name())
+		}
+	}
+}
+
+func TestWriteIsNotReadableByOtherUsers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Go reports 0666 for every file on Windows")
+	}
+	dir := t.TempDir()
+	if err := Write(dir, Capture(Params{WorkspaceID: "acme"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	info, err := os.Stat(Path(dir, "acme"))
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	// A brief names repository paths and branch names — more than a passer-by
+	// on a shared machine should be handed.
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("brief mode = %04o, want no group or world access", mode)
+	}
+}
+
+func TestWriteRequiresAWorkspaceID(t *testing.T) {
+	if err := Write(t.TempDir(), Brief{}); err == nil {
+		t.Fatal("a brief with no workspace has no filename and must fail")
+	}
+}
+
+func TestListIsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	older := Capture(Params{WorkspaceID: "old", EndedAt: time.Now().Add(-time.Hour)}, sampleRepos())
+	newer := Capture(Params{WorkspaceID: "new", EndedAt: time.Now()}, sampleRepos())
+	for _, b := range []Brief{older, newer} {
+		if err := Write(dir, b); err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+	}
+
+	got, err := List(dir)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 2 || got[0].WorkspaceID != "new" {
+		t.Errorf("List() = %+v, want the most recent restart first", got)
+	}
+}
+
+func TestListOnAMissingDirectoryIsEmpty(t *testing.T) {
+	got, err := List(t.TempDir())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List() = %+v, want empty", got)
+	}
+}
+
+func TestListSkipsUnreadableEntriesRatherThanFailing(t *testing.T) {
+	// One corrupt file must not hide every other workspace's note.
+	dir := t.TempDir()
+	if err := Write(dir, Capture(Params{WorkspaceID: "good"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, dirName, "broken.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	got, err := List(dir)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 1 || got[0].WorkspaceID != "good" {
+		t.Errorf("List() = %+v, want the readable brief only", got)
+	}
+}
+
+func TestClearRemovesTheNote(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Capture(Params{WorkspaceID: "acme"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := Clear(dir, "acme"); err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+
+	got, err := Read(dir, "acme")
+	if err != nil || got != nil {
+		t.Errorf("Read() = %v, %v after Clear", got, err)
+	}
+	// Clearing something already gone is what `workspaces forget` does on a
+	// workspace that never restarted.
+	if err := Clear(dir, "acme"); err != nil {
+		t.Errorf("Clear() on a missing brief = %v, want nil", err)
+	}
+}
+
+func TestPathStaysInsideTheBriefsDirectory(t *testing.T) {
+	// Ids come from a registry corgi writes, but this builds a filename from a
+	// name, and that is worth closing wherever it appears.
+	dir := t.TempDir()
+	base := filepath.Join(dir, dirName)
+
+	for _, id := range []string{"../escape", "..", "a/b", `..\escape`, "."} {
+		got := Path(dir, id)
+		if filepath.Dir(got) != base {
+			t.Errorf("Path(%q) = %q, want it inside %q", id, got, base)
+		}
+	}
+}
+
+func TestWriteAndReadAgreeOnASanitizedID(t *testing.T) {
+	// Both sides go through the same mapping, so an id needing sanitizing still
+	// round-trips rather than writing one file and reading another.
+	dir := t.TempDir()
+	const id = "acme/stack"
+	if err := Write(dir, Capture(Params{WorkspaceID: id}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(dir, id)
+	if err != nil || got == nil {
+		t.Fatalf("Read() = %v, %v", got, err)
+	}
+	if got.WorkspaceID != id {
+		t.Errorf("workspaceId = %q, want the original %q preserved in the payload", got.WorkspaceID, id)
+	}
+}

--- a/utils/agent/brief/brief_test.go
+++ b/utils/agent/brief/brief_test.go
@@ -309,3 +309,46 @@ func TestWriteAndReadAgreeOnASanitizedID(t *testing.T) {
 		t.Errorf("workspaceId = %q, want the original %q preserved in the payload", got.WorkspaceID, id)
 	}
 }
+
+func TestDistinctIDsDoNotShareAFile(t *testing.T) {
+	// Replacing unsafe runes alone maps both of these onto "acme-stack", so one
+	// workspace's brief would overwrite the other's and then be served for it.
+	dir := t.TempDir()
+	if err := Write(dir, Capture(Params{WorkspaceID: "acme/stack", Cause: "slash"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := Write(dir, Capture(Params{WorkspaceID: "acme-stack", Cause: "dash"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	slash, err := Read(dir, "acme/stack")
+	if err != nil || slash == nil {
+		t.Fatalf("Read(acme/stack) = %v, %v", slash, err)
+	}
+	if slash.Cause != "slash" {
+		t.Errorf("acme/stack got cause %q — another workspace's brief overwrote it", slash.Cause)
+	}
+	if Path(dir, "acme/stack") == Path(dir, "acme-stack") {
+		t.Error("two distinct ids resolved to the same file")
+	}
+}
+
+func TestIDsMatchCaseInsensitively(t *testing.T) {
+	// The registry compares ids with EqualFold, so `workspaces forget ACME`
+	// drops the row. If the brief keyed on case it would survive and resurface
+	// against whatever stack next took that id.
+	dir := t.TempDir()
+	if err := Write(dir, Capture(Params{WorkspaceID: "acme"}, sampleRepos())); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	if got, _ := Read(dir, "ACME"); got == nil {
+		t.Error("Read is case-sensitive but the registry is not")
+	}
+	if err := Clear(dir, "ACME"); err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+	if got, _ := Read(dir, "acme"); got != nil {
+		t.Error("Clear with different casing left the brief behind")
+	}
+}

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -51,13 +51,24 @@ type UserConfig struct {
 
 // WorkspaceConfig is everything that grants capability. Trusted sources only.
 type WorkspaceConfig struct {
-	Autostart      *bool  `yaml:"autostart"`
-	Bin            string `yaml:"bin"`
-	Spawn          string `yaml:"spawn"`
-	Capacity       int    `yaml:"capacity"`
-	PermissionMode string `yaml:"permissionMode"`
-	ConfigDir      string `yaml:"configDir"`
-	WakeLock       string `yaml:"wakeLock"`
+	Autostart *bool `yaml:"autostart"`
+	// Kind selects which agent CLI to supervise. Empty keeps the default, so a
+	// config written before this existed behaves exactly as it did.
+	Kind string `yaml:"kind"`
+	Bin  string `yaml:"bin"`
+	// Args is the argv for kind: custom, after the binary name.
+	//
+	// Trusted config only, like everything else here — an argv is a choice of
+	// what code runs, so a committed repo file must never reach it.
+	Args []string `yaml:"args"`
+	// ConfigDirEnv and CredentialEnv describe a custom kind's environment.
+	ConfigDirEnv   string   `yaml:"configDirEnv"`
+	CredentialEnv  []string `yaml:"credentialEnv"`
+	Spawn          string   `yaml:"spawn"`
+	Capacity       int      `yaml:"capacity"`
+	PermissionMode string   `yaml:"permissionMode"`
+	ConfigDir      string   `yaml:"configDir"`
+	WakeLock       string   `yaml:"wakeLock"`
 	// InheritAPIKey lets this workspace keep an ambient ANTHROPIC_API_KEY.
 	// Off unless the machine's owner asks for it: remote control refuses to
 	// run with one set, and an inherited key bills the API instead of a
@@ -168,8 +179,23 @@ func overlay(base, over WorkspaceConfig) WorkspaceConfig {
 	if over.Autostart != nil {
 		base.Autostart = over.Autostart
 	}
+	if over.Kind != "" {
+		base.Kind = over.Kind
+	}
 	if over.Bin != "" {
 		base.Bin = over.Bin
+	}
+	// Replaced wholesale rather than appended: an argv is one command, and
+	// concatenating a default's flags onto a workspace's own would produce a
+	// command line neither file asked for.
+	if len(over.Args) > 0 {
+		base.Args = over.Args
+	}
+	if over.ConfigDirEnv != "" {
+		base.ConfigDirEnv = over.ConfigDirEnv
+	}
+	if len(over.CredentialEnv) > 0 {
+		base.CredentialEnv = over.CredentialEnv
 	}
 	if over.Spawn != "" {
 		base.Spawn = over.Spawn

--- a/utils/agent/config/config_test.go
+++ b/utils/agent/config/config_test.go
@@ -242,3 +242,66 @@ func contains(haystack, needle string) bool {
 	}
 	return false
 }
+
+func TestKindAndArgsComeOnlyFromTrustedConfig(t *testing.T) {
+	// An argv is a choice of what code the daemon runs. The committed repo file
+	// travels with a clone and was written by whoever wrote the repository, so
+	// there is deliberately no field on RepoConfig that could reach it.
+	repo := &RepoConfig{Version: 1}
+	repo.Workspace.ID = "acme"
+
+	user := &UserConfig{Workspaces: map[string]WorkspaceConfig{
+		"acme": {Kind: "custom", Bin: "some-agent", Args: []string{"serve"}},
+	}}
+
+	got := Resolve("acme", repo, user)
+
+	if got.Kind != "custom" || got.Bin != "some-agent" {
+		t.Errorf("resolved = %+v, want the trusted kind and bin", got.WorkspaceConfig)
+	}
+	if len(got.Args) != 1 || got.Args[0] != "serve" {
+		t.Errorf("args = %v, want the trusted argv", got.Args)
+	}
+}
+
+func TestWorkspaceArgsReplaceDefaultsRatherThanAppend(t *testing.T) {
+	// Concatenating would produce a command line neither file asked for.
+	user := &UserConfig{
+		Defaults:   WorkspaceConfig{Kind: "custom", Args: []string{"default", "--flag"}},
+		Workspaces: map[string]WorkspaceConfig{"acme": {Args: []string{"specific"}}},
+	}
+
+	got := Resolve("acme", nil, user)
+
+	if len(got.Args) != 1 || got.Args[0] != "specific" {
+		t.Errorf("args = %v, want only the workspace's own", got.Args)
+	}
+	// The kind still falls through from defaults.
+	if got.Kind != "custom" {
+		t.Errorf("kind = %q, want it inherited from defaults", got.Kind)
+	}
+}
+
+func TestEmptyKindKeepsExistingConfigsWorking(t *testing.T) {
+	// Every config written before kinds existed has no kind: field. It must
+	// resolve to empty here and be defaulted downstream, not to some literal
+	// that a later rename could break.
+	user := &UserConfig{Workspaces: map[string]WorkspaceConfig{"acme": {Bin: "claude"}}}
+
+	if got := Resolve("acme", nil, user); got.Kind != "" {
+		t.Errorf("kind = %q, want empty for a config that never set one", got.Kind)
+	}
+}
+
+func TestCredentialEnvOverlays(t *testing.T) {
+	user := &UserConfig{
+		Defaults:   WorkspaceConfig{CredentialEnv: []string{"DEFAULT_KEY"}},
+		Workspaces: map[string]WorkspaceConfig{"acme": {CredentialEnv: []string{"ACME_KEY"}}},
+	}
+
+	got := Resolve("acme", nil, user)
+
+	if len(got.CredentialEnv) != 1 || got.CredentialEnv[0] != "ACME_KEY" {
+		t.Errorf("credentialEnv = %v, want the workspace's own list", got.CredentialEnv)
+	}
+}

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -244,14 +244,16 @@ func (d *Daemon) sessionEndHook(cfg supervisor.SpawnConfig, r *supervisor.Runner
 			Reason:      dec.Reason,
 			Restarts:    r.State().Restarts,
 		})
-		if b == nil || b.Empty() {
+		if b == nil {
 			return ""
 		}
-		if err := brief.Write(d.Dir, *b); err != nil {
-			// Losing the note is not worth failing a restart over, and the
-			// summary is still useful in the notification.
-			return b.Summary()
-		}
+		// Written even when Empty: the cause and reason always apply, and
+		// skipping the write would make `corgi agent brief <id>` report "it has
+		// not restarted" about a workspace that just did. Empty only decides
+		// whether there is a summary line worth adding to the notification.
+		//
+		// A failed write is not worth failing a restart over.
+		_ = brief.Write(d.Dir, *b)
 		return b.Summary()
 	}
 }

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -69,6 +69,12 @@ type Daemon struct {
 	// enumerating a stack's repositories means parsing a compose file, which the
 	// daemon has no business knowing about. Nil disables briefs entirely.
 	CaptureBrief func(brief.Params) *brief.Brief
+	// publishStopped is called as the status publisher exits.
+	//
+	// A test seam. Whether Run waits for that goroutine is otherwise observable
+	// only as a race — the publisher writing into a directory Run has finished
+	// with — which a test can lose a hundred times before catching once.
+	publishStopped func()
 
 	mu      sync.Mutex
 	runners []*supervisor.Runner
@@ -117,6 +123,9 @@ func (d *Daemon) requestPublish() {
 // state change, with a slow tick as a safety net for anything that changes
 // without notifying (the wake lock, for instance).
 func (d *Daemon) publishStatus(ctx context.Context) {
+	if d.publishStopped != nil {
+		defer d.publishStopped()
+	}
 	ticker := time.NewTicker(statusPublishInterval)
 	defer ticker.Stop()
 	for {
@@ -177,9 +186,22 @@ func (d *Daemon) Run(ctx context.Context, configs []supervisor.SpawnConfig) erro
 	}
 	defer d.cleanup()
 
+	// The publisher is awaited, not just cancelled. Without the wait, Run could
+	// return — and its deferred cleanup could delete status.json — while the
+	// publisher was still mid-write, which both resurrects the file corgi just
+	// removed and races anything clearing the directory behind it. Registered
+	// after the cleanup defer so it runs first: stop publishing, wait, then
+	// remove.
 	publishCtx, stopPublishing := context.WithCancel(ctx)
-	defer stopPublishing()
-	go d.publishStatus(publishCtx)
+	publishDone := make(chan struct{})
+	go func() {
+		defer close(publishDone)
+		d.publishStatus(publishCtx)
+	}()
+	defer func() {
+		stopPublishing()
+		<-publishDone
+	}()
 
 	var wg sync.WaitGroup
 	for _, r := range d.Runners() {

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/brief"
 	"andriiklymiuk/corgi/utils/agent/supervisor"
 )
 
@@ -47,6 +48,7 @@ type Status struct {
 type WorkspaceDiagnostic struct {
 	WorkspaceID string   `json:"workspaceId"`
 	Dir         string   `json:"dir"`
+	Kind        string   `json:"kind,omitempty"`
 	Bin         string   `json:"bin"`
 	ConfigDir   string   `json:"configDir"`
 	Spawn       string   `json:"spawn"`
@@ -63,6 +65,10 @@ type Daemon struct {
 	Start supervisor.Starter
 	// Notify reports restarts. Defaults to corgi's desktop notification.
 	Notify func(title, body string)
+	// CaptureBrief probes what an ending session left on disk. Injected because
+	// enumerating a stack's repositories means parsing a compose file, which the
+	// daemon has no business knowing about. Nil disables briefs entirely.
+	CaptureBrief func(brief.Params) *brief.Brief
 
 	mu      sync.Mutex
 	runners []*supervisor.Runner
@@ -214,8 +220,39 @@ func (d *Daemon) buildRunners(configs []supervisor.SpawnConfig) {
 		r := supervisor.NewRunner(cfg, d.Start, lock)
 		r.Notify = d.Notify
 		r.OnChange = d.requestPublish
+		r.OnSessionEnd = d.sessionEndHook(cfg, r)
 		d.runners = append(d.runners, r)
 		d.diags = append(d.diags, diagnose(cfg, env))
+	}
+}
+
+// sessionEndHook writes the handover brief for one workspace.
+//
+// A relaunched session is a NEW session with none of the previous one's
+// context. corgi cannot restore the conversation, but the branches and
+// uncommitted work it left on disk are still there, and saying so is the
+// difference between a restart costing an hour and costing nothing.
+func (d *Daemon) sessionEndHook(cfg supervisor.SpawnConfig, r *supervisor.Runner) func(supervisor.Decision) string {
+	if d.CaptureBrief == nil {
+		return nil
+	}
+	return func(dec supervisor.Decision) string {
+		b := d.CaptureBrief(brief.Params{
+			WorkspaceID: cfg.WorkspaceID,
+			Dir:         cfg.Dir,
+			Cause:       string(dec.Cause),
+			Reason:      dec.Reason,
+			Restarts:    r.State().Restarts,
+		})
+		if b == nil || b.Empty() {
+			return ""
+		}
+		if err := brief.Write(d.Dir, *b); err != nil {
+			// Losing the note is not worth failing a restart over, and the
+			// summary is still useful in the notification.
+			return b.Summary()
+		}
+		return b.Summary()
 	}
 }
 
@@ -252,10 +289,15 @@ func (d *Daemon) Status() Status {
 // be used. An ambient ANTHROPIC_API_KEY is called out explicitly: remote
 // control refuses to run with one set, and it silently bills the API.
 func diagnose(cfg supervisor.SpawnConfig, env []string) WorkspaceDiagnostic {
-	bin, _ := supervisor.SanitizeBin(cfg.Bin)
+	bin, _ := supervisor.ResolveBin(cfg)
+	kind := cfg.Kind
+	if kind == "" {
+		kind = supervisor.DefaultKind
+	}
 	d := WorkspaceDiagnostic{
 		WorkspaceID: cfg.WorkspaceID,
 		Dir:         cfg.Dir,
+		Kind:        kind,
 		Bin:         bin,
 		ConfigDir:   cfg.ConfigDir,
 		Spawn:       cfg.Spawn,

--- a/utils/agent/daemon/daemon_test.go
+++ b/utils/agent/daemon/daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -358,5 +359,35 @@ func TestDaemonWithoutABriefProbeStillRuns(t *testing.T) {
 	}
 	if b, _ := brief.Read(d.Dir, "acme"); b != nil {
 		t.Error("a nil probe must write no brief at all")
+	}
+}
+
+func TestRunWaitsForTheStatusPublisherBeforeReturning(t *testing.T) {
+	// Run's contract is "nothing of mine is still up". The status publisher runs
+	// in its own goroutine, so without an explicit wait Run can return — and its
+	// deferred cleanup delete status.json — while the publisher is still
+	// mid-write, resurrecting the file and racing anything clearing the
+	// directory behind it. Under `go test -race` that surfaced in CI as a
+	// TempDir cleanup failure in whichever test happened to run next.
+	//
+	// The delay makes the ordering deterministic: without the wait Run returns
+	// long before the publisher is finished.
+	d := testDaemon(t)
+	var publisherFinished atomic.Bool
+	d.publishStopped = func() {
+		time.Sleep(50 * time.Millisecond)
+		publisherFinished.Store(true)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = d.Run(ctx, []supervisor.SpawnConfig{cfg("acme", "/tmp")}) }()
+	waitFor(t, func() bool { return len(d.Status().Workspaces) == 1 })
+
+	cancel()
+	<-done
+
+	if !publisherFinished.Load() {
+		t.Error("Run returned while the status publisher was still going; its cleanup can now race the publisher's next write")
 	}
 }

--- a/utils/agent/daemon/daemon_test.go
+++ b/utils/agent/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"andriiklymiuk/corgi/utils/agent/brief"
 	"andriiklymiuk/corgi/utils/agent/supervisor"
 )
 
@@ -272,5 +274,89 @@ func TestReadInfoRejectsARecycledPid(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, "daemon.json")); !os.IsNotExist(statErr) {
 		t.Error("the stale record should be cleaned up")
+	}
+}
+
+// exitingStarter hands out processes that exit cleanly after a moment, which
+// the supervisor classifies as the documented network timeout and restarts.
+func exitingStarter() supervisor.Starter {
+	var n int
+	var mu sync.Mutex
+	return func(ctx context.Context, _ supervisor.SpawnConfig) (supervisor.Process, error) {
+		mu.Lock()
+		n++
+		p := &blockingProcess{pid: 2000 + n, stopped: make(chan struct{})}
+		mu.Unlock()
+		go func() {
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-ctx.Done():
+			}
+			p.Stop()
+		}()
+		return p, nil
+	}
+}
+
+func TestDaemonWritesABriefWhenASessionIsReplaced(t *testing.T) {
+	// The whole point of the feature: a restarted session is a NEW session, and
+	// what the old one left on disk has to be recorded while it is still there.
+	d := testDaemon(t)
+	d.Start = exitingStarter()
+
+	d.CaptureBrief = func(p brief.Params) *brief.Brief {
+		b := brief.Capture(p, []brief.RepoState{
+			{Service: "api", Branch: "feature/referral", Dirty: true},
+		})
+		return &b
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = d.Run(ctx, []supervisor.SpawnConfig{cfg("acme", t.TempDir())}) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, _ := brief.Read(d.Dir, "acme"); b != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	got, err := brief.Read(d.Dir, "acme")
+	if err != nil {
+		t.Fatalf("brief.Read() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("no brief written after a restart — the handover note is the feature")
+	}
+	if got.Cause == "" {
+		t.Error("brief must carry the exit cause, so it explains why this is a new session")
+	}
+	if len(got.Repos) != 1 || got.Repos[0].Branch != "feature/referral" {
+		t.Errorf("brief repos = %+v, want the probed state", got.Repos)
+	}
+	// Whether the summary reaches the notification is the supervisor's job and
+	// is asserted there, where a healthy run can be simulated without waiting
+	// out MinHealthyUptime.
+}
+
+func TestDaemonWithoutABriefProbeStillRuns(t *testing.T) {
+	// CaptureBrief is injected, and a nil one must disable the feature rather
+	// than take the daemon down on the first restart.
+	d := testDaemon(t)
+	d.Start = exitingStarter()
+	d.CaptureBrief = nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	if err := d.Run(ctx, []supervisor.SpawnConfig{cfg("acme", t.TempDir())}); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Run() = %v", err)
+	}
+	if b, _ := brief.Read(d.Dir, "acme"); b != nil {
+		t.Error("a nil probe must write no brief at all")
 	}
 }

--- a/utils/agent/supervisor/exec.go
+++ b/utils/agent/supervisor/exec.go
@@ -38,7 +38,7 @@ func StartProcess(ctx context.Context, cfg SpawnConfig) (Process, error) {
 		return nil, err
 	}
 
-	bin, err := SanitizeBin(cfg.Bin)
+	bin, err := ResolveBin(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,12 @@ func StartProcess(ctx context.Context, cfg SpawnConfig) (Process, error) {
 		return nil, fmt.Errorf("%s not found on PATH: %w", bin, err)
 	}
 
-	cmd := exec.Command(resolved, BuildArgs(cfg)...)
+	args, err := BuildArgs(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(resolved, args...)
 	cmd.Dir = cfg.Dir
 	cmd.Env = BuildEnv(cfg, os.Environ())
 	// Own process group so Stop can take down anything remote control spawned,

--- a/utils/agent/supervisor/exec_test.go
+++ b/utils/agent/supervisor/exec_test.go
@@ -50,7 +50,9 @@ func TestSanitizeBin(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"", "claude", false},
+		// Empty stays empty here; ResolveBin fills it from the kind, so the
+		// default lives in one place rather than two.
+		{"", "", false},
 		{"claude", "claude", false},
 		{"  claude  ", "claude", false},
 		{"claude-alt", "claude-alt", false},

--- a/utils/agent/supervisor/kind.go
+++ b/utils/agent/supervisor/kind.go
@@ -39,6 +39,14 @@ type Kind struct {
 	// silent no-op.
 	SupportsSpawn          bool
 	SupportsPermissionMode bool
+	// BuildsArgvFromSettings is true for a kind that assembles its own command
+	// line out of the typed settings (spawn, capacity, permissionMode, name),
+	// and false for one handed a complete argv.
+	//
+	// It decides which half of the config is meaningful, so the other half can
+	// be rejected rather than silently dropped: a `capacity: 4` that quietly
+	// does nothing reads as a configured limit that is not being applied.
+	BuildsArgvFromSettings bool
 }
 
 // Kind names. KindCustom launches an argv the machine's owner wrote out in
@@ -66,6 +74,7 @@ var kinds = map[string]Kind{
 		Args:                   claudeArgs,
 		SupportsSpawn:          true,
 		SupportsPermissionMode: true,
+		BuildsArgvFromSettings: true,
 	},
 	KindCustom: {
 		Name: KindCustom,
@@ -79,6 +88,7 @@ var kinds = map[string]Kind{
 		// invent them. Put them in `args:` instead.
 		SupportsSpawn:          false,
 		SupportsPermissionMode: false,
+		BuildsArgvFromSettings: false,
 	},
 }
 

--- a/utils/agent/supervisor/kind.go
+++ b/utils/agent/supervisor/kind.go
@@ -172,10 +172,10 @@ var forbiddenArgPrefixes = []string{
 }
 
 func checkArg(a string) error {
-	flag := strings.ToLower(strings.TrimSpace(a))
-	// Compare against the flag alone: --flag=value must be caught too.
-	if name, _, ok := strings.Cut(flag, "="); ok {
-		flag = name
+	whole := normalize(a)
+	flag, value, hasValue := strings.Cut(whole, "=")
+	if !hasValue {
+		flag = whole
 	}
 	for _, prefix := range forbiddenArgPrefixes {
 		if strings.HasPrefix(flag, prefix) {
@@ -183,6 +183,16 @@ func checkArg(a string) error {
 				"arg %q is not allowed for a supervised session — "+
 					"permission prompts are what you answer from your phone", a)
 		}
+	}
+	// A forbidden permission mode can also arrive as a plain value, either as
+	// its own arg after the flag or as --permission-mode=bypassPermissions.
+	// Without this, `kind: custom, bin: claude, args: [remote-control,
+	// --permission-mode, bypassPermissions]` walks straight around the
+	// rejection that ValidateSpawnConfig applies to the typed setting.
+	if forbiddenPermissionModes[whole] || (hasValue && forbiddenPermissionModes[value]) {
+		return fmt.Errorf(
+			"arg %q is not allowed for a supervised session — "+
+				"permission prompts are what you answer from your phone", a)
 	}
 	return nil
 }

--- a/utils/agent/supervisor/kind.go
+++ b/utils/agent/supervisor/kind.go
@@ -1,0 +1,178 @@
+package supervisor
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// A Kind is one agent CLI the supervisor knows how to keep alive.
+//
+// Everything the supervisor actually does — restart after the ways a session
+// dies, hold a wake lock, scope credentials and config directory per workspace
+// — is identical whichever agent is running. Only the launch details differ, so
+// they live here and the rest of the package never asks which agent it has.
+//
+// Adding one is a map entry. Deliberately not exported as a registration hook:
+// a kind decides the argv of a process the daemon runs unattended, so the set
+// is fixed at compile time rather than being something config can extend.
+type Kind struct {
+	// Name is what `kind:` in the trusted user config selects.
+	Name string
+	// DefaultBin is the command looked up on PATH when no `bin:` is set.
+	DefaultBin string
+	// ConfigDirEnv points the CLI at a per-workspace config directory, which is
+	// how one machine runs two accounts. Empty when the CLI has no such
+	// variable, in which case a workspace's configDir is rejected at validation
+	// rather than silently having no effect — a session running under the wrong
+	// account looks exactly like one running under the right one.
+	ConfigDirEnv string
+	// CredentialEnv are ambient credentials stripped from the child unless the
+	// workspace opts in. An inherited key routes work to another account with no
+	// visible error, so removing them is the default.
+	CredentialEnv []string
+	// Args builds argv after the binary name.
+	Args func(SpawnConfig) ([]string, error)
+	// SupportsSpawn and SupportsPermissionMode say whether this CLI understands
+	// those settings. A setting that cannot take effect is an error, not a
+	// silent no-op.
+	SupportsSpawn          bool
+	SupportsPermissionMode bool
+}
+
+// Kind names. KindCustom launches an argv the machine's owner wrote out in
+// full, which is how an agent corgi has no built-in entry for is supervised
+// without corgi guessing at flags it cannot verify.
+const (
+	KindClaude = "claude"
+	KindCustom = "custom"
+)
+
+// DefaultKind is what a workspace with no `kind:` gets, so every existing
+// config keeps its current behaviour.
+const DefaultKind = KindClaude
+
+var kinds = map[string]Kind{
+	KindClaude: {
+		Name:         KindClaude,
+		DefaultBin:   "claude",
+		ConfigDirEnv: "CLAUDE_CONFIG_DIR",
+		CredentialEnv: []string{
+			"ANTHROPIC_API_KEY",
+			"ANTHROPIC_AUTH_TOKEN",
+			"CLAUDE_CODE_OAUTH_TOKEN",
+		},
+		Args:                   claudeArgs,
+		SupportsSpawn:          true,
+		SupportsPermissionMode: true,
+	},
+	KindCustom: {
+		Name: KindCustom,
+		// No default: a custom kind must name its binary, because there is
+		// nothing sensible to fall back to.
+		DefaultBin: "",
+		// Both are configurable per workspace — see SpawnConfig.ConfigDirEnv
+		// and CredentialEnv, which KindFor folds in.
+		Args: customArgs,
+		// The supervisor cannot know this CLI's flag names, so it refuses to
+		// invent them. Put them in `args:` instead.
+		SupportsSpawn:          false,
+		SupportsPermissionMode: false,
+	},
+}
+
+// KindFor resolves a workspace's kind, folding in the per-workspace overrides
+// that only a custom kind may set.
+func KindFor(c SpawnConfig) (Kind, error) {
+	name := strings.ToLower(strings.TrimSpace(c.Kind))
+	if name == "" {
+		name = DefaultKind
+	}
+	k, ok := kinds[name]
+	if !ok {
+		return Kind{}, fmt.Errorf("unknown kind %q (want %s)", c.Kind, strings.Join(KindNames(), ", "))
+	}
+	if k.Name != KindCustom {
+		return k, nil
+	}
+	// Only a custom kind takes these from config: for a built-in, the variable
+	// names are a property of the CLI, not a choice.
+	if env := strings.TrimSpace(c.ConfigDirEnv); env != "" {
+		k.ConfigDirEnv = env
+	}
+	if len(c.CredentialEnv) > 0 {
+		k.CredentialEnv = append([]string(nil), c.CredentialEnv...)
+	}
+	return k, nil
+}
+
+// KindNames lists the registered kinds for help text and error messages.
+func KindNames() []string {
+	out := make([]string, 0, len(kinds))
+	for name := range kinds {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// claudeArgs builds `claude remote-control ...`.
+func claudeArgs(c SpawnConfig) ([]string, error) {
+	args := []string{"remote-control"}
+	if s := strings.ToLower(strings.TrimSpace(c.Spawn)); s != "" {
+		args = append(args, "--spawn", s)
+	}
+	if c.Capacity > 0 {
+		args = append(args, "--capacity", strconv.Itoa(c.Capacity))
+	}
+	if mode := strings.TrimSpace(c.PermissionMode); mode != "" && !forbiddenPermissionModes[normalize(mode)] {
+		args = append(args, "--permission-mode", mode)
+	}
+	if name := strings.TrimSpace(c.Name); name != "" {
+		args = append(args, "--name", name)
+	}
+	return args, nil
+}
+
+// customArgs returns the argv the machine's owner wrote, after checking it does
+// not disarm the permission prompts.
+func customArgs(c SpawnConfig) ([]string, error) {
+	if len(c.Args) == 0 {
+		return nil, fmt.Errorf("kind %q requires args: the argv to run after the binary name", KindCustom)
+	}
+	for _, a := range c.Args {
+		if err := checkArg(a); err != nil {
+			return nil, err
+		}
+	}
+	return append([]string(nil), c.Args...), nil
+}
+
+// forbiddenArgPrefixes never reach a supervised process, whoever wrote them.
+//
+// The permission prompts are what a person answers from their phone, and they
+// are the main defence against a session acting on instructions it read out of
+// a repository. A daemon running unattended must not be able to skip them —
+// which is the same rule that rejects permissionMode: bypassPermissions,
+// applied to the one place a custom kind could otherwise route around it.
+var forbiddenArgPrefixes = []string{
+	"--dangerously",
+	"--yolo",
+}
+
+func checkArg(a string) error {
+	flag := strings.ToLower(strings.TrimSpace(a))
+	// Compare against the flag alone: --flag=value must be caught too.
+	if name, _, ok := strings.Cut(flag, "="); ok {
+		flag = name
+	}
+	for _, prefix := range forbiddenArgPrefixes {
+		if strings.HasPrefix(flag, prefix) {
+			return fmt.Errorf(
+				"arg %q is not allowed for a supervised session — "+
+					"permission prompts are what you answer from your phone", a)
+		}
+	}
+	return nil
+}

--- a/utils/agent/supervisor/kind_test.go
+++ b/utils/agent/supervisor/kind_test.go
@@ -1,0 +1,260 @@
+package supervisor
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func customConfig() SpawnConfig {
+	return SpawnConfig{
+		WorkspaceID: "acme",
+		Dir:         "/tmp/acme",
+		Kind:        KindCustom,
+		Bin:         "some-agent",
+		Args:        []string{"serve", "--headless"},
+	}
+}
+
+func TestDefaultKindIsUnchangedBehaviour(t *testing.T) {
+	// A config written before kinds existed must launch exactly as it did, or
+	// upgrading corgi silently changes what every supervised workspace runs.
+	c := baseConfig()
+	c.Kind = ""
+
+	kind, err := KindFor(c)
+	if err != nil {
+		t.Fatalf("KindFor() error = %v", err)
+	}
+	if kind.Name != KindClaude {
+		t.Fatalf("empty kind resolved to %q, want %q", kind.Name, KindClaude)
+	}
+
+	bin, err := ResolveBin(c)
+	if err != nil {
+		t.Fatalf("ResolveBin() error = %v", err)
+	}
+	if bin != "claude" {
+		t.Errorf("ResolveBin() = %q, want claude", bin)
+	}
+
+	args, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
+	if len(args) == 0 || args[0] != "remote-control" {
+		t.Errorf("argv = %v, want it to start with remote-control", args)
+	}
+}
+
+func TestUnknownKindIsRejectedWithTheValidNames(t *testing.T) {
+	c := baseConfig()
+	c.Kind = "nonesuch"
+
+	err := ValidateSpawnConfig(c)
+	if err == nil {
+		t.Fatal("an unknown kind must fail at startup, not launch something unexpected")
+	}
+	// The message has to name the alternatives: this fails inside a daemon,
+	// where nobody is watching a terminal to go and look them up.
+	for _, name := range KindNames() {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error %q does not mention valid kind %q", err, name)
+		}
+	}
+}
+
+func TestCustomKindRunsTheConfiguredArgv(t *testing.T) {
+	c := customConfig()
+
+	if err := ValidateSpawnConfig(c); err != nil {
+		t.Fatalf("ValidateSpawnConfig() error = %v", err)
+	}
+	bin, err := ResolveBin(c)
+	if err != nil {
+		t.Fatalf("ResolveBin() error = %v", err)
+	}
+	if bin != "some-agent" {
+		t.Errorf("ResolveBin() = %q, want some-agent", bin)
+	}
+	args, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
+	if !slices.Equal(args, []string{"serve", "--headless"}) {
+		t.Errorf("argv = %v, want the configured args verbatim", args)
+	}
+}
+
+func TestCustomKindArgvIsCopiedNotAliased(t *testing.T) {
+	// The returned slice reaches exec.Command. Sharing the backing array with
+	// config would let one launch's mutation change the next one's argv.
+	c := customConfig()
+	args, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
+	args[0] = "mutated"
+
+	again, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
+	if again[0] != "serve" {
+		t.Errorf("argv[0] = %q after mutating a previous result, want serve", again[0])
+	}
+}
+
+func TestCustomKindWithoutArgsIsRejected(t *testing.T) {
+	c := customConfig()
+	c.Args = nil
+
+	if err := ValidateSpawnConfig(c); err == nil {
+		t.Fatal("kind custom with no args has nothing to run and must fail at startup")
+	}
+}
+
+func TestCustomKindWithoutBinIsRejected(t *testing.T) {
+	// There is no sensible default command for an agent corgi knows nothing
+	// about, so the failure has to be explicit rather than a PATH lookup for "".
+	c := customConfig()
+	c.Bin = ""
+
+	if err := ValidateSpawnConfig(c); err == nil {
+		t.Fatal("kind custom with no bin must fail at startup")
+	}
+}
+
+func TestCustomArgsCannotDisarmPermissionPrompts(t *testing.T) {
+	// This is the one route around the bypassPermissions rejection: a custom
+	// argv is written by hand, so the same rule has to apply to it.
+	for _, arg := range []string{
+		"--dangerously-skip-permissions",
+		"--DANGEROUSLY-SKIP-PERMISSIONS",
+		"--dangerously-skip-permissions=true",
+		"--yolo",
+	} {
+		c := customConfig()
+		c.Args = []string{"serve", arg}
+
+		if err := ValidateSpawnConfig(c); err == nil {
+			t.Errorf("arg %q must be rejected — permission prompts are the defence a phone answers", arg)
+		}
+	}
+}
+
+func TestCustomKindUsesItsOwnConfigDirVariable(t *testing.T) {
+	c := customConfig()
+	c.ConfigDirEnv = "SOME_AGENT_HOME"
+	c.ConfigDir = "/home/u/.some-agent-work"
+
+	if err := ValidateSpawnConfig(c); err != nil {
+		t.Fatalf("ValidateSpawnConfig() error = %v", err)
+	}
+	env := BuildEnv(c, []string{"PATH=/usr/bin", "CLAUDE_CONFIG_DIR=/home/u/.claude"})
+
+	if !slices.Contains(env, "SOME_AGENT_HOME=/home/u/.some-agent-work") {
+		t.Errorf("env = %v, want the custom kind's config-dir variable set", env)
+	}
+	// Another agent's variable is not this kind's business and must survive.
+	if !slices.Contains(env, "CLAUDE_CONFIG_DIR=/home/u/.claude") {
+		t.Errorf("env = %v, want an unrelated agent's variable left alone", env)
+	}
+}
+
+func TestConfigDirWithNoVariableToSetIsRejected(t *testing.T) {
+	// Silently ignoring it would leave the workspace running under the default
+	// account, which looks exactly like running under the right one.
+	c := customConfig()
+	c.ConfigDir = "/home/u/.some-agent-work"
+
+	err := ValidateSpawnConfig(c)
+	if err == nil {
+		t.Fatal("configDir with no configDirEnv must fail rather than be ignored")
+	}
+	if !strings.Contains(err.Error(), "configDirEnv") {
+		t.Errorf("error %q should name the setting that fixes it", err)
+	}
+}
+
+func TestCustomKindStripsItsOwnCredentials(t *testing.T) {
+	c := customConfig()
+	c.CredentialEnv = []string{"SOME_AGENT_API_KEY", "SOME_AGENT_OAUTH_TOKEN"}
+
+	if err := ValidateSpawnConfig(c); err != nil {
+		t.Fatalf("ValidateSpawnConfig() error = %v", err)
+	}
+	parent := []string{
+		"PATH=/usr/bin",
+		"SOME_AGENT_API_KEY=sk-live",
+		"SOME_AGENT_OAUTH_TOKEN=oauth",
+	}
+
+	env := BuildEnv(c, parent)
+	for _, unwanted := range []string{"SOME_AGENT_API_KEY=sk-live", "SOME_AGENT_OAUTH_TOKEN=oauth"} {
+		if slices.Contains(env, unwanted) {
+			t.Errorf("env still carries %q — an inherited credential bills the wrong account", unwanted)
+		}
+	}
+
+	got := StrippedCredentials(c, parent)
+	want := []string{"SOME_AGENT_API_KEY", "SOME_AGENT_OAUTH_TOKEN"}
+	if !slices.Equal(got, want) {
+		t.Errorf("StrippedCredentials() = %v, want %v — status output explains the account from this", got, want)
+	}
+}
+
+func TestCustomKindCredentialOptInsAreSeparate(t *testing.T) {
+	// The two failures differ: a key bills the wrong meter, a token points at
+	// another account. Opting in to one must not quietly opt in to the other.
+	c := customConfig()
+	c.CredentialEnv = []string{"SOME_AGENT_API_KEY", "SOME_AGENT_OAUTH_TOKEN"}
+	c.InheritAPIKey = true
+
+	env := BuildEnv(c, []string{"SOME_AGENT_API_KEY=sk-live", "SOME_AGENT_OAUTH_TOKEN=oauth"})
+
+	if !slices.Contains(env, "SOME_AGENT_API_KEY=sk-live") {
+		t.Error("inheritApiKey must keep the API key")
+	}
+	if slices.Contains(env, "SOME_AGENT_OAUTH_TOKEN=oauth") {
+		t.Error("inheritApiKey must not also keep the OAuth token")
+	}
+}
+
+func TestBuiltInKindRejectsEnvironmentOverrides(t *testing.T) {
+	// For a built-in, these variable names are a property of the CLI. Letting
+	// config change them would mean a workspace could point the strip list at
+	// nothing and hand the child every ambient credential.
+	c := baseConfig()
+	c.CredentialEnv = []string{"NOTHING_AT_ALL"}
+
+	if err := ValidateSpawnConfig(c); err == nil {
+		t.Fatal("credentialEnv on a built-in kind must be rejected")
+	}
+}
+
+func TestKindWithoutSpawnSupportRejectsSpawnAndPermissionMode(t *testing.T) {
+	// Dropping an unsupported setting silently would leave someone believing a
+	// session is isolated, or prompting, when it is neither.
+	for name, mutate := range map[string]func(*SpawnConfig){
+		"spawn":          func(c *SpawnConfig) { c.Spawn = "worktree" },
+		"permissionMode": func(c *SpawnConfig) { c.PermissionMode = "default" },
+	} {
+		c := customConfig()
+		mutate(&c)
+		if err := ValidateSpawnConfig(c); err == nil {
+			t.Errorf("%s on kind custom must be rejected, not ignored", name)
+		}
+	}
+}
+
+func TestUnknownKindProducesNoEnvironmentAtAll(t *testing.T) {
+	// BuildEnv cannot report an error, and returning the parent unchanged would
+	// hand a child every ambient credential. Empty fails loudly instead.
+	c := baseConfig()
+	c.Kind = "nonesuch"
+
+	if env := BuildEnv(c, []string{"ANTHROPIC_API_KEY=sk-live", "PATH=/usr/bin"}); len(env) != 0 {
+		t.Errorf("BuildEnv() = %v, want empty for an unresolvable kind", env)
+	}
+}

--- a/utils/agent/supervisor/kind_test.go
+++ b/utils/agent/supervisor/kind_test.go
@@ -258,3 +258,45 @@ func TestUnknownKindProducesNoEnvironmentAtAll(t *testing.T) {
 		t.Errorf("BuildEnv() = %v, want empty for an unresolvable kind", env)
 	}
 }
+
+func TestBuildEnvNeverReturnsNil(t *testing.T) {
+	// exec.Cmd treats a nil Env as "inherit the entire parent environment", so
+	// returning nil from the unresolvable-kind path would turn the fail-safe
+	// into total credential inheritance — the exact opposite of its purpose.
+	c := baseConfig()
+	c.Kind = "nonesuch"
+
+	env := BuildEnv(c, []string{"ANTHROPIC_API_KEY=sk-live", "PATH=/usr/bin"})
+
+	if env == nil {
+		t.Fatal("BuildEnv() = nil; a nil Env makes os/exec inherit everything")
+	}
+	if len(env) != 0 {
+		t.Errorf("BuildEnv() = %v, want empty", env)
+	}
+}
+
+func TestSettingsAKindCannotHonourAreRejected(t *testing.T) {
+	// The PR's own rule: a setting that cannot take effect is an error. A
+	// capacity that silently does nothing reads as a limit being applied.
+	tests := map[string]func(*SpawnConfig){
+		"args on a built-in kind":          func(c *SpawnConfig) { c.Kind = KindClaude; c.Args = []string{"--flag"} },
+		"configDirEnv on a built-in kind":  func(c *SpawnConfig) { c.Kind = KindClaude; c.ConfigDirEnv = "X_HOME" },
+		"credentialEnv on a built-in kind": func(c *SpawnConfig) { c.Kind = KindClaude; c.CredentialEnv = []string{"X"} },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := baseConfig()
+			mutate(&c)
+			if err := ValidateSpawnConfig(c); err == nil {
+				t.Error("must be rejected, not silently ignored")
+			}
+		})
+	}
+
+	c := customConfig()
+	c.Capacity = 4
+	if err := ValidateSpawnConfig(c); err == nil {
+		t.Error("capacity on a custom kind must be rejected, not silently ignored")
+	}
+}

--- a/utils/agent/supervisor/kind_test.go
+++ b/utils/agent/supervisor/kind_test.go
@@ -300,3 +300,34 @@ func TestSettingsAKindCannotHonourAreRejected(t *testing.T) {
 		t.Error("capacity on a custom kind must be rejected, not silently ignored")
 	}
 }
+
+func TestCustomArgsCannotSmuggleAForbiddenPermissionMode(t *testing.T) {
+	// The prefix check alone only blocks --dangerously* and --yolo, so
+	// `bin: claude, args: [remote-control, --permission-mode, bypassPermissions]`
+	// would walk straight around the rejection applied to the typed setting.
+	for _, args := range [][]string{
+		{"remote-control", "--permission-mode", "bypassPermissions"},
+		{"remote-control", "--permission-mode=bypassPermissions"},
+		{"remote-control", "--permission-mode", "BYPASSPERMISSIONS"},
+	} {
+		c := customConfig()
+		c.Bin = "claude"
+		c.Args = args
+
+		if err := ValidateSpawnConfig(c); err == nil {
+			t.Errorf("args %v must be rejected — this is the invariant the docs promise", args)
+		}
+	}
+}
+
+func TestCustomArgsStillAllowLegitimatePermissionModes(t *testing.T) {
+	// Only the forbidden mode is blocked; a supervised session is expected to
+	// set a real one.
+	c := customConfig()
+	c.Bin = "claude"
+	c.Args = []string{"remote-control", "--permission-mode", "acceptEdits"}
+
+	if err := ValidateSpawnConfig(c); err != nil {
+		t.Errorf("ValidateSpawnConfig() = %v, want a normal permission mode accepted", err)
+	}
+}

--- a/utils/agent/supervisor/runner.go
+++ b/utils/agent/supervisor/runner.go
@@ -44,6 +44,14 @@ type Runner struct {
 	WakeLock *WakeLock
 	// Notify reports a restart or a shutdown to the user. Optional.
 	Notify func(title, body string)
+	// OnSessionEnd runs after a supervised process exits and before its
+	// replacement starts, while whatever the session left on disk is still
+	// there. It returns a line to append to the restart notification, or "" when
+	// there is nothing worth adding. Optional.
+	//
+	// This is the only moment the state is both final and current, which is why
+	// it is a hook here rather than something the daemon polls for.
+	OnSessionEnd func(Decision) string
 	// Sleep is the delay between restarts. Injected so tests do not wait.
 	Sleep func(ctx context.Context, d time.Duration)
 	// HealthyAfter is how long a run must last to count as healthy, resetting
@@ -154,7 +162,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 
 		r.record(decision, 0, decision.Disable)
-		r.announce(decision)
+		r.announce(decision, r.captureSessionEnd(decision))
 
 		if !decision.Restart {
 			return stopReason(decision, startErr, ctx)
@@ -271,11 +279,27 @@ func (r *Runner) recordLocked(d Decision, pid int, disabled bool) {
 	}
 }
 
-func (r *Runner) announce(d Decision) {
+// captureSessionEnd records what the ending session left behind.
+//
+// Only for an end that actually replaces or stops the session: a requested stop
+// is the user closing it deliberately, and they do not need a handover note for
+// something they just did.
+func (r *Runner) captureSessionEnd(d Decision) string {
+	if r.OnSessionEnd == nil || !(d.Restart || d.Disable) {
+		return ""
+	}
+	return r.OnSessionEnd(d)
+}
+
+func (r *Runner) announce(d Decision, detail string) {
 	if !d.Notify || r.Notify == nil {
 		return
 	}
-	r.Notify("corgi agent · "+r.Config.WorkspaceID, d.Reason)
+	body := d.Reason
+	if detail != "" {
+		body += " · " + detail
+	}
+	r.Notify("corgi agent · "+r.Config.WorkspaceID, body)
 }
 
 // healthyAfter is how long a run must last before the failure streak resets.

--- a/utils/agent/supervisor/runner_test.go
+++ b/utils/agent/supervisor/runner_test.go
@@ -376,3 +376,133 @@ func TestStopDuringBackoffDoesNotStartAgain(t *testing.T) {
 		t.Errorf("started %d processes, want 1 — Stop must not be followed by another start", got)
 	}
 }
+
+func TestSessionEndHookRunsBeforeTheReplacementStarts(t *testing.T) {
+	// The state a session leaves behind is only both final and current in the
+	// gap between the old process exiting and the new one starting.
+	start, _ := scriptedStarter(
+		&fakeProcess{pid: 1, code: 0, uptime: 20 * time.Millisecond},
+	)
+	r := testRunner(t, start)
+
+	var mu sync.Mutex
+	var causes []ExitCause
+	var notified []string
+	r.OnSessionEnd = func(d Decision) string {
+		mu.Lock()
+		causes = append(causes, d.Cause)
+		mu.Unlock()
+		return "was on feature/referral"
+	}
+	r.Notify = func(_, body string) {
+		mu.Lock()
+		notified = append(notified, body)
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = r.Run(ctx) }()
+
+	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(notified) > 0 })
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(causes) == 0 || causes[0] != CauseNetworkTimeout {
+		t.Errorf("hook saw causes %v, want it called with the network timeout", causes)
+	}
+	// The summary has to reach the notification: that line is the only thing
+	// most people will ever read about the restart.
+	if !strings.Contains(notified[0], "was on feature/referral") {
+		t.Errorf("notification %q does not carry the handover summary", notified[0])
+	}
+}
+
+func TestSessionEndHookIsSkippedOnARequestedStop(t *testing.T) {
+	// Closing a session deliberately does not need a handover note about the
+	// thing you just closed.
+	start, _ := scriptedStarter(&fakeProcess{pid: 1, code: 0})
+	r := testRunner(t, start)
+
+	var mu sync.Mutex
+	called := 0
+	r.OnSessionEnd = func(Decision) string {
+		mu.Lock()
+		called++
+		mu.Unlock()
+		return "should not appear"
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = r.Run(context.Background()) }()
+
+	waitFor(t, func() bool { return r.State().Running })
+	r.Stop()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 0 {
+		t.Errorf("hook ran %d times on a requested stop, want 0", called)
+	}
+}
+
+func TestSessionEndHookRunsWhenAWorkspaceIsDisabled(t *testing.T) {
+	// A workspace disabled by an auth failure is the case where the note is
+	// worth most: nothing will restart to write one later.
+	start, _ := scriptedStarter(
+		&fakeProcess{pid: 1, code: 1, exitNow: true, output: "Remote Control requires a claude.ai subscription"},
+	)
+	r := testRunner(t, start)
+
+	var mu sync.Mutex
+	called := 0
+	r.OnSessionEnd = func(Decision) string {
+		mu.Lock()
+		called++
+		mu.Unlock()
+		return ""
+	}
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run() = %v, want nil after disabling", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 1 {
+		t.Errorf("hook ran %d times, want 1 when the workspace is disabled", called)
+	}
+}
+
+func TestEmptySessionEndSummaryLeavesTheNotificationAlone(t *testing.T) {
+	start, _ := scriptedStarter(
+		&fakeProcess{pid: 1, code: 0, uptime: 20 * time.Millisecond},
+	)
+	r := testRunner(t, start)
+	r.OnSessionEnd = func(Decision) string { return "" }
+
+	var mu sync.Mutex
+	var notified []string
+	r.Notify = func(_, body string) {
+		mu.Lock()
+		notified = append(notified, body)
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = r.Run(ctx) }()
+
+	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(notified) > 0 })
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.HasSuffix(notified[0], " · ") {
+		t.Errorf("notification %q has a dangling separator with nothing after it", notified[0])
+	}
+}

--- a/utils/agent/supervisor/spawn.go
+++ b/utils/agent/supervisor/spawn.go
@@ -5,23 +5,34 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 )
 
-// SpawnConfig is one workspace's remote-control launch settings, resolved from
-// .corgi/agent.yml.
+// SpawnConfig is one workspace's agent launch settings, resolved from the
+// trusted user config.
 type SpawnConfig struct {
 	WorkspaceID string
 	Dir         string
-	Bin         string // defaults to "claude"
-	Spawn       string // same-dir | worktree | session
-	Capacity    int
+	// Kind selects which agent CLI this workspace runs. Empty means
+	// DefaultKind, so a config written before kinds existed keeps working.
+	Kind string
+	// Bin overrides the kind's default command. Must be a bare command name.
+	Bin string
+	// Args is the full argv for KindCustom, after the binary name. Ignored by
+	// every built-in kind, which builds its own from the settings below.
+	Args []string
+	// ConfigDirEnv and CredentialEnv describe a custom kind's environment: the
+	// variable that scopes it to one account, and the ambient credentials to
+	// strip. Built-in kinds carry their own and reject these.
+	ConfigDirEnv  string
+	CredentialEnv []string
+	Spawn         string // same-dir | worktree | session
+	Capacity      int
 	// PermissionMode is passed to remote control for spawned sessions.
 	// bypassPermissions is rejected — see ValidateSpawnConfig.
 	PermissionMode string
-	// ConfigDir sets CLAUDE_CONFIG_DIR so this workspace runs under its own
-	// Claude account, memory, skills, and MCP servers.
+	// ConfigDir sets the kind's config-directory variable so this workspace runs
+	// under its own account, memory, skills, and MCP servers.
 	ConfigDir string
 	// InheritAPIKey opts this workspace in to an ambient ANTHROPIC_API_KEY.
 	// Off by default: remote control refuses to run with one set, and an
@@ -41,15 +52,6 @@ type SpawnConfig struct {
 	// stderr is a log file on disk. Only `--foreground`, where a person is
 	// watching the terminal, turns this on.
 	MirrorOutput bool
-}
-
-// credentialEnvVars are stripped from the child environment unless the
-// workspace explicitly opts in. Leaving one in place routes work to the wrong
-// account without any visible error.
-var credentialEnvVars = []string{
-	"ANTHROPIC_API_KEY",
-	"ANTHROPIC_AUTH_TOKEN",
-	"CLAUDE_CODE_OAUTH_TOKEN",
 }
 
 // forbiddenPermissionModes never reach a supervised process. A daemon running
@@ -88,6 +90,10 @@ func ValidateSpawnConfig(c SpawnConfig) error {
 	if !filepath.IsAbs(c.Dir) {
 		return fmt.Errorf("workspace %s: directory must be absolute, got %q", c.WorkspaceID, c.Dir)
 	}
+	kind, err := KindFor(c)
+	if err != nil {
+		return fmt.Errorf("workspace %s: %w", c.WorkspaceID, err)
+	}
 	if mode := normalize(c.PermissionMode); mode != "" {
 		if forbiddenPermissionModes[mode] {
 			return fmt.Errorf(
@@ -95,20 +101,50 @@ func ValidateSpawnConfig(c SpawnConfig) error {
 					"permission prompts are what you answer from your phone",
 				c.WorkspaceID, c.PermissionMode)
 		}
+		if !kind.SupportsPermissionMode {
+			return fmt.Errorf(
+				"workspace %s: kind %q does not take permissionMode — put the flag in args: instead, "+
+					"so the setting is the one this CLI actually understands",
+				c.WorkspaceID, kind.Name)
+		}
 		if !validPermissionModes[mode] {
 			return fmt.Errorf("workspace %s: unknown permissionMode %q (want %s)",
 				c.WorkspaceID, c.PermissionMode, sortedKeys(validPermissionModes))
 		}
 	}
-	if s := strings.ToLower(strings.TrimSpace(c.Spawn)); s != "" && !validSpawnModes[s] {
-		return fmt.Errorf("workspace %s: unknown spawn mode %q (want %s)",
-			c.WorkspaceID, c.Spawn, sortedKeys(validSpawnModes))
+	if s := strings.ToLower(strings.TrimSpace(c.Spawn)); s != "" {
+		if !kind.SupportsSpawn {
+			return fmt.Errorf(
+				"workspace %s: kind %q does not take spawn — put the flag in args: instead",
+				c.WorkspaceID, kind.Name)
+		}
+		if !validSpawnModes[s] {
+			return fmt.Errorf("workspace %s: unknown spawn mode %q (want %s)",
+				c.WorkspaceID, c.Spawn, sortedKeys(validSpawnModes))
+		}
 	}
 	if c.Capacity < 0 {
 		return fmt.Errorf("workspace %s: capacity cannot be negative", c.WorkspaceID)
 	}
-	if _, err := SanitizeBin(c.Bin); err != nil {
+	if _, err := ResolveBin(c); err != nil {
 		return fmt.Errorf("workspace %s: %w", c.WorkspaceID, err)
+	}
+	// Build the argv now so a bad one fails at startup with a clear message,
+	// rather than at the first restart hours later.
+	if _, err := kind.Args(c); err != nil {
+		return fmt.Errorf("workspace %s: %w", c.WorkspaceID, err)
+	}
+	if kind.Name != KindCustom && (c.ConfigDirEnv != "" || len(c.CredentialEnv) > 0) {
+		return fmt.Errorf(
+			"workspace %s: configDirEnv and credentialEnv are only for kind %q — "+
+				"kind %q already knows its own",
+			c.WorkspaceID, KindCustom, kind.Name)
+	}
+	if c.ConfigDir != "" && kind.ConfigDirEnv == "" {
+		return fmt.Errorf(
+			"workspace %s: kind %q has no config-directory variable, so configDir would be ignored — "+
+				"set configDirEnv to the variable this CLI reads",
+			c.WorkspaceID, kind.Name)
 	}
 	if c.WakeLock != "" && !ValidWakeLockMode(c.WakeLock) {
 		return fmt.Errorf("workspace %s: unknown wakeLock %q (want always, off, session)",
@@ -117,13 +153,34 @@ func ValidateSpawnConfig(c SpawnConfig) error {
 	return nil
 }
 
+// ResolveBin returns the command to run for a workspace: its `bin:` if set,
+// otherwise the kind's default.
+func ResolveBin(c SpawnConfig) (string, error) {
+	bin, err := SanitizeBin(c.Bin)
+	if err != nil {
+		return "", err
+	}
+	if bin != "" {
+		return bin, nil
+	}
+	kind, err := KindFor(c)
+	if err != nil {
+		return "", err
+	}
+	if kind.DefaultBin == "" {
+		return "", fmt.Errorf("kind %q has no default command — set bin: to the command to run", kind.Name)
+	}
+	return kind.DefaultBin, nil
+}
+
 // SanitizeBin rejects a binary name that is a path, so no config file can
 // point the supervisor at an arbitrary executable. Only a bare command name
-// resolved through PATH is allowed.
+// resolved through PATH is allowed. An empty name is left empty for ResolveBin
+// to fill from the kind.
 func SanitizeBin(bin string) (string, error) {
 	bin = strings.TrimSpace(bin)
 	if bin == "" {
-		return "claude", nil
+		return "", nil
 	}
 	if strings.ContainsAny(bin, `/\`) {
 		return "", fmt.Errorf(
@@ -136,24 +193,15 @@ func SanitizeBin(bin string) (string, error) {
 	return bin, nil
 }
 
-// BuildArgs returns the argv for a workspace's remote-control process.
-// It never emits --dangerously-skip-permissions, whatever the caller's shell
-// aliases do.
-func BuildArgs(c SpawnConfig) []string {
-	args := []string{"remote-control"}
-	if s := strings.ToLower(strings.TrimSpace(c.Spawn)); s != "" {
-		args = append(args, "--spawn", s)
+// BuildArgs returns the argv for a workspace's agent process, after the binary
+// name. It never emits a flag that disarms permission prompts, whatever the
+// caller's shell aliases or config say.
+func BuildArgs(c SpawnConfig) ([]string, error) {
+	kind, err := KindFor(c)
+	if err != nil {
+		return nil, err
 	}
-	if c.Capacity > 0 {
-		args = append(args, "--capacity", strconv.Itoa(c.Capacity))
-	}
-	if mode := strings.TrimSpace(c.PermissionMode); mode != "" && !forbiddenPermissionModes[normalize(mode)] {
-		args = append(args, "--permission-mode", mode)
-	}
-	if name := strings.TrimSpace(c.Name); name != "" {
-		args = append(args, "--name", name)
-	}
-	return args
+	return kind.Args(c)
 }
 
 // BuildEnv constructs the child environment explicitly rather than handing over
@@ -166,32 +214,48 @@ func BuildArgs(c SpawnConfig) []string {
 //
 // parentEnv is the environment to derive from, in "KEY=value" form.
 func BuildEnv(c SpawnConfig, parentEnv []string) []string {
+	kind, err := KindFor(c)
+	if err != nil {
+		// Unreachable through the daemon, which validates first. Returning the
+		// parent unchanged would hand the child every ambient credential, so
+		// return nothing instead: a process with no environment fails loudly.
+		return nil
+	}
+	configVar := kind.ConfigDirEnv
+
 	keep := make([]string, 0, len(parentEnv))
 	for _, entry := range parentEnv {
 		key, _, ok := strings.Cut(entry, "=")
 		if !ok {
 			continue
 		}
-		if isStrippedCredential(key, c) {
+		if isStrippedCredential(kind, key, c) {
 			continue
 		}
-		if key == "CLAUDE_CONFIG_DIR" && c.ConfigDir != "" {
+		if configVar != "" && key == configVar && c.ConfigDir != "" {
 			continue // replaced below
 		}
 		keep = append(keep, entry)
 	}
-	if c.ConfigDir != "" {
-		keep = append(keep, "CLAUDE_CONFIG_DIR="+expandHome(c.ConfigDir))
+	if c.ConfigDir != "" && configVar != "" {
+		keep = append(keep, configVar+"="+expandHome(c.ConfigDir))
 	}
 	return keep
 }
 
-func isStrippedCredential(key string, c SpawnConfig) bool {
-	for _, name := range credentialEnvVars {
+// isStrippedCredential reports whether a variable is one of the kind's ambient
+// credentials and the workspace has not opted in to keeping it.
+//
+// The two opt-ins are split because they fail differently: an API key bills the
+// API instead of a subscription, while an OAuth token points at another
+// account. A name containing OAUTH is treated as the token case, which is the
+// convention every CLI here follows.
+func isStrippedCredential(kind Kind, key string, c SpawnConfig) bool {
+	for _, name := range kind.CredentialEnv {
 		if key != name {
 			continue
 		}
-		if name == "CLAUDE_CODE_OAUTH_TOKEN" {
+		if strings.Contains(strings.ToUpper(name), "OAUTH") {
 			return !c.InheritOAuthToken
 		}
 		return !c.InheritAPIKey
@@ -203,10 +267,14 @@ func isStrippedCredential(key string, c SpawnConfig) bool {
 // supervisor can say so in its startup diagnostic instead of leaving the user
 // to wonder which account a task ran under.
 func StrippedCredentials(c SpawnConfig, parentEnv []string) []string {
+	kind, err := KindFor(c)
+	if err != nil {
+		return nil
+	}
 	var stripped []string
 	for _, entry := range parentEnv {
 		key, _, ok := strings.Cut(entry, "=")
-		if ok && isStrippedCredential(key, c) {
+		if ok && isStrippedCredential(kind, key, c) {
 			stripped = append(stripped, key)
 		}
 	}

--- a/utils/agent/supervisor/spawn.go
+++ b/utils/agent/supervisor/spawn.go
@@ -134,11 +134,26 @@ func ValidateSpawnConfig(c SpawnConfig) error {
 	if _, err := kind.Args(c); err != nil {
 		return fmt.Errorf("workspace %s: %w", c.WorkspaceID, err)
 	}
-	if kind.Name != KindCustom && (c.ConfigDirEnv != "" || len(c.CredentialEnv) > 0) {
+	// Same rule as spawn and permissionMode above: a setting that cannot take
+	// effect is an error rather than a silent no-op. A `capacity: 4` that
+	// quietly does nothing reads as a limit that is being applied.
+	if kind.BuildsArgvFromSettings {
+		if c.ConfigDirEnv != "" || len(c.CredentialEnv) > 0 {
+			return fmt.Errorf(
+				"workspace %s: configDirEnv and credentialEnv are only for kind %q — "+
+					"kind %q already knows its own",
+				c.WorkspaceID, KindCustom, kind.Name)
+		}
+		if len(c.Args) > 0 {
+			return fmt.Errorf(
+				"workspace %s: args is only for kind %q — kind %q builds its own argv from "+
+					"spawn, capacity and permissionMode",
+				c.WorkspaceID, KindCustom, kind.Name)
+		}
+	} else if c.Capacity > 0 {
 		return fmt.Errorf(
-			"workspace %s: configDirEnv and credentialEnv are only for kind %q — "+
-				"kind %q already knows its own",
-			c.WorkspaceID, KindCustom, kind.Name)
+			"workspace %s: kind %q does not take capacity — put the flag in args: instead",
+			c.WorkspaceID, kind.Name)
 	}
 	if c.ConfigDir != "" && kind.ConfigDirEnv == "" {
 		return fmt.Errorf(
@@ -218,8 +233,13 @@ func BuildEnv(c SpawnConfig, parentEnv []string) []string {
 	if err != nil {
 		// Unreachable through the daemon, which validates first. Returning the
 		// parent unchanged would hand the child every ambient credential, so
-		// return nothing instead: a process with no environment fails loudly.
-		return nil
+		// return an empty environment instead: a process with none fails loudly.
+		//
+		// Non-nil deliberately. exec.Cmd treats a nil Env as "inherit the whole
+		// parent environment", which is the exact opposite of what this line is
+		// for, so returning nil here would turn the safe fallback into total
+		// credential inheritance.
+		return []string{}
 	}
 	configVar := kind.ConfigDirEnv
 

--- a/utils/agent/supervisor/spawn_test.go
+++ b/utils/agent/supervisor/spawn_test.go
@@ -68,7 +68,10 @@ func TestBuildArgsNeverSkipsPermissions(t *testing.T) {
 	c.Capacity = 4
 	c.PermissionMode = "bypassPermissions"
 
-	args := BuildArgs(c)
+	args, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
 
 	for _, arg := range args {
 		if strings.Contains(arg, "dangerously-skip-permissions") {
@@ -87,7 +90,10 @@ func TestBuildArgs(t *testing.T) {
 	c.PermissionMode = "acceptEdits"
 	c.Name = "acme"
 
-	args := BuildArgs(c)
+	args, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
 
 	if len(args) == 0 || args[0] != "remote-control" {
 		t.Fatalf("argv must start with remote-control, got %v", args)

--- a/utils/agentwork.go
+++ b/utils/agentwork.go
@@ -49,6 +49,19 @@ func ProbeAgentWork(dir string) *AgentWork {
 	return aw
 }
 
+// HasUncommittedWork reports whether a checkout holds anything a fresh session
+// would not find: modified tracked files, or new untracked ones.
+//
+// Deliberately wider than isTreeDirty, which excludes untracked files because
+// it guards worktree removal — there, build output must not block a cleanup.
+// For a handover note the opposite is true: creating files is the most common
+// thing an agent does, and a note calling that "clean" would be worse than no
+// note. .gitignore is still respected, so ignored output does not count.
+func HasUncommittedWork(dir string) bool {
+	out, err := gitOut(dir, "status", "--porcelain")
+	return err == nil && strings.TrimSpace(out) != ""
+}
+
 // probePullRequest tries GitHub (gh) first, then GitLab (glab). Returns nil if
 // neither tool is installed or no PR/MR matches the branch.
 func probePullRequest(dir, branch string) *PullRequestState {

--- a/utils/agentwork.go
+++ b/utils/agentwork.go
@@ -49,17 +49,33 @@ func ProbeAgentWork(dir string) *AgentWork {
 	return aw
 }
 
-// HasUncommittedWork reports whether a checkout holds anything a fresh session
-// would not find: modified tracked files, or new untracked ones.
+// RepoState is one checkout's local git state: no forge, no network.
+type RepoState struct {
+	Branch string
+	Dirty  bool
+}
+
+// ProbeRepoState reads a checkout's branch and whether it holds uncommitted
+// work. Returns false when dir is not a git repository.
 //
-// Deliberately wider than isTreeDirty, which excludes untracked files because
-// it guards worktree removal — there, build output must not block a cleanup.
-// For a handover note the opposite is true: creating files is the most common
-// thing an agent does, and a note calling that "clean" would be worse than no
-// note. .gitignore is still respected, so ignored output does not count.
-func HasUncommittedWork(dir string) bool {
-	out, err := gitOut(dir, "status", "--porcelain")
-	return err == nil && strings.TrimSpace(out) != ""
+// Separate from ProbeAgentWork, which additionally shells out to `gh` / `glab`
+// to find the branch's PR. Those calls hit the network with no timeout, which
+// is fine for a snapshot someone asked for and wrong anywhere on a restart
+// path — a session that died *because* the network went away must not then wait
+// on GitHub, once per repository, before it can come back.
+//
+// A detached HEAD reports an empty branch rather than the literal "HEAD", since
+// a name there would be a lie.
+func ProbeRepoState(dir string) (RepoState, bool) {
+	if dir == "" || !isGitRepo(dir) {
+		return RepoState{}, false
+	}
+	var st RepoState
+	if b, err := gitOut(dir, "rev-parse", "--abbrev-ref", "HEAD"); err == nil && b != "HEAD" {
+		st.Branch = b
+	}
+	st.Dirty = HasUncommittedWork(dir)
+	return st, true
 }
 
 // probePullRequest tries GitHub (gh) first, then GitLab (glab). Returns nil if

--- a/utils/agentwork_test.go
+++ b/utils/agentwork_test.go
@@ -120,3 +120,74 @@ func TestHasUncommittedWorkOnANonRepositoryIsFalse(t *testing.T) {
 		t.Error("a directory that is not a git repo has no uncommitted work")
 	}
 }
+
+func TestProbeRepoStateReadsBranchAndUncommittedWork(t *testing.T) {
+	repo := newRepo(t, filepath.Join(t.TempDir(), "api"))
+
+	got, ok := ProbeRepoState(repo)
+	if !ok {
+		t.Fatal("ProbeRepoState() reported no repository for a git checkout")
+	}
+	if got.Branch != "main" {
+		t.Errorf("branch = %q, want main", got.Branch)
+	}
+	if got.Dirty {
+		t.Error("a freshly committed repo must not be reported dirty")
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("wip\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if got, _ := ProbeRepoState(repo); !got.Dirty {
+		t.Error("an untracked file is uncommitted work a fresh session would not find")
+	}
+}
+
+func TestProbeRepoStateReportsNoBranchWhenDetached(t *testing.T) {
+	// git prints the literal "HEAD" for a detached checkout. Passing that
+	// through would put "HEAD" in a handover note as though it were a branch
+	// name someone could check out again.
+	repo := newRepo(t, filepath.Join(t.TempDir(), "api"))
+	gitIn(t, repo, "checkout", "-q", "--detach")
+
+	got, ok := ProbeRepoState(repo)
+	if !ok {
+		t.Fatal("ProbeRepoState() reported no repository for a detached checkout")
+	}
+	if got.Branch != "" {
+		t.Errorf("branch = %q, want empty for a detached HEAD", got.Branch)
+	}
+}
+
+func TestProbeRepoStateOnANonRepository(t *testing.T) {
+	if _, ok := ProbeRepoState(t.TempDir()); ok {
+		t.Error("a plain directory is not a repository")
+	}
+	if _, ok := ProbeRepoState(""); ok {
+		t.Error("an empty path is not a repository")
+	}
+}
+
+func TestProbeRepoStateMakesNoForgeCalls(t *testing.T) {
+	// The point of this function existing alongside ProbeAgentWork: it is used
+	// on the restart path, where a session that died because the network went
+	// away must not then block on `gh pr view` once per repository.
+	dir := t.TempDir()
+	repo := newRepo(t, filepath.Join(dir, "api"))
+
+	// A gh that fails the test if it is ever run, ahead of any real one.
+	fakeBin := t.TempDir()
+	writeFakeBin(t, fakeBin, "gh", "#!/bin/sh\necho CALLED > "+filepath.Join(dir, "gh-was-called")+"\nexit 0\n")
+	writeFakeBin(t, fakeBin, "glab", "#!/bin/sh\necho CALLED > "+filepath.Join(dir, "glab-was-called")+"\nexit 0\n")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, ok := ProbeRepoState(repo); !ok {
+		t.Fatal("ProbeRepoState() reported no repository")
+	}
+
+	for _, marker := range []string{"gh-was-called", "glab-was-called"} {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			t.Errorf("%s: a forge CLI was invoked on the restart path", marker)
+		}
+	}
+}

--- a/utils/agentwork_test.go
+++ b/utils/agentwork_test.go
@@ -76,3 +76,47 @@ func TestNormalizeCIConclusion(t *testing.T) {
 		}
 	}
 }
+
+func TestHasUncommittedWorkCountsUntrackedFiles(t *testing.T) {
+	// The difference from isTreeDirty, and the reason this exists: a session's
+	// newly created files are the work most easily lost, and `git diff` alone
+	// says nothing about them.
+	repo := newRepo(t, filepath.Join(t.TempDir(), "api"))
+
+	if HasUncommittedWork(repo) {
+		t.Fatal("a fresh repo must be reported clean")
+	}
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("wip\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if !HasUncommittedWork(repo) {
+		t.Error("an untracked file is uncommitted work a fresh session would not find")
+	}
+}
+
+func TestHasUncommittedWorkRespectsGitignore(t *testing.T) {
+	// Otherwise every stack with build output reports every repo as dirty, and
+	// the count in a handover note stops meaning anything.
+	repo := newRepo(t, filepath.Join(t.TempDir(), "api"))
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("build/\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	commitAll(t, repo, "ignore build")
+
+	if err := os.MkdirAll(filepath.Join(repo, "build"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "build", "out.js"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if HasUncommittedWork(repo) {
+		t.Error("ignored build output must not count as uncommitted work")
+	}
+}
+
+func TestHasUncommittedWorkOnANonRepositoryIsFalse(t *testing.T) {
+	if HasUncommittedWork(t.TempDir()) {
+		t.Error("a directory that is not a git repo has no uncommitted work")
+	}
+}

--- a/utils/agentworktrees.go
+++ b/utils/agentworktrees.go
@@ -285,7 +285,7 @@ func releaseBranchWorktrees(composeDir, branch string, force bool) (removed, ski
 		if head, herr := gitOut(dest, gitRevParse, gitAbbrevRef, "HEAD"); herr == nil && head != branch {
 			continue
 		}
-		if !force && hasUncommittedWork(dest) {
+		if !force && HasUncommittedWork(dest) {
 			skippedDirty = append(skippedDirty, dest)
 			continue
 		}
@@ -307,13 +307,15 @@ func releaseBranchWorktrees(composeDir, branch string, force bool) (removed, ski
 	return removed, skippedDirty, nil
 }
 
-// hasUncommittedWork reports whether a worktree holds anything not committed,
+// HasUncommittedWork reports whether a checkout holds anything not committed,
 // including untracked files.
 //
 // isTreeDirty deliberately ignores untracked files, which is right for asking
 // "has this checkout diverged" — but wrong here. An agent's work is usually a
-// set of brand-new files, and those are the ones it would hurt most to discard.
-func hasUncommittedWork(dir string) bool {
+// set of brand-new files, and those are the ones it would hurt most to discard,
+// which is equally true when releasing a worktree and when writing a handover
+// brief. .gitignore still applies, so build output does not count.
+func HasUncommittedWork(dir string) bool {
 	out, err := gitOut(dir, "status", "--porcelain")
 	return err == nil && strings.TrimSpace(out) != ""
 }
@@ -326,8 +328,19 @@ func hasUncommittedWork(dir string) bool {
 // services would resolve to the same destination and the second would silently
 // be pointed at the first repository's worktree.
 func worktreeDirName(repo, branch string) string {
+	return fmt.Sprintf("%s@%s", WorktreeDirPrefix(repo), branchDirSegment(branch))
+}
+
+// WorktreeDirPrefix is the part of a worktree directory name before the "@",
+// derived only from the repository path.
+//
+// Exported so a caller holding a compose file can map an existing worktree
+// directory back to the service that owns it. Parsing the name by hand does not
+// work: the prefix is "<basename>-<hash>", so splitting on "@" yields
+// "api-3f2a1b" rather than "api".
+func WorktreeDirPrefix(repo string) string {
 	sum := sha256.Sum256([]byte(repo))
-	return fmt.Sprintf("%s-%x@%s", filepath.Base(repo), sum[:3], branchDirSegment(branch))
+	return fmt.Sprintf("%s-%x", filepath.Base(repo), sum[:3])
 }
 
 // branchDirSegment flattens a branch name into one path segment.

--- a/utils/tunnel/access.go
+++ b/utils/tunnel/access.go
@@ -1,0 +1,142 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Exposure is how reachable an endpoint is, which is a different question from
+// whether it has a stable URL.
+//
+// corgi already treats "is there a tunnel" as a yes/no, and gates the mutating
+// tools on it. That is too blunt: a named tunnel behind an identity proxy is
+// not open to the internet, and a quick tunnel is open to anyone who guesses
+// the hostname. Those deserve different answers.
+type Exposure string
+
+const (
+	// ExposureLocal is a loopback or LAN listener with no tunnel at all.
+	ExposureLocal Exposure = "local"
+	// ExposurePrivate is a tunnel an identity proxy stands in front of, so an
+	// unauthenticated request never reaches corgi.
+	ExposurePrivate Exposure = "private"
+	// ExposurePublic is a tunnel anyone holding the URL can reach.
+	ExposurePublic Exposure = "public"
+)
+
+// AccessResult is what probing an endpoint learned.
+type AccessResult struct {
+	// Protected is true only when an identity proxy was actually observed
+	// intercepting the request. Anything else — an error, a timeout, an
+	// unrecognised response — leaves it false.
+	Protected bool `json:"protected"`
+	// Provider names what answered, for the line corgi prints.
+	Provider string `json:"provider,omitempty"`
+	// Detail says how it was recognised, or why it was not.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Exposure maps a probe result onto the tier a tunnelled endpoint sits in.
+func (r AccessResult) Exposure() Exposure {
+	if r.Protected {
+		return ExposurePrivate
+	}
+	return ExposurePublic
+}
+
+// accessProbeTimeout bounds the probe. It runs while a tunnel is coming up and
+// nothing waits on the result, but an unbounded request would keep a goroutine
+// alive for the life of the process.
+const accessProbeTimeout = 10 * time.Second
+
+// ProbeAccess asks whether an identity proxy stands in front of a URL.
+//
+// The check is deliberately positive-only: corgi downgrades an endpoint to
+// "private" solely on evidence that an unauthenticated request was intercepted.
+// Guessing the other way — assuming protection because a probe failed, or
+// because the config said so — would relax a security gate on a hunch, and the
+// failure mode is an open shell endpoint.
+//
+// It follows no redirects, because the redirect itself is the evidence.
+func ProbeAccess(ctx context.Context, rawURL string) AccessResult {
+	if !strings.HasPrefix(rawURL, "https://") {
+		// An identity proxy terminates TLS. Anything on plain HTTP is not
+		// behind one, whatever it answers.
+		return AccessResult{Detail: "not an https endpoint"}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, accessProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return AccessResult{Detail: err.Error()}
+	}
+	client := &http.Client{
+		// The interception is what is being measured, so following it would
+		// discard the answer and report on the login page instead.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return AccessResult{Detail: fmt.Sprintf("probe failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	return classifyAccessResponse(resp.StatusCode, resp.Header)
+}
+
+// classifyAccessResponse recognises an identity proxy from the response alone.
+// Split out from the request so the recognition rules are testable without a
+// network.
+func classifyAccessResponse(status int, header http.Header) AccessResult {
+	location := header.Get("Location")
+
+	// Cloudflare Access redirects an unauthenticated request to its own login
+	// path, and stamps the response on the way through.
+	if strings.Contains(location, "/cdn-cgi/access/login") {
+		return AccessResult{
+			Protected: true,
+			Provider:  "cloudflare-access",
+			Detail:    "unauthenticated request redirected to the Access login",
+		}
+	}
+	for name := range header {
+		if strings.HasPrefix(strings.ToLower(name), "cf-access-") {
+			return AccessResult{
+				Protected: true,
+				Provider:  "cloudflare-access",
+				Detail:    "response carries a " + name + " header",
+			}
+		}
+	}
+	// A generic identity proxy in front of an API endpoint answers 401 with a
+	// challenge naming itself. corgi's own bearer auth also answers 401, so the
+	// challenge has to name something other than corgi to count.
+	if status == http.StatusUnauthorized {
+		if challenge := header.Get("Www-Authenticate"); challenge != "" && !isCorgiChallenge(challenge) {
+			return AccessResult{
+				Protected: true,
+				Provider:  "identity-proxy",
+				Detail:    "unauthenticated request challenged: " + challenge,
+			}
+		}
+	}
+
+	return AccessResult{Detail: fmt.Sprintf("no identity proxy observed (status %d)", status)}
+}
+
+// isCorgiChallenge reports whether a 401 came from corgi's own bearer check
+// rather than something standing in front of it. Treating corgi's own auth as
+// an identity proxy would let the endpoint declare itself private on the
+// strength of the very token the gate exists to protect.
+func isCorgiChallenge(challenge string) bool {
+	lower := strings.ToLower(challenge)
+	return strings.Contains(lower, "corgi") ||
+		(strings.HasPrefix(lower, "bearer") && !strings.Contains(lower, "realm="))
+}

--- a/utils/tunnel/access.go
+++ b/utils/tunnel/access.go
@@ -62,6 +62,14 @@ const accessProbeTimeout = 10 * time.Second
 //
 // It follows no redirects, because the redirect itself is the evidence.
 func ProbeAccess(ctx context.Context, rawURL string) AccessResult {
+	return ProbeAccessWith(ctx, rawURL, &http.Client{})
+}
+
+// ProbeAccessWith is ProbeAccess against a caller-supplied client, so a test
+// can point it at a server whose certificate the default client would reject.
+// The redirect policy is set here rather than taken from the client: not
+// following the redirect is what makes the check work, not a caller's choice.
+func ProbeAccessWith(ctx context.Context, rawURL string, client *http.Client) AccessResult {
 	if !strings.HasPrefix(rawURL, "https://") {
 		// An identity proxy terminates TLS. Anything on plain HTTP is not
 		// behind one, whatever it answers.
@@ -75,14 +83,13 @@ func ProbeAccess(ctx context.Context, rawURL string) AccessResult {
 	if err != nil {
 		return AccessResult{Detail: err.Error()}
 	}
-	client := &http.Client{
-		// The interception is what is being measured, so following it would
-		// discard the answer and report on the login page instead.
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	probe := *client
+	// The interception is what is being measured, so following it would
+	// discard the answer and report on the login page instead.
+	probe.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
-	resp, err := client.Do(req)
+	resp, err := probe.Do(req)
 	if err != nil {
 		return AccessResult{Detail: fmt.Sprintf("probe failed: %v", err)}
 	}

--- a/utils/tunnel/access_test.go
+++ b/utils/tunnel/access_test.go
@@ -1,0 +1,193 @@
+package tunnel
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClassifyRecognisesTheAccessLoginRedirect(t *testing.T) {
+	h := http.Header{}
+	h.Set("Location", "https://acme.cloudflareaccess.com/cdn-cgi/access/login/corgi.example")
+
+	got := classifyAccessResponse(http.StatusFound, h)
+
+	if !got.Protected {
+		t.Fatal("a redirect to the Access login is the endpoint being intercepted — that is the evidence")
+	}
+	if got.Provider != "cloudflare-access" {
+		t.Errorf("provider = %q, want cloudflare-access", got.Provider)
+	}
+	if got.Exposure() != ExposurePrivate {
+		t.Errorf("exposure = %q, want %q", got.Exposure(), ExposurePrivate)
+	}
+}
+
+func TestClassifyRecognisesAccessHeaders(t *testing.T) {
+	// Header names are canonicalised by net/http, but a probe result should not
+	// depend on which casing the proxy happened to send.
+	for _, name := range []string{"Cf-Access-Jwt-Assertion", "CF-Access-Client-Id"} {
+		h := http.Header{}
+		h.Set(name, "value")
+
+		got := classifyAccessResponse(http.StatusOK, h)
+		if !got.Protected {
+			t.Errorf("header %q should be recognised as an identity proxy", name)
+		}
+	}
+}
+
+func TestClassifyRecognisesAGenericChallenge(t *testing.T) {
+	h := http.Header{}
+	h.Set("Www-Authenticate", `Bearer realm="identity-aware-proxy"`)
+
+	got := classifyAccessResponse(http.StatusUnauthorized, h)
+
+	if !got.Protected {
+		t.Fatal("a 401 naming a realm other than corgi is something standing in front of corgi")
+	}
+	if got.Provider != "identity-proxy" {
+		t.Errorf("provider = %q, want identity-proxy", got.Provider)
+	}
+}
+
+func TestCorgisOwnBearerCheckIsNotAnIdentityProxy(t *testing.T) {
+	// This is the failure that matters: corgi answers 401 to an unauthenticated
+	// request too. Counting that as protection would let the endpoint declare
+	// itself private on the strength of the very token the gate protects, and
+	// silently re-enable corgi_exec over an open URL.
+	for _, challenge := range []string{
+		"Bearer",
+		`Bearer realm="corgi"`,
+		"bearer",
+	} {
+		h := http.Header{}
+		h.Set("Www-Authenticate", challenge)
+
+		got := classifyAccessResponse(http.StatusUnauthorized, h)
+		if got.Protected {
+			t.Errorf("challenge %q must not count as an identity proxy", challenge)
+		}
+	}
+}
+
+func TestClassifyDefaultsToPublic(t *testing.T) {
+	// Anything not recognised is public. The gate must fail closed: assuming
+	// protection on an unrecognised response is how an open shell endpoint
+	// happens.
+	tests := []struct {
+		name   string
+		status int
+		header http.Header
+	}{
+		{"plain 200", http.StatusOK, http.Header{}},
+		{"a redirect somewhere else", http.StatusFound, headerWith("Location", "https://example.com/login")},
+		{"401 with no challenge", http.StatusUnauthorized, http.Header{}},
+		{"server error", http.StatusBadGateway, http.Header{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyAccessResponse(tt.status, tt.header)
+			if got.Protected {
+				t.Errorf("status %d must not be read as protected", tt.status)
+			}
+			if got.Exposure() != ExposurePublic {
+				t.Errorf("exposure = %q, want %q", got.Exposure(), ExposurePublic)
+			}
+			if got.Detail == "" {
+				t.Error("an unprotected result must say why, since it decides whether a tool is blocked")
+			}
+		})
+	}
+}
+
+func headerWith(key, value string) http.Header {
+	h := http.Header{}
+	h.Set(key, value)
+	return h
+}
+
+func TestProbeAccessRejectsPlainHTTP(t *testing.T) {
+	// An identity proxy terminates TLS. A plain-HTTP endpoint is not behind
+	// one, so there is nothing to probe and no request worth making.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cf-Access-Jwt-Assertion", "value")
+	}))
+	defer srv.Close()
+
+	got := ProbeAccess(context.Background(), srv.URL)
+
+	if got.Protected {
+		t.Error("an http:// endpoint must never be reported as protected")
+	}
+	if !strings.Contains(got.Detail, "https") {
+		t.Errorf("detail = %q, want it to explain the scheme requirement", got.Detail)
+	}
+}
+
+func TestProbeAccessDoesNotFollowTheRedirect(t *testing.T) {
+	// Following it would discard the evidence and classify the login page.
+	var hits int
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path == "/cdn-cgi/access/login" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/cdn-cgi/access/login", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	got := probeWithClientOf(srv)
+
+	if !got.Protected {
+		t.Fatalf("result = %+v, want the redirect recognised", got)
+	}
+	if hits != 1 {
+		t.Errorf("made %d requests, want 1 — the redirect must not be followed", hits)
+	}
+}
+
+func TestProbeAccessTreatsAFailedRequestAsPublic(t *testing.T) {
+	// A probe that cannot reach the endpoint knows nothing, and "knows nothing"
+	// must not open the gate.
+	got := ProbeAccess(context.Background(), "https://127.0.0.1:1/nothing-listening")
+
+	if got.Protected {
+		t.Error("an unreachable endpoint must not be reported as protected")
+	}
+	if got.Exposure() != ExposurePublic {
+		t.Errorf("exposure = %q, want %q", got.Exposure(), ExposurePublic)
+	}
+}
+
+func TestProbeAccessRespectsACancelledContext(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if got := ProbeAccess(ctx, srv.URL); got.Protected {
+		t.Error("a cancelled probe must not report protection")
+	}
+}
+
+// probeWithClientOf runs the probe against a TLS test server, whose certificate
+// the default client will not trust. It repeats ProbeAccess's redirect and
+// classification behaviour against that server's client so the no-follow rule
+// is exercised end to end.
+func probeWithClientOf(srv *httptest.Server) AccessResult {
+	client := srv.Client()
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		return AccessResult{Detail: err.Error()}
+	}
+	defer resp.Body.Close()
+	return classifyAccessResponse(resp.StatusCode, resp.Header)
+}


### PR DESCRIPTION
Three additions to agent mode. Each closes a gap the supervisor already had, and none of them reimplements something Remote Control does well.

## 1. Supervising an agent other than Claude Code

`utils/agent/supervisor/spawn.go` hardcoded `args := []string{"remote-control"}` and the Claude-specific flags around it, so agent mode spoke exactly one vendor — even though the MCP tool surface is already vendor-neutral and the restart/backoff/wake-lock/account-scoping machinery is identical whichever CLI runs.

Launch details now live in a `Kind`:

| kind | launches |
|---|---|
| `claude` | `claude remote-control …` built from `spawn`, `capacity`, `permissionMode`. **The default**, so every existing config is unchanged. |
| `custom` | exactly the `args` you wrote, after `bin`. |

**Why `custom` takes the whole argv rather than corgi shipping guessed flags for other vendors.** A supervised process runs unattended. A flag corgi invented for a CLI whose interface it cannot verify fails at 3am with a message nobody sees. Writing the command out means what runs is what you tested in a terminal. Adding a first-class kind later is a map entry in `kind.go`, once those flags can be verified.

The safety rules carry over rather than being re-litigated:
- `args` is trusted config only — no field in the committed `.corgi/agent.yml` reaches it, so a cloned repo cannot choose the command.
- `--dangerously-*` and `--yolo` are rejected in `args`, the same rule that already rejects `permissionMode: bypassPermissions`.
- A setting a kind cannot honour is an error, not a silent no-op. That includes `configDir` with no `configDirEnv` to put it in — ignoring that one leaves the workspace on the default account, which looks exactly like being on the right one.

## 2. Session handover briefs

`docs/agent.md` was already honest that a restart produces a **new** session with none of the prior context, and stopped there. corgi can't restore the conversation, but it knows the half that survives on disk.

A brief is captured in the gap between the old process exiting and the new one starting — the only moment that state is both final and current:

```
$ corgi agent brief acme-stack
acme-stack
  ended   2026-08-14 14:32 (network-timeout)
  state   was on feature/referral · 1 repo has uncommitted changes
    api              feature/referral (worktree)
    web              feature/referral · uncommitted changes (worktree)
```

The worktrees are the payload. A branch spread across four repositories is invisible from a fresh session's cwd, and nothing else would tell the new session it exists. The summary line is appended to the restart notification, so the lock screen says *where*, not just *that*. Read back via `corgi agent brief [--json]` or `corgi_session_brief` from a phone.

Untracked files count as uncommitted work here, unlike `isTreeDirty` which guards worktree removal and must not let build output block a cleanup — creating files is the most common thing an agent does. `.gitignore` still applies. A requested stop writes no brief; you don't need a handover note for something you just closed.

## 3. Tunnel exposure tiers

"Is there a tunnel" was the wrong thing to gate on: it treated a tunnel behind an identity proxy identically to one anyone with the URL can reach.

| tier | mutating tools |
|---|---|
| `local` — loopback/LAN, no tunnel | allowed |
| `private` — an identity proxy intercepts unauthenticated requests | allowed |
| `public` — anyone with the URL | blocked unless `CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1` |

`private` is reached **only by observing it**. On publish, corgi makes one unauthenticated request and reads the response: a redirect to an Access login, a `cf-access-*` header, a challenge naming a realm. No config can assert protection — a gate that relaxes on a claim fails open on a typo.

corgi's own bearer check answers 401 too and is deliberately excluded; counting it would let an endpoint declare itself private on the strength of the very token the gate protects. Anything unrecognised, including a probe that couldn't connect, stays `public`. The gate starts closed and opens on evidence.

The practical effect: `CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1` — set once and then forgotten forever — stops being the only way to use these tools from a phone.

**Deliberately out of scope:** previews. `corgi_preview_*` runs inside handlers documented as never blocking, and a probe is a network call. Previews stay public, `sensitive` workspaces still refuse them, idle reaping still applies.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` and the full `go test ./...` all pass. New coverage:

- `utils/agent/supervisor/kind_test.go` — default kind is byte-for-byte unchanged behaviour; unknown kind rejected with the valid names; argv copied not aliased; every disarm-the-prompts variant rejected including `--flag=value` and mixed case; per-kind config-dir variable and credential stripping; unresolvable kind yields an *empty* environment rather than the parent's (an unreachable path, but the wrong failure there hands a child every ambient credential).
- `utils/agent/brief/brief_test.go` — round-trip, atomic write with no `.tmp` residue, `0600`, newest-first listing, one corrupt file not hiding the rest, and path traversal contained for `../escape`, `..`, `a/b`, `.`.
- `utils/agent/supervisor/runner_test.go` — hook fires before the replacement starts and on disable, skipped on a requested stop, and no dangling separator when the summary is empty.
- `utils/tunnel/access_test.go` — each recognised signal, the redirect explicitly not followed, and corgi's own 401 not counting as protection.
- `cmd/agent_brief_test.go` — worktree branches and untracked work probed from real git repos; a workspace on a missing path still yields a brief rather than crashing the restart path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuC2iT5yrt1mRPJsqX2AnL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuC2iT5yrt1mRPJsqX2AnL)_