### PR TITLE
e2e: actually collect the artifacts: paths

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -52,6 +52,12 @@ func init() {
 each service's own test script. A suite that drives several services at once
 belongs to the stack rather than to any one of them.`,
 	)
+	testCmd.Flags().String(
+		"artifacts-dir",
+		"",
+		`Directory to copy the e2e block's `+"`artifacts:`"+` paths into after the run,
+pass or fail. Defaults to `+defaultE2EArtifactsDir+` next to the compose file.`,
+	)
 	registerServiceWorkdirFlags(testCmd.Flags())
 }
 

--- a/cmd/test_e2e.go
+++ b/cmd/test_e2e.go
@@ -2,13 +2,19 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"andriiklymiuk/corgi/utils"
 
 	"github.com/spf13/cobra"
 )
+
+// defaultE2EArtifactsDir is where `artifacts:` are collected when
+// --artifacts-dir is not given.
+const defaultE2EArtifactsDir = "corgi_artifacts/e2e"
 
 // runE2ESuite runs the stack's e2e: block against whatever is already running.
 // It deliberately does not start anything: an e2e suite asserts on a live
@@ -35,8 +41,14 @@ func runE2ESuite(cmd *cobra.Command) {
 		}
 	}
 
-	if err := utils.RunServiceCmd("e2e", suite.Run, workdir, false, utils.SkipAutoSourceEnv); err != nil {
-		failE2E(fmt.Sprintf("e2e: %v", err))
+	runErr := utils.RunServiceCmd("e2e", suite.Run, workdir, false, utils.SkipAutoSourceEnv)
+
+	// Collect before reporting: a red suite is exactly when its screenshots and
+	// videos are worth having, and failE2E exits the process.
+	collectE2EArtifacts(cmd, suite, workdir)
+
+	if runErr != nil {
+		failE2E(fmt.Sprintf("e2e: %v", runErr))
 	}
 
 	utils.Info("✅ e2e passed")
@@ -49,4 +61,78 @@ func failE2E(msg string) {
 		fmt.Fprintln(os.Stderr, "❌", msg)
 	}
 	os.Exit(1)
+}
+
+// collectE2EArtifacts copies the paths declared in the suite's `artifacts:` into
+// one directory. Paths are relative to the suite's workdir, which is where the
+// runner writes them.
+func collectE2EArtifacts(cmd *cobra.Command, suite *utils.E2ESuite, workdir string) {
+	if len(suite.Artifacts) == 0 {
+		return
+	}
+
+	dest, _ := cmd.Flags().GetString("artifacts-dir")
+	if dest == "" {
+		dest = filepath.Join(utils.CorgiComposePathDir, defaultE2EArtifactsDir)
+	}
+
+	var collected int
+	for _, declared := range suite.Artifacts {
+		rel := strings.Trim(declared, "/")
+		if rel == "" {
+			continue
+		}
+		src := filepath.Join(workdir, rel)
+		info, statErr := os.Stat(src)
+		if statErr != nil {
+			utils.Infof(
+				"⚠️  e2e artifacts: %q not found under the suite workdir (%s) — `artifacts:` paths are relative to `workdir:`\n",
+				declared, workdir,
+			)
+			continue
+		}
+
+		target := filepath.Join(dest, filepath.Base(rel))
+		var copyErr error
+		if info.IsDir() {
+			copyErr = copyTree(src, target)
+		} else {
+			if copyErr = os.MkdirAll(filepath.Dir(target), 0o755); copyErr == nil {
+				copyErr = copyFile(src, target)
+			}
+		}
+		if copyErr != nil {
+			utils.Infof("⚠️  e2e artifacts: could not collect %q: %v\n", declared, copyErr)
+			continue
+		}
+		collected++
+	}
+
+	if collected > 0 {
+		utils.Infof("📦 collected %d e2e artifact path(s) into %s\n", collected, dest)
+	}
+}
+
+// copyTree copies a directory recursively, creating dst as needed.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		out := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(out, 0o755)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, out)
+	})
 }

--- a/cmd/test_e2e_artifacts_test.go
+++ b/cmd/test_e2e_artifacts_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+
+	"github.com/spf13/cobra"
+)
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func artifactsCmd(dest string) *cobra.Command {
+	c := &cobra.Command{}
+	c.Flags().String("artifacts-dir", dest, "")
+	return c
+}
+
+func TestCopyTreeCopiesNestedFiles(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	writeFile(t, filepath.Join(src, "a.png"), "a")
+	writeFile(t, filepath.Join(src, "nested", "b.png"), "b")
+
+	if err := copyTree(src, dst); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+
+	for _, rel := range []string{"a.png", filepath.Join("nested", "b.png")} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); err != nil {
+			t.Errorf("expected %s to be copied: %v", rel, err)
+		}
+	}
+}
+
+// The whole point of the field: a declared directory is collected, so a red
+// suite leaves its screenshots behind.
+func TestCollectE2EArtifactsCopiesDeclaredDir(t *testing.T) {
+	workdir := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "collected")
+	writeFile(t, filepath.Join(workdir, "artifacts", "shot.png"), "png")
+
+	collectE2EArtifacts(
+		artifactsCmd(dest),
+		&utils.E2ESuite{Artifacts: []string{"artifacts"}},
+		workdir,
+	)
+
+	if _, err := os.Stat(filepath.Join(dest, "artifacts", "shot.png")); err != nil {
+		t.Fatalf("declared artifacts dir was not collected: %v", err)
+	}
+}
+
+// Paths are relative to workdir. A path that does not resolve must not abort the
+// run or invent an empty directory — it warns and moves on.
+func TestCollectE2EArtifactsSkipsMissingPath(t *testing.T) {
+	workdir := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "collected")
+
+	collectE2EArtifacts(
+		artifactsCmd(dest),
+		&utils.E2ESuite{Artifacts: []string{"flows/artifacts"}},
+		workdir,
+	)
+
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("expected no destination dir for a missing artifacts path, got err=%v", err)
+	}
+}
+
+func TestCollectE2EArtifactsNoopWithoutDeclaration(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "collected")
+
+	collectE2EArtifacts(artifactsCmd(dest), &utils.E2ESuite{}, t.TempDir())
+
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("expected no destination dir when nothing is declared, got err=%v", err)
+	}
+}

--- a/plugins/corgi/skills/corgi/references/yml-schema.md
+++ b/plugins/corgi/skills/corgi/references/yml-schema.md
@@ -46,13 +46,21 @@ e2e:
 anything itself, so start the stack first (`corgi run -d --wait`). Same entry
 point locally and in CI; the CI pipeline recipe is the `ci` skill's job.
 
-> **`artifacts:` parses but is not collected.** The field exists on the struct
-> and nothing reads it, so declaring it does nothing — and, being silent, it
-> reads as if screenshots/videos are being gathered when they are not. Collect
-> them in the CI job instead (an upload step pointed at the real output path),
-> and remember the suite's paths are relative to `workdir`, so a `run` that
-> writes `artifacts/x.png` from `workdir: ./e2e` puts it at `e2e/artifacts/`,
-> not `e2e/<flows-dir>/artifacts/`.
+```yaml
+e2e:
+  workdir: ./e2e
+  run: maestro test flows/
+  artifacts:                # optional, paths RELATIVE TO workdir
+    - artifacts             # -> e2e/artifacts
+```
+
+`artifacts:` are copied after the run — **pass or fail**, since a red suite is
+exactly when its screenshots are worth having — into `corgi_artifacts/e2e/` next
+to the compose file, or `--artifacts-dir <dir>` to point somewhere else (a CI job
+uploads that directory). A declared path that does not resolve warns and is
+skipped rather than failing the run. Paths are relative to `workdir`, so a suite
+run from `workdir: ./e2e` that writes `artifacts/x.png` declares `artifacts`,
+not `flows/artifacts`.
 
 ## `envTiers.<name>` (optional)
 


### PR DESCRIPTION
`E2ESuite.Artifacts` was declared on the struct and **nothing read it**. Declaring `artifacts:` parsed, validated, and did nothing — while the compose file read as though screenshots and videos were being gathered.

`KnownFields(true)` can't catch this, because it *is* a known field. That's what makes it worse than a typo: a typo warns, this stays silent.

Found the hard way — chasing a red cross-repo suite whose screenshots turned out never to have been collected at all, in either the compose file or the CI job.

## What it does now

```yaml
e2e:
  workdir: ./e2e
  run: maestro test flows/
  artifacts:          # paths RELATIVE TO workdir
    - artifacts       # -> e2e/artifacts
```

- Each declared path is copied into `corgi_artifacts/e2e/` next to the compose file, or wherever `--artifacts-dir <dir>` points (a CI job uploads that directory).
- **Collection runs before the pass/fail report.** A red suite is exactly when you want its screenshots, and `failE2E` exits the process — so a deferred copy would never run.
- A path that doesn't resolve **warns and is skipped** rather than failing the run, and the warning names `workdir`, since a path written relative to the flows dir instead of the workdir is the easy mistake.

Directory copies are recursive; non-regular files are skipped.

## Testing

`go build ./...` clean, full suite green (1993 tests). Four new tests: recursive copy, a declared dir actually collected, a missing path skipped without inventing an empty destination, and no-op when nothing is declared.

Schema reference updated to document the real behaviour and the workdir-relative rule.