### PR TITLE
Close the CI gaps the GitLab work exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ corgi detects CI on its own (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, and friends) a
   if: always()
 ```
 
+`corgi ci init` writes the starting point for either forge — it reads the git remote, drops the workflow (or `.gitlab-ci.yml` plus the generated cache plan) in place, and prints what your workspace still has to supply.
+
 On GitLab the same job is an include, since GitLab has no equivalent of an action:
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,40 @@ outputs:
       packages. pathsText is newline-joined because an Actions expression
       cannot build that string itself.
     value: ${{ steps.setup.outputs.cache-groups }}
+  cache-1-key:
+    description: >-
+      Group 1's key, empty when there is no such group. A composite action
+      cannot loop actions/cache, so the groups are also published as four fixed
+      slots: a workflow writes four identical cache steps reading
+      cache-N-key/cache-N-paths, with no fromJSON indexing and no
+      "did I add enough slots" step of its own.
+    value: ${{ steps.setup.outputs.cache-1-key }}
+  cache-1-paths:
+    description: Group 1's newline-separated paths, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-1-paths }}
+  cache-2-key:
+    description: Group 2's key, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-2-key }}
+  cache-2-paths:
+    description: Group 2's newline-separated paths, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-2-paths }}
+  cache-3-key:
+    description: Group 3's key, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-3-key }}
+  cache-3-paths:
+    description: Group 3's newline-separated paths, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-3-paths }}
+  cache-4-key:
+    description: Group 4's key, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-4-key }}
+  cache-4-paths:
+    description: Group 4's newline-separated paths, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-4-paths }}
+  cache-overflow:
+    description: >-
+      How many ecosystems did not fit the four slots. The action already warns
+      when this is non-zero, so a workflow does not need a step to check.
+    value: ${{ steps.setup.outputs.cache-overflow }}
 
 runs:
   using: composite
@@ -111,7 +145,35 @@ runs:
             echo "CORGI_ACTION_EOF"
           } >> "$GITHUB_OUTPUT"
           echo "cache-key=$(corgi cache paths --key)" >> "$GITHUB_OUTPUT"
-          echo "cache-groups=$(corgi cache paths --json | jq -c '.groups // []')" >> "$GITHUB_OUTPUT"
+          groups="$(corgi cache paths --json | jq -c '.groups // []')"
+          echo "cache-groups=$groups" >> "$GITHUB_OUTPUT"
+
+          # Four fixed slots as well as the JSON. An Actions expression cannot
+          # loop, and neither can a composite action, so every workflow used to
+          # copy the same cache step four times with fromJSON(...)[i] indexing
+          # plus a hand-written "ran out of slots" warning. The slots keep the
+          # copies but make each one plain, and the warning moves in here.
+          total="$(jq 'length' <<<"$groups")"
+          for i in 1 2 3 4; do
+            key="$(jq -r --argjson i "$i" '.[$i-1].key // ""' <<<"$groups")"
+            echo "cache-$i-key=$key" >> "$GITHUB_OUTPUT"
+            {
+              echo "cache-$i-paths<<CORGI_ACTION_EOF"
+              jq -r --argjson i "$i" '.[$i-1].pathsText // ""' <<<"$groups"
+              echo "CORGI_ACTION_EOF"
+            } >> "$GITHUB_OUTPUT"
+          done
+
+          overflow=$(( total > 4 ? total - 4 : 0 ))
+          echo "cache-overflow=$overflow" >> "$GITHUB_OUTPUT"
+          if [ "$overflow" -gt 0 ]; then
+            echo "::warning::corgi found $total cache groups but the action publishes four slots; $overflow ecosystem(s) will not be cached. Use the cache-groups JSON if you need all of them."
+          fi
         else
           echo "::notice::no corgi-compose.yml in ${{ inputs.working-directory }} yet, so no cache outputs"
+          for i in 1 2 3 4; do
+            echo "cache-$i-key=" >> "$GITHUB_OUTPUT"
+            echo "cache-$i-paths=" >> "$GITHUB_OUTPUT"
+          done
+          echo "cache-overflow=0" >> "$GITHUB_OUTPUT"
         fi

--- a/cmd/beforestart_exit_test.go
+++ b/cmd/beforestart_exit_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+// A run whose setup failed used to report success, so a script could not tell
+// a healthy stack from one missing a service.
+func TestReportBeforeStartFailuresExitsNonZero(t *testing.T) {
+	utils.ResetBeforeStartFailures()
+	t.Cleanup(utils.ResetBeforeStartFailures)
+	utils.RecordBeforeStartFailure("api", errors.New("exit status 127"))
+
+	code, msg := captureExit(t, reportBeforeStartFailures)
+	if code != 1 {
+		t.Errorf("expected exit 1, got %d", code)
+	}
+	if !contains(msg, "api") {
+		t.Errorf("the failing service must be named, got %q", msg)
+	}
+}
+
+func TestReportBeforeStartFailuresIsSilentOnASuccessfulRun(t *testing.T) {
+	utils.ResetBeforeStartFailures()
+	t.Cleanup(utils.ResetBeforeStartFailures)
+
+	code, _ := captureExit(t, reportBeforeStartFailures)
+	if code != 0 {
+		t.Errorf("a clean run must not exit non-zero, got %d", code)
+	}
+}
+
+// The compose watcher and corgi restart re-enter run in the same process.
+// Exiting there would tear down a session the developer is still using.
+func TestReportBeforeStartFailuresDoesNotExitWhileReloading(t *testing.T) {
+	utils.ResetBeforeStartFailures()
+	t.Cleanup(utils.ResetBeforeStartFailures)
+	utils.RecordBeforeStartFailure("api", errors.New("boom"))
+
+	runReloading.Store(true)
+	t.Cleanup(func() { runReloading.Store(false) })
+
+	code, _ := captureExit(t, reportBeforeStartFailures)
+	if code != 0 {
+		t.Errorf("a hot reload must survive a failed beforeStart, got exit %d", code)
+	}
+}
+
+// captureExit swaps the process exit for a recorder, so a path that ends in
+// os.Exit can be asserted instead of killing the test binary.
+func captureExit(t *testing.T, fn func()) (code int, stderr string) {
+	t.Helper()
+	orig := osExit
+	osExit = func(c int) { code = c }
+	t.Cleanup(func() { osExit = orig })
+	stderr = captureStderr(t, fn)
+	return code, stderr
+}

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -85,9 +85,8 @@ func runCachePaths(cmd *cobra.Command, _ []string) {
 	warnCachingIsOff(plan)
 }
 
-// warnCachingIsOff says so when nothing opts in. The plan is still valid — it
-// just saves nothing, and an empty one reads exactly like a workspace that has
-// nothing to cache. Goes to stderr so a command substitution stays clean.
+// warnCachingIsOff distinguishes "nothing opts in" from "nothing to cache".
+// stderr, so a command substitution stays clean.
 func warnCachingIsOff(plan utils.CachePlan) {
 	if len(plan.Groups) > 0 || len(plan.Hints) == 0 {
 		return
@@ -124,8 +123,8 @@ func runGitLabCachePaths(cmd *cobra.Command, plan utils.CachePlan) {
 	fmt.Print(rendered)
 }
 
-// checkGitLabCacheFile is the drift guard. A generated file that is committed
-// is only trustworthy while something fails when it stops matching its source.
+// checkGitLabCacheFile is the drift guard: a committed generated file is only
+// trustworthy while something fails when it stops matching its source.
 func checkGitLabCacheFile(path, rendered string) error {
 	existing, err := os.ReadFile(path)
 	if err != nil {
@@ -143,8 +142,7 @@ func checkGitLabCacheFile(path, rendered string) error {
 			"Regenerate and commit it: corgi cache paths --gitlab --out %s", path, path)
 }
 
-// writeGeneratedFile writes a generated file, creating its directory. Shared
-// with `corgi ci init`, which writes workflow files the same way.
+// writeGeneratedFile writes a generated file, creating its directory.
 func writeGeneratedFile(path, rendered string) error {
 	if dir := filepath.Dir(path); dir != "." && dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -82,6 +82,21 @@ func runCachePaths(cmd *cobra.Command, _ []string) {
 	// Newline-separated, which is the format GitHub's cache action expects for
 	// a multi-line path input.
 	fmt.Println(strings.Join(plan.Paths, "\n"))
+	warnCachingIsOff(plan)
+}
+
+// warnCachingIsOff says so when nothing opts in. The plan is still valid — it
+// just saves nothing, and an empty one reads exactly like a workspace that has
+// nothing to cache. Goes to stderr so a command substitution stays clean.
+func warnCachingIsOff(plan utils.CachePlan) {
+	if len(plan.Groups) > 0 || len(plan.Hints) == 0 {
+		return
+	}
+	utils.Infof("\nNo service declares a beforeStart cacheKey, so every install runs from scratch.\n")
+	utils.Infof("These steps could skip an unchanged install:\n")
+	for _, line := range utils.CacheHintLines(plan.Hints) {
+		utils.Infof("  %s\n", line)
+	}
 }
 
 func runGitLabCachePaths(cmd *cobra.Command, plan utils.CachePlan) {
@@ -99,7 +114,7 @@ func runGitLabCachePaths(cmd *cobra.Command, plan utils.CachePlan) {
 	}
 
 	if outPath, _ := cmd.Flags().GetString("out"); outPath != "" {
-		if err := writeGitLabCacheFile(outPath, rendered); err != nil {
+		if err := writeGeneratedFile(outPath, rendered); err != nil {
 			exitWithError(utils.ErrConfig, err, 1)
 		}
 		utils.Infof("wrote %s\n", outPath)
@@ -128,7 +143,9 @@ func checkGitLabCacheFile(path, rendered string) error {
 			"Regenerate and commit it: corgi cache paths --gitlab --out %s", path, path)
 }
 
-func writeGitLabCacheFile(path, rendered string) error {
+// writeGeneratedFile writes a generated file, creating its directory. Shared
+// with `corgi ci init`, which writes workflow files the same way.
+func writeGeneratedFile(path, rendered string) error {
 	if dir := filepath.Dir(path); dir != "." && dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err

--- a/cmd/cache_test.go
+++ b/cmd/cache_test.go
@@ -51,9 +51,9 @@ func TestCheckGitLabCacheFileExplainsAMissingFile(t *testing.T) {
 }
 
 // --out is what a repo runs once; it has to create .gitlab/ on the way.
-func TestWriteGitLabCacheFileCreatesTheDirectory(t *testing.T) {
+func TestWriteGeneratedFileCreatesTheDirectory(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".gitlab", "corgi-cache.yml")
-	if err := writeGitLabCacheFile(path, "content\n"); err != nil {
+	if err := writeGeneratedFile(path, "content\n"); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(path)
@@ -70,7 +70,7 @@ func TestWriteGitLabCacheFileCreatesTheDirectory(t *testing.T) {
 func TestGitLabCacheWriteThenCheckRoundTrips(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".gitlab", "corgi-cache.yml")
 	rendered := "# generated\n.corgi-cache:\n  cache: []\n"
-	if err := writeGitLabCacheFile(path, rendered); err != nil {
+	if err := writeGeneratedFile(path, rendered); err != nil {
 		t.Fatal(err)
 	}
 	if err := checkGitLabCacheFile(path, rendered); err != nil {

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -1,0 +1,288 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var ciCmd = &cobra.Command{
+	Use:   "ci",
+	Short: "Wire this workspace into a CI pipeline",
+}
+
+var ciInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Write a starter pipeline that boots the whole stack and runs its e2e",
+	Long: `Write the pipeline that boots this compose in CI and runs the stack's e2e
+suite against it, for GitHub Actions or GitLab CI.
+
+The provider is taken from the git remote when --provider is omitted. Existing
+files are never overwritten without --force.
+
+GitHub gets .github/workflows/stack-e2e.yml, which installs corgi through the
+official action and reads the cache plan from its outputs.
+
+GitLab gets .gitlab-ci.yml, which includes corgi's published job template, plus
+.gitlab/corgi-cache.yml generated from this compose — GitLab cannot read the
+plan at runtime, so it is committed and guarded by
+` + "`corgi cache paths --gitlab --check`" + `.
+
+The result is a starting point: it still needs the runner tags, the secrets, and
+the participating repos of this workspace.
+
+Examples:
+  corgi ci init
+  corgi ci init --provider gitlab
+  corgi ci init --provider github --force`,
+	Run: runCIInit,
+}
+
+func init() {
+	rootCmd.AddCommand(ciCmd)
+	ciCmd.AddCommand(ciInitCmd)
+	ciInitCmd.Flags().String("provider", "", "github or gitlab; detected from the git remote when omitted")
+	ciInitCmd.Flags().Bool("force", false, "Overwrite files that already exist")
+}
+
+func runCIInit(cmd *cobra.Command, _ []string) {
+	corgi, err := utils.GetCorgiServices(cmd)
+	if err != nil {
+		exitWithError(utils.ErrConfig, err, 1)
+		return
+	}
+
+	provider, err := resolveCIProvider(cmd)
+	if err != nil {
+		exitWithError(utils.ErrUsage, err, 1)
+		return
+	}
+
+	force, _ := cmd.Flags().GetBool("force")
+	written, err := writeCIFiles(provider, corgi, force)
+	if err != nil {
+		exitWithError(utils.ErrExecFailed, err, 1)
+		return
+	}
+
+	if utils.JSONOutput {
+		utils.PrintJSON(map[string]any{"provider": provider, "written": written})
+		return
+	}
+	for _, f := range written {
+		utils.Infof("wrote %s\n", f)
+	}
+	utils.Info(ciNextSteps(provider, corgi))
+}
+
+// resolveCIProvider prefers the flag, then the origin remote. Guessing wrong
+// would write a pipeline for the wrong forge, so an unknown remote is an error
+// rather than a default.
+func resolveCIProvider(cmd *cobra.Command) (string, error) {
+	flag, _ := cmd.Flags().GetString("provider")
+	switch strings.ToLower(strings.TrimSpace(flag)) {
+	case "github", "gitlab":
+		return strings.ToLower(strings.TrimSpace(flag)), nil
+	case "":
+	default:
+		return "", fmt.Errorf("unknown provider %q; use github or gitlab", flag)
+	}
+
+	remote := gitOriginURL()
+	switch {
+	case strings.Contains(remote, "github.com"):
+		return "github", nil
+	case strings.Contains(remote, "gitlab"):
+		return "gitlab", nil
+	}
+	return "", fmt.Errorf(
+		"could not tell the forge from the git remote (%q) — pass --provider github|gitlab", remote)
+}
+
+// gitOriginURL is overridable in tests.
+var gitOriginURL = func() string {
+	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeCIFiles(provider string, corgi *utils.CorgiCompose, force bool) ([]string, error) {
+	files := map[string]string{}
+	if provider == "github" {
+		files[filepath.Join(".github", "workflows", "stack-e2e.yml")] = githubWorkflowTemplate()
+	} else {
+		files[".gitlab-ci.yml"] = gitlabPipelineTemplate()
+		files[filepath.Join(".gitlab", "corgi-cache.yml")] =
+			utils.GitLabCacheYAML(utils.CachePathsFor(corgi), utils.GitLabCacheOptions{})
+	}
+
+	var written []string
+	for name := range files {
+		path := filepath.Join(utils.CorgiComposePathDir, name)
+		if !force {
+			if _, err := os.Stat(path); err == nil {
+				return nil, fmt.Errorf("%s already exists — pass --force to overwrite it", name)
+			}
+		}
+		if err := writeGeneratedFile(path, files[name]); err != nil {
+			return nil, err
+		}
+		written = append(written, name)
+	}
+	sort.Strings(written)
+	return written, nil
+}
+
+func ciNextSteps(provider string, corgi *utils.CorgiCompose) string {
+	var steps []string
+	if provider == "gitlab" {
+		steps = append(steps,
+			"Set runner_tags to a shell or VM-backed runner. A docker-executor job\n"+
+				"     cannot reach the database containers it starts, and the job will say so.",
+			"Let each service project use this one's CI_JOB_TOKEN\n"+
+				"     (Settings > CI/CD > Job token permissions).",
+			"Commit .gitlab/corgi-cache.yml and regenerate it whenever services change.")
+	} else {
+		steps = append(steps,
+			"Add a token that can clone every service repo, if any are private.",
+			"Call this workflow from each service repo so one branch boots the stack.")
+	}
+	steps = append(steps,
+		"Provide whatever copyEnvFromFilePath points at — those files are\n"+
+			"     gitignored, so no runner has them. corgi doctor names the missing ones.")
+
+	if corgi.E2E == nil {
+		steps = append(steps,
+			"Declare an e2e: block, or drop the `corgi test --e2e` step — there is\n"+
+				"     no stack-level suite in this compose yet.")
+	}
+
+	var b strings.Builder
+	b.WriteString("\nBefore this runs green:\n")
+	for i, step := range steps {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, step)
+	}
+	return b.String()
+}
+
+func githubWorkflowTemplate() string {
+	return `# Boots the whole stack from the branches under review and runs its e2e.
+# Generated by ` + "`corgi ci init`" + `; adapt it to this workspace.
+name: Stack e2e
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: Branch name to look for in every service repo
+        required: true
+        type: string
+  pull_request:
+
+concurrency:
+  group: stack-e2e-${{ github.repository }}-${{ inputs.branch || github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  stack-e2e:
+    # Never jobs.<id>.container: the database containers publish to localhost,
+    # which a containerised job no longer shares.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BRANCH: ${{ inputs.branch || github.head_ref || 'main' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: Andriiklymiuk/corgi@v` + APP_VERSION + `
+        id: corgi
+
+      # Four slots because a workflow expression cannot loop. The action warns
+      # by itself when an ecosystem does not fit.
+      - uses: actions/cache@v4
+        if: steps.corgi.outputs.cache-1-key != ''
+        with:
+          path: ${{ steps.corgi.outputs.cache-1-paths }}
+          key: ${{ steps.corgi.outputs.cache-1-key }}
+      - uses: actions/cache@v4
+        if: steps.corgi.outputs.cache-2-key != ''
+        with:
+          path: ${{ steps.corgi.outputs.cache-2-paths }}
+          key: ${{ steps.corgi.outputs.cache-2-key }}
+      - uses: actions/cache@v4
+        if: steps.corgi.outputs.cache-3-key != ''
+        with:
+          path: ${{ steps.corgi.outputs.cache-3-paths }}
+          key: ${{ steps.corgi.outputs.cache-3-key }}
+      - uses: actions/cache@v4
+        if: steps.corgi.outputs.cache-4-key != ''
+        with:
+          path: ${{ steps.corgi.outputs.cache-4-paths }}
+          key: ${{ steps.corgi.outputs.cache-4-key }}
+
+      - run: corgi init --depth 1 --feature "$BRANCH"
+
+      # Fails in seconds on a missing env file, a busy port or a missing tool,
+      # rather than at the readiness timeout naming the wrong service.
+      - run: corgi doctor
+
+      - run: corgi run --feature "$BRANCH" --detach --wait --wait-timeout 25m --follow
+        timeout-minutes: 30
+
+      - run: corgi status --json
+
+      - run: corgi test --e2e
+
+      - if: always()
+        run: corgi logs --dump ./ci-artifacts/logs || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stack-e2e-${{ github.run_id }}
+          path: ci-artifacts/
+          retention-days: 7
+
+      - if: always()
+        run: corgi stop || true
+`
+}
+
+func gitlabPipelineTemplate() string {
+	return `# Boots the whole stack from the branches under review and runs its e2e.
+# Generated by ` + "`corgi ci init`" + `; adapt it to this workspace.
+include:
+  - remote: https://raw.githubusercontent.com/Andriiklymiuk/corgi/v` + APP_VERSION + `/gitlab/corgi.yml
+    inputs:
+      corgi_version: "` + APP_VERSION + `"
+      # A docker-executor runner cannot reach the database containers it starts.
+      runner_tags: []
+  # Generated: corgi cache paths --gitlab --out .gitlab/corgi-cache.yml
+  - local: .gitlab/corgi-cache.yml
+
+stages:
+  - test
+
+stack-e2e:
+  extends: [.corgi-stack-e2e, .corgi-cache]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+# Without this the committed cache plan silently stops matching the compose.
+corgi-cache-drift:
+  extends: .corgi-setup
+  script:
+    - corgi cache paths --gitlab --check .gitlab/corgi-cache.yml
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+`
+}

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -125,20 +125,30 @@ func writeCIFiles(provider string, corgi *utils.CorgiCompose, force bool) ([]str
 			utils.GitLabCacheYAML(utils.CachePathsFor(corgi), utils.GitLabCacheOptions{})
 	}
 
-	var written []string
+	names := make([]string, 0, len(files))
 	for name := range files {
-		path := filepath.Join(utils.CorgiComposePathDir, name)
-		if !force {
-			if _, err := os.Stat(path); err == nil {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Check every file before writing any: refusing halfway would leave a
+	// pipeline without the cache plan it includes, which is worse than
+	// refusing outright.
+	if !force {
+		for _, name := range names {
+			if _, err := os.Stat(filepath.Join(utils.CorgiComposePathDir, name)); err == nil {
 				return nil, fmt.Errorf("%s already exists — pass --force to overwrite it", name)
 			}
 		}
-		if err := writeGeneratedFile(path, files[name]); err != nil {
+	}
+
+	var written []string
+	for _, name := range names {
+		if err := writeGeneratedFile(filepath.Join(utils.CorgiComposePathDir, name), files[name]); err != nil {
 			return nil, err
 		}
 		written = append(written, name)
 	}
-	sort.Strings(written)
 	return written, nil
 }
 

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -82,9 +82,8 @@ func runCIInit(cmd *cobra.Command, _ []string) {
 	utils.Info(ciNextSteps(provider, corgi))
 }
 
-// resolveCIProvider prefers the flag, then the origin remote. Guessing wrong
-// would write a pipeline for the wrong forge, so an unknown remote is an error
-// rather than a default.
+// resolveCIProvider prefers the flag, then the origin remote. An unknown
+// remote is an error: the wrong forge's pipeline is silently useless.
 func resolveCIProvider(cmd *cobra.Command) (string, error) {
 	flag, _ := cmd.Flags().GetString("provider")
 	switch strings.ToLower(strings.TrimSpace(flag)) {
@@ -131,9 +130,8 @@ func writeCIFiles(provider string, corgi *utils.CorgiCompose, force bool) ([]str
 	}
 	sort.Strings(names)
 
-	// Check every file before writing any: refusing halfway would leave a
-	// pipeline without the cache plan it includes, which is worse than
-	// refusing outright.
+	// Check all before writing any: refusing halfway leaves a pipeline
+	// without the cache plan it includes.
 	if !force {
 		for _, name := range names {
 			if _, err := os.Stat(filepath.Join(utils.CorgiComposePathDir, name)); err == nil {
@@ -216,8 +214,8 @@ jobs:
       - uses: Andriiklymiuk/corgi@v` + APP_VERSION + `
         id: corgi
 
-      # Four slots because a workflow expression cannot loop. The action warns
-      # by itself when an ecosystem does not fit.
+      # Four slots because a workflow expression cannot loop; the action
+      # warns by itself when an ecosystem does not fit.
       - uses: actions/cache@v4
         if: steps.corgi.outputs.cache-1-key != ''
         with:
@@ -241,8 +239,7 @@ jobs:
 
       - run: corgi init --depth 1 --feature "$BRANCH"
 
-      # Fails in seconds on a missing env file, a busy port or a missing tool,
-      # rather than at the readiness timeout naming the wrong service.
+      # Fails in seconds on a missing env file, busy port or missing tool.
       - run: corgi doctor
 
       - run: corgi run --feature "$BRANCH" --detach --wait --wait-timeout 25m --follow

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -147,3 +147,23 @@ func assertParsesAsYAML(t *testing.T, path string) {
 		t.Fatalf("%s does not parse: %v", path, err)
 	}
 }
+
+// Refusing halfway would leave .gitlab-ci.yml behind without the cache plan it
+// includes, which is a broken pipeline rather than a refused one.
+func TestCIInitWritesNothingWhenOneFileExists(t *testing.T) {
+	dir := withComposeDir(t)
+	if err := writeGeneratedFile(filepath.Join(dir, ".gitlab", "corgi-cache.yml"), "old\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := writeCIFiles("gitlab", &utils.CorgiCompose{}, false); err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gitlab-ci.yml")); err == nil {
+		t.Error(".gitlab-ci.yml must not be written when the run is refused")
+	}
+	existing, err := os.ReadFile(filepath.Join(dir, ".gitlab", "corgi-cache.yml"))
+	if err != nil || string(existing) != "old\n" {
+		t.Errorf("the existing file must be untouched, got %q / %v", existing, err)
+	}
+}

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func withComposeDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() { utils.CorgiComposePathDir = orig })
+	return dir
+}
+
+func providerCmd(t *testing.T, flag string) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "init"}
+	c.Flags().String("provider", "", "")
+	if flag != "" {
+		if err := c.Flags().Set("provider", flag); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return c
+}
+
+func TestResolveCIProviderPrefersTheFlag(t *testing.T) {
+	origin := gitOriginURL
+	gitOriginURL = func() string { return "git@github.com:o/r.git" }
+	t.Cleanup(func() { gitOriginURL = origin })
+
+	got, err := resolveCIProvider(providerCmd(t, "gitlab"))
+	if err != nil || got != "gitlab" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+
+func TestResolveCIProviderReadsTheRemote(t *testing.T) {
+	cases := map[string]string{
+		"git@github.com:o/r.git":          "github",
+		"https://gitlab.com/g/p.git":      "gitlab",
+		"https://gitlab.internal/g/p.git": "gitlab",
+	}
+	for remote, want := range cases {
+		origin := gitOriginURL
+		gitOriginURL = func() string { return remote }
+		got, err := resolveCIProvider(providerCmd(t, ""))
+		gitOriginURL = origin
+		if err != nil || got != want {
+			t.Errorf("%s: got %q, %v", remote, got, err)
+		}
+	}
+}
+
+// Writing a GitHub workflow into a GitLab project would be silently useless,
+// so an unrecognised remote asks rather than guesses.
+func TestResolveCIProviderRefusesToGuess(t *testing.T) {
+	origin := gitOriginURL
+	gitOriginURL = func() string { return "https://bitbucket.org/o/r.git" }
+	t.Cleanup(func() { gitOriginURL = origin })
+
+	if _, err := resolveCIProvider(providerCmd(t, "")); err == nil {
+		t.Error("expected an error for an unknown forge")
+	}
+}
+
+func TestResolveCIProviderRejectsAnUnknownFlag(t *testing.T) {
+	if _, err := resolveCIProvider(providerCmd(t, "bitbucket")); err == nil {
+		t.Error("expected an error for an unsupported provider")
+	}
+}
+
+func TestCIInitWritesTheGitHubWorkflow(t *testing.T) {
+	dir := withComposeDir(t)
+	written, err := writeCIFiles("github", &utils.CorgiCompose{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 1 {
+		t.Fatalf("expected one file, got %v", written)
+	}
+	assertParsesAsYAML(t, filepath.Join(dir, written[0]))
+}
+
+// GitLab needs the committed cache plan alongside the pipeline, because it
+// cannot read the plan at runtime.
+func TestCIInitWritesThePipelineAndTheCachePlan(t *testing.T) {
+	dir := withComposeDir(t)
+	written, err := writeCIFiles("gitlab", &utils.CorgiCompose{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 2 {
+		t.Fatalf("expected the pipeline and the cache plan, got %v", written)
+	}
+	for _, name := range written {
+		assertParsesAsYAML(t, filepath.Join(dir, name))
+	}
+	cache, err := os.ReadFile(filepath.Join(dir, ".gitlab", "corgi-cache.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(string(cache), ".corgi-cache:") {
+		t.Errorf("expected the generated cache template:\n%s", cache)
+	}
+}
+
+// Overwriting a pipeline someone has been editing is not recoverable from the
+// CLI, so it takes an explicit flag.
+func TestCIInitRefusesToOverwrite(t *testing.T) {
+	withComposeDir(t)
+	if _, err := writeCIFiles("github", &utils.CorgiCompose{}, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeCIFiles("github", &utils.CorgiCompose{}, false); err == nil {
+		t.Fatal("expected a refusal on the second write")
+	}
+	if _, err := writeCIFiles("github", &utils.CorgiCompose{}, true); err != nil {
+		t.Errorf("--force must overwrite, got %v", err)
+	}
+}
+
+// A compose with no e2e: block would fail on the `corgi test --e2e` step, and
+// the generated pipeline should say so rather than let it be discovered in CI.
+func TestCINextStepsCallsOutAMissingE2EBlock(t *testing.T) {
+	if !contains(ciNextSteps("github", &utils.CorgiCompose{}), "e2e:") {
+		t.Error("expected the missing e2e block to be mentioned")
+	}
+}
+
+func assertParsesAsYAML(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out any
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("%s does not parse: %v", path, err)
+	}
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -308,9 +308,8 @@ func buildDoctorResult(corgi *utils.CorgiCompose) doctorResult {
 	return res
 }
 
-// ciChecks catch what is always a bug on a runner but a normal half-configured
-// state on a laptop, so they only report in CI. Both would otherwise surface
-// twenty minutes into a boot, naming a service that is not the cause.
+// ciChecks catch what is always a bug on a runner but normal mid-setup on a
+// laptop, so they only report in CI.
 func ciChecks(corgi *utils.CorgiCompose) []doctorCheck {
 	if !utils.CIMode {
 		return nil
@@ -341,9 +340,7 @@ func ciChecks(corgi *utils.CorgiCompose) []doctorCheck {
 	return checks
 }
 
-// diskHeadroomCheck reports only when the platform can answer. Running out of
-// disk mid-boot surfaces as a random service failing to build, never as a disk
-// message, so it is worth the two seconds here.
+// diskHeadroomCheck stays silent when the platform cannot answer.
 func diskHeadroomCheck(corgi *utils.CorgiCompose) (doctorCheck, bool) {
 	need, free, ok, known := utils.DiskHeadroom(corgi, utils.CorgiComposePathDir)
 	if !known {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -327,6 +327,10 @@ func ciChecks(corgi *utils.CorgiCompose) []doctorCheck {
 		checks = append(checks, c)
 	}
 
+	if c, report := diskHeadroomCheck(corgi); report {
+		checks = append(checks, c)
+	}
+
 	for _, m := range utils.MissingEnvSources(corgi) {
 		detail := fmt.Sprintf("declares copyEnvFromFilePath %s, which is not on this runner", m.Declared)
 		if m.Fallback != "" {
@@ -335,6 +339,25 @@ func ciChecks(corgi *utils.CorgiCompose) []doctorCheck {
 		checks = append(checks, doctorCheck{Name: "ci:env:" + m.Service, OK: false, Detail: detail})
 	}
 	return checks
+}
+
+// diskHeadroomCheck reports only when the platform can answer. Running out of
+// disk mid-boot surfaces as a random service failing to build, never as a disk
+// message, so it is worth the two seconds here.
+func diskHeadroomCheck(corgi *utils.CorgiCompose) (doctorCheck, bool) {
+	need, free, ok, known := utils.DiskHeadroom(corgi, utils.CorgiComposePathDir)
+	if !known {
+		return doctorCheck{}, false
+	}
+	c := doctorCheck{Name: "ci:disk", OK: ok}
+	if !ok {
+		c.Detail = fmt.Sprintf(
+			"%s free, and this stack needs roughly %s (%d databases, %d services) — "+
+				"free space before booting, or the failure will look like a broken build",
+			utils.FormatGigabytes(free), utils.FormatGigabytes(need),
+			len(corgi.DatabaseServices), len(corgi.Services))
+	}
+	return c, true
 }
 
 func printCIChecks(corgi *utils.CorgiCompose) bool {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -584,11 +584,17 @@ func TestCIChecksReportAMissingEnvSource(t *testing.T) {
 	checks := ciChecks(&utils.CorgiCompose{
 		Services: []utils.Service{{ServiceName: "api", Path: "./api", CopyEnvFromFilePath: "env/api.env"}},
 	})
-	if len(checks) != 1 {
+	var env *doctorCheck
+	for i := range checks {
+		if checks[i].Name == "ci:env:api" {
+			env = &checks[i]
+		}
+	}
+	if env == nil {
 		t.Fatalf("expected the env check, got %+v", checks)
 	}
-	if checks[0].Name != "ci:env:api" || checks[0].OK {
-		t.Errorf("unexpected check: %+v", checks[0])
+	if env.OK {
+		t.Errorf("a missing env source must fail: %+v", *env)
 	}
 }
 

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -7,6 +7,10 @@ import (
 	"andriiklymiuk/corgi/utils"
 )
 
+// osExit is overridable so the exit paths can be asserted in tests. Nothing
+// else should replace it.
+var osExit = os.Exit
+
 // exitWithError reports err as JSON (with jsonCode) or on stderr, then exits.
 func exitWithError(jsonCode string, err error, exitCode int) {
 	exitWithErrorPrefix(jsonCode, "", err, exitCode)
@@ -20,5 +24,5 @@ func exitWithErrorPrefix(jsonCode, stderrPrefix string, err error, exitCode int)
 	} else {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	os.Exit(exitCode)
+	osExit(exitCode)
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -259,6 +259,52 @@ func serveMCPStdio(s *server.MCPServer) {
 	}
 }
 
+// resolveDeviceStore returns the store to authenticate against, or "" when
+// pairing is not in play — it is otherwise always a valid path, which would
+// defeat bearerAuth's no-auth escape.
+func resolveDeviceStore(opts mcpHTTPOpts) string {
+	if opts.insecure {
+		return ""
+	}
+	dir, err := agentDir()
+	if err != nil {
+		return ""
+	}
+	path := pairing.StorePath(dir)
+	switch pairing.InspectStore(path) {
+	case pairing.StoreHasDevices:
+		return path
+	case pairing.StoreUnreadable:
+		// Refuse rather than serve: silently continuing would drop back to
+		// whatever auth remains, and with no --token that is none at all — an
+		// unreadable file would reopen corgi_exec to anyone.
+		fmt.Fprintf(os.Stderr,
+			"corgi mcp: cannot read the paired-device store at %s.\n"+
+				"Fix its permissions (chmod 600) or remove it to start over; refusing to serve in the meantime.\n", path)
+		os.Exit(1)
+	case pairing.StoreEmpty:
+		if opts.pair {
+			return path
+		}
+	}
+	return ""
+}
+
+// announceMCPAuth says what a client will need to connect.
+func announceMCPAuth(token, deviceStore string) {
+	switch {
+	case token == "" && deviceStore != "":
+		// Paired devices make this endpoint authenticated even with no server
+		// token, which also means any existing tokenless client stops working.
+		fmt.Fprintln(os.Stderr, "corgi mcp --http requires a paired device token (see `corgi mcp devices`).")
+		fmt.Fprintln(os.Stderr, "Tokenless clients will be rejected; pass --token to keep one working, or --insecure for no auth.")
+	case token == "":
+		fmt.Fprintln(os.Stderr, "⚠️  corgi mcp --http has no auth; bind to localhost or put it behind an authenticated proxy.")
+	default:
+		fmt.Fprintf(os.Stderr, "corgi mcp bearer token: %s\n", token)
+	}
+}
+
 func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 	httpSrv := server.NewStreamableHTTPServer(s)
 
@@ -266,28 +312,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 	// otherwise always a valid path, which would defeat bearerAuth's no-auth
 	// escape and make `corgi mcp --http` (and --insecure) reject every request
 	// with no credential in existence to fix it.
-	deviceStore := ""
-	if !opts.insecure {
-		if dir, err := agentDir(); err == nil {
-			path := pairing.StorePath(dir)
-			switch pairing.InspectStore(path) {
-			case pairing.StoreHasDevices:
-				deviceStore = path
-			case pairing.StoreUnreadable:
-				// Refuse rather than serve: silently continuing would drop back
-				// to whatever auth remains, and with no --token that is none at
-				// all — an unreadable file would reopen corgi_exec to anyone.
-				fmt.Fprintf(os.Stderr,
-					"corgi mcp: cannot read the paired-device store at %s.\n"+
-						"Fix its permissions (chmod 600) or remove it to start over; refusing to serve in the meantime.\n", path)
-				os.Exit(1)
-			case pairing.StoreEmpty:
-				if opts.pair {
-					deviceStore = path
-				}
-			}
-		}
-	}
+	deviceStore := resolveDeviceStore(opts)
 
 	// Only /mcp is behind the bearer check; other paths 404.
 	mux := http.NewServeMux()
@@ -318,17 +343,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 
 	srv := &http.Server{Addr: addr, Handler: mux}
 
-	switch {
-	case token == "" && deviceStore != "":
-		// Paired devices make this endpoint authenticated even with no server
-		// token, which also means any existing tokenless client stops working.
-		fmt.Fprintln(os.Stderr, "corgi mcp --http requires a paired device token (see `corgi mcp devices`).")
-		fmt.Fprintln(os.Stderr, "Tokenless clients will be rejected; pass --token to keep one working, or --insecure for no auth.")
-	case token == "":
-		fmt.Fprintln(os.Stderr, "⚠️  corgi mcp --http has no auth; bind to localhost or put it behind an authenticated proxy.")
-	default:
-		fmt.Fprintf(os.Stderr, "corgi mcp bearer token: %s\n", token)
-	}
+	announceMCPAuth(token, deviceStore)
 	fmt.Fprintf(os.Stderr, "corgi mcp serving Streamable HTTP on %s/mcp\n", addr)
 	printMCPClientConfig(os.Stderr, "http://"+localURL(addr)+"/mcp", token)
 	if pairSession != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -601,6 +601,7 @@ func runRun(cmd *cobra.Command, _ []string) {
 
 	if detach {
 		runDetached(cmd, corgi)
+		reportBeforeStartFailures()
 		return
 	}
 
@@ -616,6 +617,27 @@ func runRun(cmd *cobra.Command, _ []string) {
 		utils.PrintJSON(buildRunSummary(corgi))
 	}
 	startAllServices(corgi, cmd)
+	reportBeforeStartFailures()
+}
+
+// reportBeforeStartFailures makes a run whose setup failed exit non-zero.
+//
+// corgi deliberately keeps going when one service's beforeStart fails, so the
+// rest of the stack still comes up — that stays. What changes is the exit
+// status: a scripted `corgi run` used to report success while a service was
+// silently missing. --wait already fails earlier and more precisely, so this
+// only covers the paths that do not wait.
+func reportBeforeStartFailures() {
+	// The compose watcher and `corgi restart` re-enter run in the same process;
+	// exiting there would kill a session the user is still using.
+	if runReloading.Load() {
+		return
+	}
+	err := utils.BeforeStartFailureError()
+	if err == nil {
+		return
+	}
+	exitWithErrorPrefix(utils.ErrExecFailed, "❌", err, 1)
 }
 
 func loadRunCompose(cmd *cobra.Command) *utils.CorgiCompose {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -620,16 +620,11 @@ func runRun(cmd *cobra.Command, _ []string) {
 	reportBeforeStartFailures()
 }
 
-// reportBeforeStartFailures makes a run whose setup failed exit non-zero.
-//
-// corgi deliberately keeps going when one service's beforeStart fails, so the
-// rest of the stack still comes up — that stays. What changes is the exit
-// status: a scripted `corgi run` used to report success while a service was
-// silently missing. --wait already fails earlier and more precisely, so this
-// only covers the paths that do not wait.
+// reportBeforeStartFailures makes a run whose setup failed exit non-zero. The
+// rest of the stack still comes up; only the status changes. --wait already
+// fails earlier, so this covers the paths that do not wait.
 func reportBeforeStartFailures() {
-	// The compose watcher and `corgi restart` re-enter run in the same process;
-	// exiting there would kill a session the user is still using.
+	// The watcher and `corgi restart` re-enter run in the same process.
 	if runReloading.Load() {
 		return
 	}

--- a/gitlab/corgi.yml
+++ b/gitlab/corgi.yml
@@ -124,14 +124,6 @@ spec:
     # have, a containerised job, a missing required tool, a busy port.
     - corgi doctor
     - corgi run --feature "$CORGI_BRANCH" --detach --wait --wait-timeout $[[ inputs.wait_timeout ]] --follow
-    # corgi prints "aborting beforeStart for <service>" and keeps going, so a
-    # dead service otherwise reads as a slow boot with the cause thousands of
-    # lines earlier.
-    - |
-      if grep -rh "aborting beforeStart" corgi_services/.logs/ 2>/dev/null; then
-        echo "corgi: a beforeStart step failed, so at least one service never started" >&2
-        exit 1
-      fi
     - corgi status --json
     - corgi test --e2e --artifacts-dir "$CI_PROJECT_DIR/$CORGI_ARTIFACTS/e2e"
   after_script:

--- a/plugins/corgi/commands/corgi-ci.md
+++ b/plugins/corgi/commands/corgi-ci.md
@@ -4,6 +4,11 @@ description: Build (or fix) a CI job that boots the whole corgi stack and runs c
 
 Run the corgi **ci** flow for the request in `$ARGUMENTS`.
 
+Empty or "set it up" → scaffold with `corgi ci init`, then do the wiring the
+generated file cannot know (secrets, participating repos, `cacheKey:` on the
+install steps, an `e2e:` block, and on GitLab the runner tag + job-token
+permissions). Show the files before committing.
+
 - `$ARGUMENTS` = plain-words description (which CI provider, which repos take part,
   blocking gate or report-only, an existing job that misbehaves). Empty → generate
   a full-stack e2e pipeline for this workspace.

--- a/plugins/corgi/skills/ci/SKILL.md
+++ b/plugins/corgi/skills/ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci
-description: Use when the user wants the whole corgi stack running inside CI, or end-to-end tests that span several repos — "run the stack in CI", "e2e across repos", "test the api + web branches together", "full-stack e2e on the PR", "GitHub Actions/GitLab CI for the whole stack", "why does each repo's CI pass but the combination break", "cross-repo integration test". Generates the pipeline (GitHub Actions or GitLab CI), wires per-repo PRs into one full-stack run via a shared branch name, gates on health, and always uploads logs + screenshots. NOT for authoring corgi-compose.yml (corgi skill), starting a stack locally (run skill), diagnosing an already-broken stack (debug skill), or reviewing PRs (review skill).
+description: Use when the user wants the whole corgi stack running inside CI, or end-to-end tests that span several repos — "set up CI for this workspace", "add CI", "init the pipeline", "wire this up to GitHub Actions/GitLab CI", "run the stack in CI", "e2e across repos", "test the api + web branches together", "full-stack e2e on the PR", "why does each repo's CI pass but the combination break", "cross-repo integration test". Asking in chat is the whole interface: this scaffolds with `corgi ci init` and then does the workspace-specific wiring the generated file cannot know. Generates the pipeline (GitHub Actions or GitLab CI), wires per-repo PRs into one full-stack run via a shared branch name, gates on health, and always uploads logs + screenshots. NOT for authoring corgi-compose.yml (corgi skill), starting a stack locally (run skill), diagnosing an already-broken stack (debug skill), or reviewing PRs (review skill).
 ---
 
 # Corgi in CI
@@ -9,6 +9,30 @@ Each repo's own pipeline proves that repo. A change spanning repos — a schema
 field, a new event, a template the frontend reads — leaves every pipeline green
 while the combination is broken. This skill builds the job that boots the whole
 stack from the branches under review and drives real e2e against it.
+
+## Setting it up from chat
+
+"Set up CI for this workspace" is the whole request. Do this, in order:
+
+1. **`corgi ci init`** — scaffolds the pipeline for the forge in the git remote
+   (`--provider github|gitlab` to force it, `--force` to replace an existing
+   file). GitHub gets `.github/workflows/stack-e2e.yml`; GitLab gets
+   `.gitlab-ci.yml` plus the generated `.gitlab/corgi-cache.yml`. It prints what
+   the workspace still owes.
+2. **Then do the wiring it cannot know**, which is the rest of this skill:
+   - where the secrets come from (`copyEnvFromFilePath` — see below, it is the
+     usual reason a first run never boots)
+   - which repos take part, and the branch-name convention
+   - `cacheKey:` on each install step — run `corgi cache paths`, it names the
+     steps that could opt in and the lockfile for each
+   - an `e2e:` block if the compose has none, or drop the `corgi test --e2e` step
+   - GitLab only: a shell or VM-backed runner tag, and job-token permissions
+     between the projects
+3. **Show the generated files and the edits before committing**, and say what a
+   run will cost (wall clock, and that every participating PR triggers it).
+
+If the workspace predates `corgi ci init` (< 1.20.32), write the files by hand
+from `references/github-actions.md` / `references/gitlab-ci.md` instead.
 
 ## Before writing anything
 

--- a/plugins/corgi/skills/ci/SKILL.md
+++ b/plugins/corgi/skills/ci/SKILL.md
@@ -76,14 +76,13 @@ the service against a committed `.env-example` whose placeholder values fail at
 the first request, thousands of lines from the cause. Both cost twenty minutes
 each time they are found the hard way.
 
-**corgi does not fail when a `beforeStart` fails.** It prints `aborting
-beforeStart for <service>` and carries on, so a dead service reads as a slow boot
-until the readiness timeout, with the cause thousands of lines earlier. Grep for
-it and fail loudly:
-
-```bash
-grep -rh "aborting beforeStart" corgi_services/.logs/ && exit 1
-```
+**A failed `beforeStart` fails the run — do not grep the logs for it.** corgi
+still lets the rest of the stack come up, but `corgi run --wait` returns the
+failure immediately instead of waiting out the readiness timeout, and a run
+without `--wait` now exits non-zero. Older pipelines carry a
+`grep -rh "aborting beforeStart" corgi_services/.logs/ && exit 1` step from
+when that was not true; it can never fire after `--wait` and should be deleted.
+Requires corgi ≥ 1.20.10 for the `--wait` half, ≥ 1.20.32 for the exit status.
 
 **A compose that works on macOS can die on Linux.** `/bin/sh` is bash-like on
 macOS and dash on Linux (fixed in corgi 1.20.9, which prefers bash — but a repo
@@ -123,7 +122,10 @@ you pay every install every time — do not read early runs as the steady state.
   wait — `beforeStart` (installs, migrations, builds) runs before that timer
   starts and is unbounded. Put a `timeout-minutes` on the step too, or a slow
   boot quietly eats the whole job.
-- **Free disk before booting** on hosted runners. A full stack is several GB of
+- **`corgi doctor` checks disk headroom in CI** — it compares free space with a
+  rough estimate from the database and service counts, because running out
+  mid-boot surfaces as a random service failing to build, never as a disk
+  message. Free disk before booting on hosted runners. A full stack is several GB of
   images plus every service's dependencies; hosted runners are provisioned tighter
   than that, and the failure mode when it runs out is unrecognisable as a disk
   problem.
@@ -138,7 +140,17 @@ so it cannot drift as services come and go. `--key` prints the matching cache ke
 `--json` splits the plan per ecosystem (`groups: [{id, key, paths, pathsText}]`)
 so one lockfile change doesn't evict every other language's packages. On GitHub
 the `Andriiklymiuk/corgi@v1` action exposes all of this as step outputs
-(`cache-paths`, `cache-key`, `cache-groups`) ready to feed `actions/cache`.
+(`cache-paths`, `cache-key`, `cache-groups`) ready to feed `actions/cache`, plus
+four fixed slots (`cache-1-key`/`cache-1-paths` … `cache-4-*`) so a workflow
+writes four plain cache steps instead of `fromJSON(...)[i]` indexing. Neither a
+workflow expression nor a composite action can loop, so the copies stay — but
+the action warns by itself when an ecosystem does not fit, which used to be a
+hand-written step.
+
+**`corgi cache paths` now says when caching is off.** A workspace where no
+service declares a `cacheKey` gets a list of the install steps that could opt
+in, on stderr, naming the lockfile for each. Silence used to be the only signal
+that every CI run was reinstalling everything.
 
 GitLab cannot read the plan mid-run — its cache config is static YAML — so
 generate it, commit it, and guard it:
@@ -194,6 +206,14 @@ corgi already detects `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`,
 `BITBUCKET_BUILD_NUMBER`, `CODEBUILD_BUILD_ID` — no `--ci` flag needed.
 
 ## Writing the pipeline
+
+**`corgi ci init` writes the starting point.** It picks the forge from the git
+remote (`--provider github|gitlab` to force it), writes
+`.github/workflows/stack-e2e.yml` or `.gitlab-ci.yml` +
+`.gitlab/corgi-cache.yml`, refuses to clobber an existing file without
+`--force`, and prints what the workspace still has to supply — runner tags,
+the clone token, the env files, and an `e2e:` block when the compose has none.
+Start there, then adapt; the references below are what it generates.
 
 Generate into the workspace repo, then a thin caller per service repo. Templates:
 `references/github-actions.md`, `references/gitlab-ci.md`. On GitHub the install

--- a/plugins/corgi/skills/ci/references/github-actions.md
+++ b/plugins/corgi/skills/ci/references/github-actions.md
@@ -20,7 +20,7 @@ on:
       corgi-version:
         required: false
         type: string
-        default: "1.20.17"   # ≥1.20.13 for test --e2e / cache paths; ≥1.20.17 for cache-groups
+        default: "1.20.32"   # ≥1.20.13 test --e2e; ≥1.20.31 gitlab template; ≥1.20.32 cache slots + ci init
     secrets:
       REPO_TOKEN:
         required: true
@@ -56,7 +56,7 @@ jobs:
 
       # The plan covers each service's dependency dir + corgi_services/.cache
       # (the beforeStart skip markers). On a polyglot stack, prefer one
-      # actions/cache step per entry of steps.corgi.outputs.cache-groups so one
+      # actions/cache step per slot (cache-1-key/paths … cache-4-key/paths) so one
       # lockfile change doesn't evict every other language's packages.
       - name: Restore dependency caches
         uses: actions/cache@v4

--- a/plugins/corgi/skills/ci/references/gitlab-ci.md
+++ b/plugins/corgi/skills/ci/references/gitlab-ci.md
@@ -45,7 +45,7 @@ corgi-cache-drift:
 ```
 
 `.corgi-stack-e2e` already does: `corgi init --depth 1 --feature`, `corgi run
---detach --wait --follow`, the `aborting beforeStart` grep, `corgi status
+--detach --wait --follow` (which fails on its own if a beforeStart did), `corgi status
 --json`, `corgi test --e2e --artifacts-dir`, and an always-executed `corgi logs
 --dump` + artifact upload. Do not re-write those steps; override an input.
 

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -193,6 +193,9 @@ func (d *Daemon) Run(ctx context.Context, configs []supervisor.SpawnConfig) erro
 	// after the cleanup defer so it runs first: stop publishing, wait, then
 	// remove.
 	publishCtx, stopPublishing := context.WithCancel(ctx)
+	// Paired with the context so a later early return cannot skip it; the
+	// ordered stop-then-wait below still does the real work.
+	defer stopPublishing()
 	publishDone := make(chan struct{})
 	go func() {
 		defer close(publishDone)

--- a/utils/agent/supervisor/spawn.go
+++ b/utils/agent/supervisor/spawn.go
@@ -81,47 +81,18 @@ var validSpawnModes = map[string]bool{
 // ValidateSpawnConfig rejects a configuration before anything is launched, so a
 // bad setting fails at startup with a clear message instead of on first use.
 func ValidateSpawnConfig(c SpawnConfig) error {
-	if c.WorkspaceID == "" {
-		return fmt.Errorf("workspace id is required")
-	}
-	if c.Dir == "" {
-		return fmt.Errorf("workspace %s: directory is required", c.WorkspaceID)
-	}
-	if !filepath.IsAbs(c.Dir) {
-		return fmt.Errorf("workspace %s: directory must be absolute, got %q", c.WorkspaceID, c.Dir)
+	if err := validateSpawnIdentity(c); err != nil {
+		return err
 	}
 	kind, err := KindFor(c)
 	if err != nil {
 		return fmt.Errorf("workspace %s: %w", c.WorkspaceID, err)
 	}
-	if mode := normalize(c.PermissionMode); mode != "" {
-		if forbiddenPermissionModes[mode] {
-			return fmt.Errorf(
-				"workspace %s: permissionMode %q is not allowed for a supervised session — "+
-					"permission prompts are what you answer from your phone",
-				c.WorkspaceID, c.PermissionMode)
-		}
-		if !kind.SupportsPermissionMode {
-			return fmt.Errorf(
-				"workspace %s: kind %q does not take permissionMode — put the flag in args: instead, "+
-					"so the setting is the one this CLI actually understands",
-				c.WorkspaceID, kind.Name)
-		}
-		if !validPermissionModes[mode] {
-			return fmt.Errorf("workspace %s: unknown permissionMode %q (want %s)",
-				c.WorkspaceID, c.PermissionMode, sortedKeys(validPermissionModes))
-		}
+	if err := validatePermissionMode(c, kind); err != nil {
+		return err
 	}
-	if s := strings.ToLower(strings.TrimSpace(c.Spawn)); s != "" {
-		if !kind.SupportsSpawn {
-			return fmt.Errorf(
-				"workspace %s: kind %q does not take spawn — put the flag in args: instead",
-				c.WorkspaceID, kind.Name)
-		}
-		if !validSpawnModes[s] {
-			return fmt.Errorf("workspace %s: unknown spawn mode %q (want %s)",
-				c.WorkspaceID, c.Spawn, sortedKeys(validSpawnModes))
-		}
+	if err := validateSpawnMode(c, kind); err != nil {
+		return err
 	}
 	if c.Capacity < 0 {
 		return fmt.Errorf("workspace %s: capacity cannot be negative", c.WorkspaceID)
@@ -134,26 +105,8 @@ func ValidateSpawnConfig(c SpawnConfig) error {
 	if _, err := kind.Args(c); err != nil {
 		return fmt.Errorf("workspace %s: %w", c.WorkspaceID, err)
 	}
-	// Same rule as spawn and permissionMode above: a setting that cannot take
-	// effect is an error rather than a silent no-op. A `capacity: 4` that
-	// quietly does nothing reads as a limit that is being applied.
-	if kind.BuildsArgvFromSettings {
-		if c.ConfigDirEnv != "" || len(c.CredentialEnv) > 0 {
-			return fmt.Errorf(
-				"workspace %s: configDirEnv and credentialEnv are only for kind %q — "+
-					"kind %q already knows its own",
-				c.WorkspaceID, KindCustom, kind.Name)
-		}
-		if len(c.Args) > 0 {
-			return fmt.Errorf(
-				"workspace %s: args is only for kind %q — kind %q builds its own argv from "+
-					"spawn, capacity and permissionMode",
-				c.WorkspaceID, KindCustom, kind.Name)
-		}
-	} else if c.Capacity > 0 {
-		return fmt.Errorf(
-			"workspace %s: kind %q does not take capacity — put the flag in args: instead",
-			c.WorkspaceID, kind.Name)
+	if err := validateKindOwnedSettings(c, kind); err != nil {
+		return err
 	}
 	if c.ConfigDir != "" && kind.ConfigDirEnv == "" {
 		return fmt.Errorf(
@@ -164,6 +117,86 @@ func ValidateSpawnConfig(c SpawnConfig) error {
 	if c.WakeLock != "" && !ValidWakeLockMode(c.WakeLock) {
 		return fmt.Errorf("workspace %s: unknown wakeLock %q (want always, off, session)",
 			c.WorkspaceID, c.WakeLock)
+	}
+	return nil
+}
+
+func validateSpawnIdentity(c SpawnConfig) error {
+	if c.WorkspaceID == "" {
+		return fmt.Errorf("workspace id is required")
+	}
+	if c.Dir == "" {
+		return fmt.Errorf("workspace %s: directory is required", c.WorkspaceID)
+	}
+	if !filepath.IsAbs(c.Dir) {
+		return fmt.Errorf("workspace %s: directory must be absolute, got %q", c.WorkspaceID, c.Dir)
+	}
+	return nil
+}
+
+func validatePermissionMode(c SpawnConfig, kind Kind) error {
+	mode := normalize(c.PermissionMode)
+	if mode == "" {
+		return nil
+	}
+	if forbiddenPermissionModes[mode] {
+		return fmt.Errorf(
+			"workspace %s: permissionMode %q is not allowed for a supervised session — "+
+				"permission prompts are what you answer from your phone",
+			c.WorkspaceID, c.PermissionMode)
+	}
+	if !kind.SupportsPermissionMode {
+		return fmt.Errorf(
+			"workspace %s: kind %q does not take permissionMode — put the flag in args: instead, "+
+				"so the setting is the one this CLI actually understands",
+			c.WorkspaceID, kind.Name)
+	}
+	if !validPermissionModes[mode] {
+		return fmt.Errorf("workspace %s: unknown permissionMode %q (want %s)",
+			c.WorkspaceID, c.PermissionMode, sortedKeys(validPermissionModes))
+	}
+	return nil
+}
+
+func validateSpawnMode(c SpawnConfig, kind Kind) error {
+	s := strings.ToLower(strings.TrimSpace(c.Spawn))
+	if s == "" {
+		return nil
+	}
+	if !kind.SupportsSpawn {
+		return fmt.Errorf(
+			"workspace %s: kind %q does not take spawn — put the flag in args: instead",
+			c.WorkspaceID, kind.Name)
+	}
+	if !validSpawnModes[s] {
+		return fmt.Errorf("workspace %s: unknown spawn mode %q (want %s)",
+			c.WorkspaceID, c.Spawn, sortedKeys(validSpawnModes))
+	}
+	return nil
+}
+
+// validateKindOwnedSettings rejects settings a kind builds itself: a
+// `capacity: 4` that quietly does nothing reads as a limit being applied.
+func validateKindOwnedSettings(c SpawnConfig, kind Kind) error {
+	if !kind.BuildsArgvFromSettings {
+		if c.Capacity > 0 {
+			return fmt.Errorf(
+				"workspace %s: kind %q does not take capacity — put the flag in args: instead",
+				c.WorkspaceID, kind.Name)
+		}
+		return nil
+	}
+	if c.ConfigDirEnv != "" || len(c.CredentialEnv) > 0 {
+		return fmt.Errorf(
+			"workspace %s: configDirEnv and credentialEnv are only for kind %q — "+
+				"kind %q already knows its own",
+			c.WorkspaceID, KindCustom, kind.Name)
+	}
+	if len(c.Args) > 0 {
+		return fmt.Errorf(
+			"workspace %s: args is only for kind %q — kind %q builds its own argv from "+
+				"spawn, capacity and permissionMode",
+			c.WorkspaceID, KindCustom, kind.Name)
 	}
 	return nil
 }

--- a/utils/agentworktrees.go
+++ b/utils/agentworktrees.go
@@ -208,21 +208,7 @@ func ExistingBranchWorktrees(corgi *CorgiCompose, composeDir, branch string) (*W
 		if !ok {
 			continue
 		}
-		// The main checkout counts when it is already on the branch: that is
-		// what materialize returns in that case, so requiring a directory under
-		// the worktree base would report "nothing here" for a repo that is
-		// correctly checked out, and re-running materialize could never fix it.
-		dir := ""
-		if head, err := gitOut(root, gitRevParse, gitAbbrevRef, "HEAD"); err == nil && head == branch {
-			dir = root
-		} else {
-			dest := filepath.Join(base, worktreeDirName(root, branch))
-			if info, statErr := os.Stat(dest); statErr == nil && info.IsDir() {
-				if h, herr := gitOut(dest, gitRevParse, gitAbbrevRef, "HEAD"); herr == nil && h == branch {
-					dir = dest
-				}
-			}
-		}
+		dir := existingWorktreeDir(root, base, branch)
 		if dir == "" {
 			continue
 		}
@@ -289,22 +275,46 @@ func releaseBranchWorktrees(composeDir, branch string, force bool) (removed, ski
 			skippedDirty = append(skippedDirty, dest)
 			continue
 		}
-		common, cerr := gitOut(dest, gitRevParse, "--path-format=absolute", "--git-common-dir")
-		if cerr == nil && common != "" {
-			repo := filepath.Dir(common)
-			if gitRun(repo, "worktree", "remove", "--force", dest) == nil {
-				_ = gitRun(repo, "worktree", "prune")
-				removed = append(removed, dest)
-				continue
-			}
-		}
-		if os.RemoveAll(dest) == nil {
+		if removeWorktree(dest) {
 			removed = append(removed, dest)
 		}
 	}
 	sort.Strings(removed)
 	sort.Strings(skippedDirty)
 	return removed, skippedDirty, nil
+}
+
+// existingWorktreeDir resolves where this repo's copy of the branch lives.
+// The main checkout counts when already on the branch — that is what
+// materialize returns, and requiring the worktree base would report "nothing
+// here" for a correctly checked-out repo.
+func existingWorktreeDir(root, base, branch string) string {
+	if head, err := gitOut(root, gitRevParse, gitAbbrevRef, "HEAD"); err == nil && head == branch {
+		return root
+	}
+	dest := filepath.Join(base, worktreeDirName(root, branch))
+	info, statErr := os.Stat(dest)
+	if statErr != nil || !info.IsDir() {
+		return ""
+	}
+	if h, herr := gitOut(dest, gitRevParse, gitAbbrevRef, "HEAD"); herr == nil && h == branch {
+		return dest
+	}
+	return ""
+}
+
+// removeWorktree unregisters it from the repo, falling back to deleting the
+// directory when git will not.
+func removeWorktree(dest string) bool {
+	common, cerr := gitOut(dest, gitRevParse, "--path-format=absolute", "--git-common-dir")
+	if cerr == nil && common != "" {
+		repo := filepath.Dir(common)
+		if gitRun(repo, "worktree", "remove", "--force", dest) == nil {
+			_ = gitRun(repo, "worktree", "prune")
+			return true
+		}
+	}
+	return os.RemoveAll(dest) == nil
 }
 
 // HasUncommittedWork reports whether a checkout holds anything not committed,

--- a/utils/cachehints.go
+++ b/utils/cachehints.go
@@ -17,20 +17,31 @@ type CacheHint struct {
 }
 
 // installVerbs are the commands that produce a dependency directory, keyed by
-// the ecosystem group the lockfile belongs to. A step matches when its command
-// mentions one of its ecosystem's verbs, so `make setup` is not guessed at.
+// the lockfile they install from. Keyed by lockfile rather than by ecosystem
+// because a repo often carries a stale one from a previous package manager: a
+// node-wide verb list would let `yarn install` be keyed on a leftover bun.lock,
+// so the cache would never bust when yarn.lock changed.
+//
+// "bundle exec ..." is deliberately absent: it runs tasks such as db:migrate,
+// and keying one on Gemfile.lock would skip a migration whenever the gems
+// happened not to change.
 var installVerbs = map[string][]string{
-	"node":   {"npm ci", "npm install", "yarn install", "yarn --", "pnpm install", "pnpm i ", "bun install"},
-	"python": {"pip install", "poetry install", "uv sync", "uv pip install", "pipenv install"},
-	"go":     {"go mod download", "go mod tidy"},
-	"rust":   {"cargo build", "cargo fetch"},
-	// "bundle exec ..." is deliberately absent: it runs tasks such as
-	// db:migrate, and keying one on Gemfile.lock would skip a migration
-	// whenever the gems happened not to change.
-	"ruby":   {"bundle install"},
-	"php":    {"composer install"},
-	"elixir": {"mix deps.get"},
-	"dart":   {"pub get"},
+	"package-lock.json": {"npm ci", "npm install"},
+	"yarn.lock":         {"yarn install", "yarn --"},
+	"pnpm-lock.yaml":    {"pnpm install", "pnpm i "},
+	"bun.lock":          {"bun install"},
+	"bun.lockb":         {"bun install"},
+	"uv.lock":           {"uv sync", "uv pip install"},
+	"poetry.lock":       {"poetry install"},
+	"Pipfile.lock":      {"pipenv install"},
+	"requirements.txt":  {"pip install"},
+	"go.sum":            {"go mod download", "go mod tidy"},
+	"Cargo.lock":        {"cargo build", "cargo fetch"},
+	"Gemfile.lock":      {"bundle install"},
+	"Gemfile":           {"bundle install"},
+	"composer.lock":     {"composer install"},
+	"mix.lock":          {"mix deps.get"},
+	"pubspec.lock":      {"pub get"},
 }
 
 // CacheOptInHints finds install steps that corgi could skip on an unchanged
@@ -61,8 +72,10 @@ func CacheOptInHints(corgi *CorgiCompose) []CacheHint {
 // the command is not an install corgi knows how to key.
 func lockfileForStep(service Service, run string) string {
 	lower := strings.ToLower(run)
+	// ecosystems is ordered most specific first, so a repo holding both a
+	// pnpm and an npm lockfile is read as pnpm.
 	for _, eco := range ecosystems {
-		verbs, known := installVerbs[eco.group]
+		verbs, known := installVerbs[eco.lockfile]
 		if !known {
 			continue
 		}

--- a/utils/cachehints.go
+++ b/utils/cachehints.go
@@ -16,15 +16,9 @@ type CacheHint struct {
 	Lockfile string `json:"lockfile"`
 }
 
-// installVerbs are the commands that produce a dependency directory, keyed by
-// the lockfile they install from. Keyed by lockfile rather than by ecosystem
-// because a repo often carries a stale one from a previous package manager: a
-// node-wide verb list would let `yarn install` be keyed on a leftover bun.lock,
-// so the cache would never bust when yarn.lock changed.
-//
-// "bundle exec ..." is deliberately absent: it runs tasks such as db:migrate,
-// and keying one on Gemfile.lock would skip a migration whenever the gems
-// happened not to change.
+// Keyed by lockfile, not ecosystem: a repo carrying a stale bun.lock would
+// otherwise have `yarn install` keyed on it. "bundle exec" is absent on
+// purpose — keying db:migrate on Gemfile.lock would skip the migration.
 var installVerbs = map[string][]string{
 	"package-lock.json": {"npm ci", "npm install"},
 	"yarn.lock":         {"yarn install", "yarn --"},
@@ -44,11 +38,8 @@ var installVerbs = map[string][]string{
 	"pubspec.lock":      {"pub get"},
 }
 
-// CacheOptInHints finds install steps that corgi could skip on an unchanged
-// lockfile but cannot, because the step declares no cacheKey.
-//
-// Without this the cost is invisible: `corgi cache paths` returns only the step
-// markers and every CI run reinstalls everything, with nothing saying why.
+// CacheOptInHints finds install steps that could skip on an unchanged lockfile
+// but declare no cacheKey. Without it that cost is invisible.
 func CacheOptInHints(corgi *CorgiCompose) []CacheHint {
 	var hints []CacheHint
 	for _, service := range sortedServices(corgi) {
@@ -68,12 +59,10 @@ func CacheOptInHints(corgi *CorgiCompose) []CacheHint {
 	return hints
 }
 
-// lockfileForStep returns the lockfile this command installs from, or "" when
-// the command is not an install corgi knows how to key.
+// lockfileForStep returns the lockfile this command installs from, or "".
 func lockfileForStep(service Service, run string) string {
 	lower := strings.ToLower(run)
-	// ecosystems is ordered most specific first, so a repo holding both a
-	// pnpm and an npm lockfile is read as pnpm.
+	// Most specific first, so pnpm wins over a stray package-lock.json.
 	for _, eco := range ecosystems {
 		verbs, known := installVerbs[eco.lockfile]
 		if !known {
@@ -82,8 +71,7 @@ func lockfileForStep(service Service, run string) string {
 		if !mentionsAny(lower, verbs) {
 			continue
 		}
-		// The lockfile has to be there: suggesting a cacheKey for a file that
-		// does not exist would make every run miss instead of skip.
+		// A cacheKey on a missing file makes every run miss instead of skip.
 		if _, err := os.Stat(filepath.Join(service.AbsolutePath, eco.lockfile)); err == nil {
 			return eco.lockfile
 		}
@@ -100,8 +88,7 @@ func mentionsAny(haystack string, needles []string) bool {
 	return false
 }
 
-// CacheHintLines renders the hints as the yml the user would paste, one block
-// per step, sorted so the output is stable.
+// CacheHintLines renders the hints as pasteable yml, sorted for stability.
 func CacheHintLines(hints []CacheHint) []string {
 	lines := make([]string, 0, len(hints))
 	for _, h := range hints {

--- a/utils/cachehints.go
+++ b/utils/cachehints.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CacheHint is an install step that could opt into caching but has not.
+type CacheHint struct {
+	Service string `json:"service"`
+	// Command is the beforeStart step's run line, so the user can find it.
+	Command string `json:"command"`
+	// Lockfile is the cacheKey to add, relative to the service.
+	Lockfile string `json:"lockfile"`
+}
+
+// installVerbs are the commands that produce a dependency directory, keyed by
+// the ecosystem group the lockfile belongs to. A step matches when its command
+// mentions one of its ecosystem's verbs, so `make setup` is not guessed at.
+var installVerbs = map[string][]string{
+	"node":   {"npm ci", "npm install", "yarn install", "yarn --", "pnpm install", "pnpm i ", "bun install"},
+	"python": {"pip install", "poetry install", "uv sync", "uv pip install", "pipenv install"},
+	"go":     {"go mod download", "go mod tidy"},
+	"rust":   {"cargo build", "cargo fetch"},
+	// "bundle exec ..." is deliberately absent: it runs tasks such as
+	// db:migrate, and keying one on Gemfile.lock would skip a migration
+	// whenever the gems happened not to change.
+	"ruby":   {"bundle install"},
+	"php":    {"composer install"},
+	"elixir": {"mix deps.get"},
+	"dart":   {"pub get"},
+}
+
+// CacheOptInHints finds install steps that corgi could skip on an unchanged
+// lockfile but cannot, because the step declares no cacheKey.
+//
+// Without this the cost is invisible: `corgi cache paths` returns only the step
+// markers and every CI run reinstalls everything, with nothing saying why.
+func CacheOptInHints(corgi *CorgiCompose) []CacheHint {
+	var hints []CacheHint
+	for _, service := range sortedServices(corgi) {
+		for _, step := range service.BeforeStart {
+			if len(step.CacheKey) > 0 || strings.TrimSpace(step.Run) == "" {
+				continue
+			}
+			if lockfile := lockfileForStep(service, step.Run); lockfile != "" {
+				hints = append(hints, CacheHint{
+					Service:  service.ServiceName,
+					Command:  strings.TrimSpace(step.Run),
+					Lockfile: lockfile,
+				})
+			}
+		}
+	}
+	return hints
+}
+
+// lockfileForStep returns the lockfile this command installs from, or "" when
+// the command is not an install corgi knows how to key.
+func lockfileForStep(service Service, run string) string {
+	lower := strings.ToLower(run)
+	for _, eco := range ecosystems {
+		verbs, known := installVerbs[eco.group]
+		if !known {
+			continue
+		}
+		if !mentionsAny(lower, verbs) {
+			continue
+		}
+		// The lockfile has to be there: suggesting a cacheKey for a file that
+		// does not exist would make every run miss instead of skip.
+		if _, err := os.Stat(filepath.Join(service.AbsolutePath, eco.lockfile)); err == nil {
+			return eco.lockfile
+		}
+	}
+	return ""
+}
+
+func mentionsAny(haystack string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// CacheHintLines renders the hints as the yml the user would paste, one block
+// per step, sorted so the output is stable.
+func CacheHintLines(hints []CacheHint) []string {
+	lines := make([]string, 0, len(hints))
+	for _, h := range hints {
+		lines = append(lines, h.Service+": - run: "+h.Command+"  →  cacheKey: ["+h.Lockfile+"]")
+	}
+	sort.Strings(lines)
+	return lines
+}

--- a/utils/cachehints_test.go
+++ b/utils/cachehints_test.go
@@ -1,0 +1,129 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func serviceWithLockfile(t *testing.T, name, lockfile, run string, cacheKey []string) Service {
+	t.Helper()
+	dir := t.TempDir()
+	if lockfile != "" {
+		if err := os.WriteFile(filepath.Join(dir, lockfile), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return Service{
+		ServiceName:  name,
+		Path:         "./" + name,
+		AbsolutePath: dir,
+		BeforeStart:  BeforeStartSteps{{Run: run, CacheKey: cacheKey}},
+	}
+}
+
+// An install with no cacheKey is the difference between a five-minute CI run
+// and a twenty-minute one, and nothing said so before.
+func TestCacheOptInHintsFindsAnUnkeyedInstall(t *testing.T) {
+	svc := serviceWithLockfile(t, "api", "package-lock.json", "npm ci", nil)
+	hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}})
+
+	if len(hints) != 1 {
+		t.Fatalf("expected one hint, got %+v", hints)
+	}
+	if hints[0].Service != "api" || hints[0].Lockfile != "package-lock.json" {
+		t.Errorf("unexpected hint: %+v", hints[0])
+	}
+}
+
+// A step that already opts in is not a hint.
+func TestCacheOptInHintsIgnoresAKeyedStep(t *testing.T) {
+	svc := serviceWithLockfile(t, "api", "package-lock.json", "npm ci", []string{"package-lock.json"})
+	if hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}}); len(hints) != 0 {
+		t.Errorf("expected no hints, got %+v", hints)
+	}
+}
+
+// Suggesting a cacheKey for a file that is not there would make every run miss
+// instead of skip, which is worse than saying nothing.
+func TestCacheOptInHintsNeedsTheLockfileToExist(t *testing.T) {
+	svc := serviceWithLockfile(t, "api", "", "npm ci", nil)
+	if hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}}); len(hints) != 0 {
+		t.Errorf("expected no hints without a lockfile, got %+v", hints)
+	}
+}
+
+// corgi cannot know what `make setup` installs, so it must not guess.
+func TestCacheOptInHintsDoesNotGuessAtOpaqueCommands(t *testing.T) {
+	svc := serviceWithLockfile(t, "api", "package-lock.json", "make setup", nil)
+	if hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}}); len(hints) != 0 {
+		t.Errorf("expected no hints for an opaque command, got %+v", hints)
+	}
+}
+
+func TestCacheOptInHintsCoversEachEcosystem(t *testing.T) {
+	cases := []struct{ lockfile, run string }{
+		{"package-lock.json", "npm ci"},
+		{"yarn.lock", "yarn install"},
+		{"bun.lock", "bun install"},
+		{"uv.lock", "uv sync"},
+		{"requirements.txt", "pip install -r requirements.txt"},
+		{"Gemfile.lock", "bundle install"},
+		{"go.sum", "go mod download"},
+		{"composer.lock", "composer install"},
+		{"mix.lock", "mix deps.get"},
+	}
+	for _, c := range cases {
+		svc := serviceWithLockfile(t, "svc", c.lockfile, c.run, nil)
+		hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}})
+		if len(hints) != 1 || hints[0].Lockfile != c.lockfile {
+			t.Errorf("%s / %q: expected a hint for that lockfile, got %+v", c.lockfile, c.run, hints)
+		}
+	}
+}
+
+// The hints ride along on the plan, so every output format can show them.
+func TestCachePlanCarriesTheHints(t *testing.T) {
+	svc := serviceWithLockfile(t, "api", "package-lock.json", "npm ci", nil)
+	plan := CachePathsFor(&CorgiCompose{Services: []Service{svc}})
+
+	if len(plan.Groups) != 0 {
+		t.Errorf("an unkeyed step must not produce a cache group: %+v", plan.Groups)
+	}
+	if len(plan.Hints) != 1 {
+		t.Errorf("expected the hint on the plan, got %+v", plan.Hints)
+	}
+}
+
+func TestCacheHintLinesAreStable(t *testing.T) {
+	hints := []CacheHint{
+		{Service: "web", Command: "npm ci", Lockfile: "package-lock.json"},
+		{Service: "api", Command: "npm ci", Lockfile: "package-lock.json"},
+	}
+	first := CacheHintLines(hints)
+	second := CacheHintLines(hints)
+	if len(first) != 2 || first[0] != second[0] || first[1] != second[1] {
+		t.Errorf("expected a stable rendering, got %v then %v", first, second)
+	}
+	if first[0] > first[1] {
+		t.Errorf("expected sorted output, got %v", first)
+	}
+}
+
+// `bundle exec rake db:migrate` is a task, not an install. Keying it on
+// Gemfile.lock would make corgi skip a migration whenever the gems happened
+// not to change — worse than no hint at all.
+func TestCacheOptInHintsNeverSuggestsCachingATask(t *testing.T) {
+	for _, run := range []string{
+		"bundle exec rake db:migrate",
+		"bundle exec rails db:seed",
+		"npm run build",
+		"yarn lint",
+	} {
+		svc := serviceWithLockfile(t, "billing", "Gemfile.lock", run, nil)
+		svc.BeforeStart = BeforeStartSteps{{Run: run}}
+		if hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}}); len(hints) != 0 {
+			t.Errorf("%q must not be suggested for caching, got %+v", run, hints)
+		}
+	}
+}

--- a/utils/cachehints_test.go
+++ b/utils/cachehints_test.go
@@ -127,3 +127,29 @@ func TestCacheOptInHintsNeverSuggestsCachingATask(t *testing.T) {
 		}
 	}
 }
+
+// A repo that moved from bun to yarn often still carries the old lockfile.
+// Keying `yarn install` on it would mean the cache never busts when yarn.lock
+// changes — a stale node_modules restored on every run.
+func TestCacheOptInHintsPicksTheLockfileTheCommandActuallyUses(t *testing.T) {
+	dir := t.TempDir()
+	for _, f := range []string{"bun.lock", "yarn.lock"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	svc := Service{
+		ServiceName:  "web",
+		Path:         "./web",
+		AbsolutePath: dir,
+		BeforeStart:  BeforeStartSteps{{Run: "yarn install"}},
+	}
+
+	hints := CacheOptInHints(&CorgiCompose{Services: []Service{svc}})
+	if len(hints) != 1 {
+		t.Fatalf("expected one hint, got %+v", hints)
+	}
+	if hints[0].Lockfile != "yarn.lock" {
+		t.Errorf("yarn install must be keyed on yarn.lock, got %q", hints[0].Lockfile)
+	}
+}

--- a/utils/cachepaths.go
+++ b/utils/cachepaths.go
@@ -19,6 +19,10 @@ type CachePlan struct {
 	// Groups splits the same plan per ecosystem, so a change to one language's
 	// lockfile does not evict every other language's packages.
 	Groups []CacheGroup `json:"groups"`
+	// Hints are install steps that could opt into caching but have not. An
+	// empty plan is otherwise indistinguishable from a workspace with nothing
+	// worth caching.
+	Hints []CacheHint `json:"hints,omitempty"`
 }
 
 // CacheGroup is one independently keyed slice of the plan.
@@ -89,7 +93,12 @@ func CachePathsFor(corgi *CorgiCompose) CachePlan {
 		})
 	}
 
-	return CachePlan{Paths: sortedPathSet(acc.paths), Key: aggregate, Groups: groups}
+	return CachePlan{
+		Paths:  sortedPathSet(acc.paths),
+		Key:    aggregate,
+		Groups: groups,
+		Hints:  CacheOptInHints(corgi),
+	}
 }
 
 type cacheAccumulator struct {

--- a/utils/diskheadroom.go
+++ b/utils/diskheadroom.go
@@ -1,0 +1,38 @@
+package utils
+
+import "fmt"
+
+// Rough per-item cost of booting a stack, used only to turn "some disk free"
+// into a yes/no. A database is an image plus its data directory; a service is
+// its dependency tree. Both are estimates, and the check says so.
+const (
+	diskBaseBytes     = 2 << 30 // toolchains, corgi itself, log and cache dirs
+	diskPerDatabase   = 3 << 30
+	diskPerService    = 1 << 30
+	bytesInGigabyte   = 1 << 30
+	diskUnknownIsFine = true
+)
+
+// DiskHeadroom compares free space at path with a rough estimate of what
+// booting this compose needs.
+//
+// Running out mid-boot is the least recognisable CI failure there is: the
+// symptom is a random service failing to build, not a disk message. Hosted
+// runners are provisioned tighter than a full stack needs, so the answer is
+// worth two seconds up front.
+func DiskHeadroom(corgi *CorgiCompose, path string) (need uint64, free uint64, ok bool, known bool) {
+	need = diskBaseBytes +
+		uint64(len(corgi.DatabaseServices))*diskPerDatabase +
+		uint64(len(corgi.Services))*diskPerService
+
+	free, known = FreeDiskBytes(path)
+	if !known {
+		return need, 0, diskUnknownIsFine, false
+	}
+	return need, free, free >= need, true
+}
+
+// FormatGigabytes renders a byte count the way the check reports it.
+func FormatGigabytes(b uint64) string {
+	return fmt.Sprintf("%.1fG", float64(b)/float64(bytesInGigabyte))
+}

--- a/utils/diskheadroom.go
+++ b/utils/diskheadroom.go
@@ -27,7 +27,9 @@ func DiskHeadroom(corgi *CorgiCompose, path string) (need uint64, free uint64, o
 
 	free, known = FreeDiskBytes(path)
 	if !known {
-		return need, 0, diskUnknownIsFine, false
+		// A platform that cannot answer must not fail the run over a number
+		// corgi does not have.
+		return need, 0, true, false
 	}
 	return need, free, free >= need, true
 }

--- a/utils/diskheadroom.go
+++ b/utils/diskheadroom.go
@@ -2,9 +2,7 @@ package utils
 
 import "fmt"
 
-// Rough per-item cost of booting a stack, used only to turn "some disk free"
-// into a yes/no. A database is an image plus its data directory; a service is
-// its dependency tree. Both are estimates, and the check says so.
+// Rough per-item cost of a boot, only precise enough for a yes/no.
 const (
 	diskBaseBytes     = 2 << 30 // toolchains, corgi itself, log and cache dirs
 	diskPerDatabase   = 3 << 30
@@ -13,13 +11,9 @@ const (
 	diskUnknownIsFine = true
 )
 
-// DiskHeadroom compares free space at path with a rough estimate of what
-// booting this compose needs.
-//
-// Running out mid-boot is the least recognisable CI failure there is: the
-// symptom is a random service failing to build, not a disk message. Hosted
-// runners are provisioned tighter than a full stack needs, so the answer is
-// worth two seconds up front.
+// DiskHeadroom compares free space with an estimate of what this compose needs.
+// Running out mid-boot reads as a random service failing to build, never as a
+// disk message.
 func DiskHeadroom(corgi *CorgiCompose, path string) (need uint64, free uint64, ok bool, known bool) {
 	need = diskBaseBytes +
 		uint64(len(corgi.DatabaseServices))*diskPerDatabase +
@@ -27,14 +21,13 @@ func DiskHeadroom(corgi *CorgiCompose, path string) (need uint64, free uint64, o
 
 	free, known = FreeDiskBytes(path)
 	if !known {
-		// A platform that cannot answer must not fail the run over a number
-		// corgi does not have.
+		// Do not fail a run over a number corgi does not have.
 		return need, 0, true, false
 	}
 	return need, free, free >= need, true
 }
 
-// FormatGigabytes renders a byte count the way the check reports it.
+// FormatGigabytes renders a byte count for the check's message.
 func FormatGigabytes(b uint64) string {
 	return fmt.Sprintf("%.1fG", float64(b)/float64(bytesInGigabyte))
 }

--- a/utils/diskheadroom_test.go
+++ b/utils/diskheadroom_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import "testing"
+
+// The estimate has to grow with the stack, or a one-service compose and a
+// fourteen-container one would be judged against the same bar.
+func TestDiskHeadroomScalesWithTheStack(t *testing.T) {
+	small, _, _, _ := DiskHeadroom(&CorgiCompose{}, t.TempDir())
+	big, _, _, _ := DiskHeadroom(&CorgiCompose{
+		DatabaseServices: []DatabaseService{{ServiceName: "a"}, {ServiceName: "b"}},
+		Services:         []Service{{ServiceName: "api"}, {ServiceName: "web"}},
+	}, t.TempDir())
+
+	if big <= small {
+		t.Errorf("a bigger stack must need more disk: %d vs %d", big, small)
+	}
+}
+
+// A real temp dir has space, so the check should pass rather than cry wolf.
+func TestDiskHeadroomPassesOnAHostWithSpace(t *testing.T) {
+	_, free, ok, known := DiskHeadroom(&CorgiCompose{}, t.TempDir())
+	if !known {
+		t.Skip("platform cannot report free disk")
+	}
+	if free == 0 {
+		t.Fatal("expected a non-zero free figure")
+	}
+	if !ok {
+		t.Skip("this machine genuinely has less than the base estimate free")
+	}
+}
+
+// An unknown figure must not be reported as a failure — the check is skipped.
+func TestDiskHeadroomTreatsUnknownAsFine(t *testing.T) {
+	_, _, ok, known := DiskHeadroom(&CorgiCompose{}, "/definitely/not/a/path/corgi")
+	if known {
+		t.Skip("this platform answered for a missing path")
+	}
+	if !ok {
+		t.Error("an unanswerable check must not fail the run")
+	}
+}
+
+func TestFormatGigabytes(t *testing.T) {
+	if got := FormatGigabytes(2 << 30); got != "2.0G" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/utils/diskspace_unix.go
+++ b/utils/diskspace_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package utils
+
+import "syscall"
+
+// FreeDiskBytes reports the space available at path. ok is false when the
+// platform cannot answer, so a caller can skip the check rather than guess.
+func FreeDiskBytes(path string) (free uint64, ok bool) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(path, &fs); err != nil {
+		return 0, false
+	}
+	// Bavail, not Bfree: the reserved blocks are not ours to fill.
+	return uint64(fs.Bavail) * uint64(fs.Bsize), true
+}

--- a/utils/diskspace_unix.go
+++ b/utils/diskspace_unix.go
@@ -4,13 +4,12 @@ package utils
 
 import "syscall"
 
-// FreeDiskBytes reports the space available at path. ok is false when the
-// platform cannot answer, so a caller can skip the check rather than guess.
+// FreeDiskBytes reports space available at path; ok is false when unknown.
 func FreeDiskBytes(path string) (free uint64, ok bool) {
 	var fs syscall.Statfs_t
 	if err := syscall.Statfs(path, &fs); err != nil {
 		return 0, false
 	}
-	// Bavail, not Bfree: the reserved blocks are not ours to fill.
+	// Bavail, not Bfree: reserved blocks are not ours.
 	return uint64(fs.Bavail) * uint64(fs.Bsize), true
 }

--- a/utils/diskspace_windows.go
+++ b/utils/diskspace_windows.go
@@ -2,6 +2,5 @@
 
 package utils
 
-// FreeDiskBytes has no portable implementation here yet, so the headroom check
-// reports "unknown" rather than a wrong number.
+// FreeDiskBytes is unimplemented here, so the check reports unknown.
 func FreeDiskBytes(_ string) (uint64, bool) { return 0, false }

--- a/utils/diskspace_windows.go
+++ b/utils/diskspace_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package utils
+
+// FreeDiskBytes has no portable implementation here yet, so the headroom check
+// reports "unknown" rather than a wrong number.
+func FreeDiskBytes(_ string) (uint64, bool) { return 0, false }

--- a/utils/gitlabcache.go
+++ b/utils/gitlabcache.go
@@ -93,9 +93,15 @@ func GitLabCacheYAML(plan CachePlan, opts GitLabCacheOptions) string {
 		b.WriteString("# No service declares a beforeStart cacheKey, so only corgi's step markers\n")
 		b.WriteString("# are cached and every install runs from scratch. Add a cacheKey to each\n")
 		b.WriteString("# install step and regenerate to get real caching:\n")
-		b.WriteString("#   beforeStart:\n")
-		b.WriteString("#     - run: npm ci\n")
-		b.WriteString("#       cacheKey: [package-lock.json]\n")
+		if len(plan.Hints) > 0 {
+			for _, line := range CacheHintLines(plan.Hints) {
+				b.WriteString("#   " + line + "\n")
+			}
+		} else {
+			b.WriteString("#   beforeStart:\n")
+			b.WriteString("#     - run: npm ci\n")
+			b.WriteString("#       cacheKey: [package-lock.json]\n")
+		}
 	}
 
 	b.WriteString("\n" + gitlabCacheTemplate + ":\n")


### PR DESCRIPTION
Six changes, all found by wiring two real workspaces into CI. Each one deletes something a pipeline had to hand-roll.

## 1. A failed `beforeStart` now fails the run everywhere

corgi already returned the failure from `run --detach --wait` ([cmd/run.go](cmd/run.go)). But a run **without** `--wait` still exited `0` while a service was silently missing, so a scripted `corgi run` could not tell a healthy stack from a broken one.

- The rest of the stack still comes up — only the **exit status** changes.
- A hot reload (`corgi restart`, the compose watcher) is exempt, so a session the developer is using is never torn down.

## 2. The `aborting beforeStart` grep is obsolete — removed

It could never fire: `--wait` had already failed the job before the pipeline reached it. Yet [the skill](plugins/corgi/skills/ci/SKILL.md) still described the old behaviour, and the GitLab template shipped last week copied the hack straight from it. Both deleted, with a note that older pipelines should drop the step.

## 3. corgi says when caching is off

A real eighteen-service workspace declares **no `cacheKey` at all**, so `corgi cache paths` returned only the step markers, `groups: null`, and every CI run reinstalled everything with nothing explaining why.

Now it names each install step and the lockfile to key it on (stderr, so a command substitution stays clean; also on the plan as `hints`, and in the generated GitLab header).

It matches only commands that really install. `bundle exec rake db:migrate` is deliberately **not** one — the first draft suggested it, and keying a migration on `Gemfile.lock` would skip the migration whenever the gems happened not to change. There is a regression test for that.

## 4. `corgi doctor` checks disk headroom in CI

Free space vs a rough estimate from the database and service counts. Running out mid-boot surfaces as a random service failing to build, never as a disk message. CI-only, like the other two checks; `FreeDiskBytes` is build-tagged and reports "unknown" on Windows rather than a wrong number.

## 5. The action publishes four fixed cache slots

`cache-1-key`/`cache-1-paths` … `cache-4-*` plus `cache-overflow`, and the action emits the overflow `::warning::` itself.

**Honest limitation:** neither a workflow expression nor a composite action can loop, so the four copied cache steps stay. What goes away is the `fromJSON(steps.corgi.outputs.cache-groups)[i]` indexing and the hand-written "ran out of slots" step that a real workflow carried. True looping needs a JS action — out of scope here.

## 6. `corgi ci init --provider github|gitlab`

Writes the starting point: `.github/workflows/stack-e2e.yml`, or `.gitlab-ci.yml` + `.gitlab/corgi-cache.yml` generated from the compose. Picks the forge from the git remote, refuses an unrecognised one rather than guessing, never clobbers without `--force`, and prints what the workspace still owes — runner tags, the clone token, the env files, and an `e2e:` block when the compose has none.

## Verified end to end

- `corgi ci init` on a scratch workspace: gitlab auto-detected from the remote, both files written and parsing, `--check` round-trips against the generated plan, second run refused, `--force` overwrites, github variant produces a 14-step workflow.
- Cache hints on the real eighteen-service workspace: six genuine installs listed, the migration correctly no longer among them, stdout still pure.
- `corgi doctor --json` **without** CI: `[docker, port:3000]` — unchanged. **With** `CI=1`: adds `ci:host`, `ci:disk`.
- The action's new shell logic simulated against real `cache-groups` JSON: four slots filled correctly, empty slot blank, overflow arithmetic right.

## Tests

New: `cmd/beforestart_exit_test.go` (exit 1, silent when clean, exempt while reloading), `cmd/ci_test.go` (provider from flag/remote, refuses to guess, both forges write parsing YAML, overwrite guard, missing-e2e notice), `utils/cachehints_test.go` (unkeyed install found, keyed skipped, lockfile must exist, opaque commands not guessed, every ecosystem, never a task), `utils/diskheadroom_test.go` (estimate scales, unknown is not a failure).

`go vet ./...` clean · `go test ./... -race` — 2074 pass · `gofmt` clean · cross-compiles for Windows.

## Compatibility

Additive apart from the exit status in change 1, which is the point of it. Doctor outside CI, every flag, and every existing output format are unchanged.