### PR TITLE
Keep a record of what a run actually did

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -20,9 +20,10 @@ func exitWithErrorPrefix(jsonCode, stderrPrefix string, err error, exitCode int)
 	if utils.JSONOutput {
 		utils.JSONError(jsonCode, err.Error())
 	} else if stderrPrefix != "" {
-		fmt.Fprintln(os.Stderr, stderrPrefix, err)
+		fmt.Fprintln(utils.WithMirror(os.Stderr), stderrPrefix, err)
 	} else {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(utils.WithMirror(os.Stderr), err)
 	}
+	utils.CloseSessionLog()
 	osExit(exitCode)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -22,6 +22,7 @@ var logsPruneFlag bool
 var logsAllFlag bool
 var logsIdleFlag time.Duration
 var logsDumpFlag string
+var logsSessionFlag bool
 
 var logsCmd = &cobra.Command{
 	Use:     "logs",
@@ -36,6 +37,7 @@ Examples:
   corgi logs                      # interactive picker
   corgi logs --service api        # jump straight to run picker for "api"
   corgi logs --all                # merge the newest run of every service into one stream
+  corgi logs --session            # corgi's own output for the last run
   corgi logs --idle 0             # tail forever (until Ctrl-C)
   corgi logs --prune              # delete all .logs/ directories`,
 	Run: runLogs,
@@ -48,6 +50,7 @@ func init() {
 	logsCmd.Flags().BoolVar(&logsAllFlag, "all", false, "Merge the newest run of every service into one timestamp-sorted stream")
 	logsCmd.Flags().DurationVar(&logsIdleFlag, "idle", 30*time.Second, "Exit after this much dead-air on the file (set 0 to tail forever)")
 	logsCmd.Flags().StringVar(&logsDumpFlag, "dump", "", "Copy the newest run of every service into this directory and exit (for CI artifacts)")
+	logsCmd.Flags().BoolVar(&logsSessionFlag, "session", false, "Show corgi's own run output (validation errors, port conflicts, resolved branches) instead of a service's")
 }
 
 func logJSONLine(service, ts, level, line string) string {
@@ -100,6 +103,9 @@ func runLogs(cmd *cobra.Command, _ []string) {
 	}
 
 	serviceName := logsServiceFlag
+	if logsSessionFlag {
+		serviceName = utils.SessionLogDir
+	}
 	if serviceName == "" {
 		var err error
 		serviceName, err = chooseLogService(base)
@@ -147,7 +153,7 @@ func pruneAllLogs(base string) {
 
 // dumpNewestLogs copies each service's newest run into dir as <service>.log.
 func dumpNewestLogs(base, dir string) error {
-	services, err := utils.ListLoggedServices(base)
+	services, err := utils.ListLoggedStreams(base)
 	if err != nil || len(services) == 0 {
 		return fmt.Errorf("no log directories found under %s/.logs/", base)
 	}
@@ -445,7 +451,7 @@ func (h *mergeHeap) Pop() interface{} {
 // timestamp-sorted stream. K-way merge → memory is O(num services), not
 // O(total log bytes), so big projects don't OOM the CLI.
 func followAllLogs(base string) error {
-	services, err := utils.ListLoggedServices(base)
+	services, err := utils.ListLoggedStreams(base)
 	if err != nil || len(services) == 0 {
 		return fmt.Errorf("no log directories found under %s/.logs/\nRun the stack first: corgi run (capture is on unless --logs=false)", base)
 	}
@@ -495,7 +501,7 @@ func keepFollowing(idleSince *time.Time) bool {
 // adoptNewServices picks up services that started logging after the follow
 // began — a slow one has no log file when the first pass runs.
 func adoptNewServices(base string, streams map[string]*mergeStream) {
-	services, err := utils.ListLoggedServices(base)
+	services, err := utils.ListLoggedStreams(base)
 	if err != nil {
 		return
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -533,6 +532,7 @@ func confirmTier(cmd *cobra.Command, corgi *utils.CorgiCompose) error {
 
 func runRun(cmd *cobra.Command, _ []string) {
 	applyRunFlags(cmd)
+	defer utils.CloseSessionLog()
 
 	if err := resolveHostFlag(cmd); err != nil {
 		fmt.Println(art.RedColor, "host flag:", err, art.WhiteColor)
@@ -648,6 +648,8 @@ func loadRunCompose(cmd *cobra.Command) *utils.CorgiCompose {
 		}
 		os.Exit(1)
 	}
+
+	utils.StartSessionLog()
 
 	if !utils.AbortOnValidationErrors(corgi) {
 		if runReloading.Load() {
@@ -1682,7 +1684,7 @@ func handleComposeEvent(watcher *fsnotify.Watcher, cmd *cobra.Command, event fsn
 // reload does not leak file descriptors.
 func setupLogWriters(corgi *utils.CorgiCompose) {
 	utils.CloseAllLogWriters()
-	base := filepath.Join(utils.CorgiComposePathDir, "corgi_services")
+	base := utils.CorgiServicesDir()
 	if err := os.MkdirAll(base, 0o755); err != nil {
 		utils.Infof("⚠ logs: could not create %s: %v\n", base, err)
 		return

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -230,11 +230,11 @@ func findStateEntry(entries []utils.RunStateEntry, name string) (utils.RunStateE
 	return utils.RunStateEntry{}, false
 }
 
-// removeStateLocked deletes the run-state file under the advisory lock so it
-// can't clobber a concurrent restart's read-modify-write.
 func removeStateLocked(statePath string) {
 	unlock, _ := utils.LockRunState(utils.CorgiComposePathDir)
-	_ = os.Remove(statePath)
+	if err := os.Rename(statePath, utils.RunStateLastPath(utils.CorgiComposePathDir)); err != nil {
+		_ = os.Remove(statePath)
+	}
 	if unlock != nil {
 		unlock()
 	}

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"andriiklymiuk/corgi/utils"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -118,5 +120,49 @@ func TestEmitStopSummary_JSON(t *testing.T) {
 	})
 	if !strings.Contains(out, `"api"`) || !strings.Contains(out, "stopped") {
 		t.Errorf("expected JSON summary with api, got %q", out)
+	}
+}
+
+func TestRemoveStateLockedKeepsLastRunState(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "corgi_services"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = root
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	statePath := utils.RunStatePath(root)
+	exit := 0
+	want := utils.RunState{
+		ComposePath: "corgi-compose.yml",
+		Services: []utils.RunStateEntry{{
+			Name:     "api",
+			Command:  "npm run dev",
+			Port:     3000,
+			LogFile:  "/tmp/api.log",
+			Status:   "crashed",
+			ExitCode: &exit,
+		}},
+	}
+	if err := utils.WriteRunState(statePath, want); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	removeStateLocked(statePath)
+
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatal("live state file must be gone so nothing reads the stack as running")
+	}
+	lastPath := utils.RunStateLastPath(root)
+	got, err := utils.ReadRunState(lastPath)
+	if err != nil {
+		t.Fatalf("last run state not kept: %v", err)
+	}
+	if len(got.Services) != 1 || got.Services[0].Command != "npm run dev" {
+		t.Fatalf("kept state lost the spawn command: %+v", got.Services)
+	}
+	if got.Services[0].LogFile != "/tmp/api.log" {
+		t.Fatalf("kept state lost the log index: %+v", got.Services)
 	}
 }

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -36,20 +36,29 @@ var worktreeListCmd = &cobra.Command{
 	},
 }
 
+var worktreePruneForce bool
+
 var worktreePruneCmd = &cobra.Command{
 	Use:     "prune",
 	Aliases: []string{"clean"},
-	Short:   "Remove all corgi-created service worktrees",
+	Short:   "Remove corgi-created service worktrees (keeps ones with uncommitted work)",
 	Run: func(cmd *cobra.Command, _ []string) {
 		if _, err := utils.GetCorgiServices(cmd); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		if err := utils.CleanCorgiWorktrees(); err != nil {
+		skipped, err := utils.CleanCorgiWorktrees(worktreePruneForce)
+		if err != nil {
 			fmt.Fprintln(os.Stderr, "couldn't prune worktrees:", err)
 			os.Exit(1)
 		}
 		fmt.Println("🗑️ pruned corgi worktrees")
+		if len(skipped) > 0 {
+			fmt.Printf("kept %d with uncommitted changes (--force to drop):\n", len(skipped))
+			for _, d := range skipped {
+				fmt.Println(" ", d)
+			}
+		}
 	},
 }
 
@@ -57,4 +66,5 @@ func init() {
 	rootCmd.AddCommand(worktreeCmd)
 	worktreeCmd.AddCommand(worktreeListCmd)
 	worktreeCmd.AddCommand(worktreePruneCmd)
+	worktreePruneCmd.Flags().BoolVar(&worktreePruneForce, "force", false, "Also remove worktrees with uncommitted or untracked changes (discards that work)")
 }

--- a/plugins/corgi/skills/review/SKILL.md
+++ b/plugins/corgi/skills/review/SKILL.md
@@ -129,7 +129,7 @@ risky transitive bump isn't invisible.
 ## Phase 1.5 — Tracker enrichment (intent)
 
 Scan the **input**, **each PR/MR body**, AND the **branch name**
-(`headRefName`/`source_branch` — e.g. `feature/HUM-1063/...` carries `HUM-1063`)
+(`headRefName`/`source_branch` — e.g. `feature/ABC-123/...` carries `ABC-123`)
 for ticket references: `linear.app/…`, `atlassian.net/…`, or a bare `ABC-123` key.
 **Dedupe keys across
 the whole set first** — a shared ticket (the common api+web case) is fetched

--- a/utils/config.go
+++ b/utils/config.go
@@ -841,7 +841,12 @@ func CleanFromScratch(cmd *cobra.Command, corgi CorgiCompose) {
 
 func CleanCorgiServicesFolder() {
 	// git worktree remove before rm so source repos don't keep dangling entries.
-	_ = CleanCorgiWorktrees()
+	if skipped, _ := CleanCorgiWorktrees(false); len(skipped) > 0 {
+		Infof("kept %d worktree(s) with uncommitted changes (corgi worktree prune --force to drop):\n", len(skipped))
+		for _, d := range skipped {
+			Infof("  %s\n", d)
+		}
+	}
 	root := "./corgi_services"
 	entries, err := os.ReadDir(root)
 	if err != nil {

--- a/utils/jsonout.go
+++ b/utils/jsonout.go
@@ -15,7 +15,7 @@ func PrintJSONTo(w io.Writer, v any) {
 	_ = enc.Encode(v)
 }
 
-func PrintJSON(v any) { PrintJSONTo(os.Stdout, v) }
+func PrintJSON(v any) { PrintJSONTo(withMirror(os.Stdout), v) }
 
 type jsonErr struct {
 	Error struct {
@@ -31,4 +31,4 @@ func WriteJSONError(w io.Writer, code, message string) {
 	PrintJSONTo(w, e)
 }
 
-func JSONError(code, message string) { WriteJSONError(os.Stdout, code, message) }
+func JSONError(code, message string) { WriteJSONError(withMirror(os.Stdout), code, message) }

--- a/utils/logs.go
+++ b/utils/logs.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	logsDirName    = ".logs"
+	SessionLogDir  = "_corgi"
 	maxLogFileSize = 50 * 1024 * 1024 // 50 MB
 	defaultKeepN   = 10
 	logTimeFormat  = "2006-01-02T15:04:05.000Z07:00"
@@ -49,6 +50,7 @@ type logWriter struct {
 	rotations   int    // count of .partN siblings opened so far
 	pending     []byte // bytes received without a trailing newline yet
 	pendingTime time.Time
+	redact      bool
 }
 
 // Path returns the underlying file path. Used by tests and rename-on-close.
@@ -158,20 +160,22 @@ func (lw *logWriter) bufferPartialLine(chunk []byte) {
 
 func (lw *logWriter) emitLine(line []byte) error {
 	ts := lw.pendingTime
-	if len(lw.pending) == 0 {
+	full := line
+	if len(lw.pending) > 0 {
+		full = append(append(make([]byte, 0, len(lw.pending)+len(line)), lw.pending...), line...)
+		lw.pending = lw.pending[:0]
+		lw.pendingTime = time.Time{}
+	} else {
 		ts = time.Now().UTC()
+	}
+	full = normalizeWindowsLineEnding(full)
+	if lw.redact {
+		full = RedactBytes(full)
 	}
 	if err := lw.writeAndCount(ts.Format(logTimeFormat) + " "); err != nil {
 		return err
 	}
-	if len(lw.pending) > 0 {
-		if err := lw.writeBytesAndCount(normalizeWindowsLineEnding(lw.pending)); err != nil {
-			return err
-		}
-		lw.pending = lw.pending[:0]
-		lw.pendingTime = time.Time{}
-	}
-	return lw.writeBytesAndCount(normalizeWindowsLineEnding(line))
+	return lw.writeBytesAndCount(full)
 }
 
 func (lw *logWriter) writeAndCount(s string) error {
@@ -210,8 +214,12 @@ func (lw *logWriter) flushPendingLocked() {
 		ts = time.Now().UTC()
 	}
 	stamp := ts.Format(logTimeFormat) + " "
+	out := lw.pending
+	if lw.redact {
+		out = RedactBytes(out)
+	}
 	_, _ = lw.f.WriteString(stamp)
-	_, _ = lw.f.Write(lw.pending)
+	_, _ = lw.f.Write(out)
 	_, _ = lw.f.Write([]byte{'\n'})
 	lw.pending = lw.pending[:0]
 	lw.pendingTime = time.Time{}
@@ -271,6 +279,17 @@ func OpenLogWriter(corgiServicesPath, serviceName string) (io.WriteCloser, error
 		return nil, fmt.Errorf("logs: create %s: %w", path, err)
 	}
 	return &logWriter{f: f, path: path}, nil
+}
+
+func OpenSessionLogWriter(corgiServicesPath string) (io.WriteCloser, error) {
+	w, err := OpenLogWriter(corgiServicesPath, SessionLogDir)
+	if err != nil {
+		return nil, err
+	}
+	if lw, ok := w.(*logWriter); ok {
+		lw.redact = true
+	}
+	return w, nil
 }
 
 // PruneLogs deletes the oldest log files for serviceName, keeping at most
@@ -342,11 +361,23 @@ func ListLoggedServices(corgiServicesPath string) ([]string, error) {
 	}
 	var names []string
 	for _, e := range entries {
-		if e.IsDir() {
+		if e.IsDir() && e.Name() != SessionLogDir {
 			names = append(names, e.Name())
 		}
 	}
 	sort.Strings(names)
+	return names, nil
+}
+
+func ListLoggedStreams(corgiServicesPath string) ([]string, error) {
+	names, err := ListLoggedServices(corgiServicesPath)
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(corgiServicesPath, logsDirName, SessionLogDir)
+	if info, statErr := os.Stat(dir); statErr == nil && info.IsDir() {
+		names = append(names, SessionLogDir)
+	}
 	return names, nil
 }
 
@@ -401,4 +432,53 @@ func sanitizeName(name string) string {
 		return "_"
 	}
 	return mapped
+}
+
+var (
+	sessionLogMu sync.Mutex
+	sessionLog   io.WriteCloser
+)
+
+func CorgiServicesDir() string {
+	return filepath.Join(CorgiComposePathDir, "corgi_services")
+}
+
+func StartSessionLog() {
+	sessionLogMu.Lock()
+	defer sessionLogMu.Unlock()
+	if sessionLog != nil {
+		return
+	}
+	base := CorgiServicesDir()
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return
+	}
+	w, err := OpenSessionLogWriter(base)
+	if err != nil || w == nil {
+		return
+	}
+	EnsureLogsGitignore(base)
+	sessionLog = w
+	SetConsoleMirror(w)
+	PruneLogs(base, SessionLogDir, 0)
+}
+
+func CloseSessionLog() {
+	sessionLogMu.Lock()
+	defer sessionLogMu.Unlock()
+	if sessionLog == nil {
+		return
+	}
+	ClearConsoleMirror()
+	path := ""
+	if lw, ok := sessionLog.(*logWriter); ok {
+		path = lw.Path()
+	}
+	_ = sessionLog.Close()
+	sessionLog = nil
+	if path != "" {
+		if info, err := os.Stat(path); err == nil && info.Size() == 0 {
+			_ = os.Remove(path)
+		}
+	}
 }

--- a/utils/output.go
+++ b/utils/output.go
@@ -27,6 +27,28 @@ func OverrideWriter() io.Writer {
 	return nil
 }
 
+var consoleMirror atomic.Pointer[io.Writer]
+
+func SetConsoleMirror(w io.Writer) { consoleMirror.Store(&w) }
+
+func ClearConsoleMirror() { consoleMirror.Store(nil) }
+
+func MirrorWriter() io.Writer {
+	if p := consoleMirror.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func withMirror(base io.Writer) io.Writer {
+	if m := MirrorWriter(); m != nil {
+		return io.MultiWriter(base, m)
+	}
+	return base
+}
+
+func WithMirror(base io.Writer) io.Writer { return withMirror(base) }
+
 // infoWriter is where human-facing log lines go: the console override when set,
 // else stderr in JSON mode so the JSON payload on stdout stays clean, else
 // stdout.
@@ -38,12 +60,12 @@ var PayloadOnStdout bool
 
 func infoWriter() io.Writer {
 	if w := OverrideWriter(); w != nil {
-		return w
+		return withMirror(w)
 	}
 	if JSONOutput || PayloadOnStdout {
-		return os.Stderr
+		return withMirror(os.Stderr)
 	}
-	return os.Stdout
+	return withMirror(os.Stdout)
 }
 
 // Info prints a human-facing informational line (Println semantics).
@@ -61,10 +83,10 @@ func Infof(format string, a ...any) {
 // payload), else stdout.
 func ConsoleOut() io.Writer {
 	if w := OverrideWriter(); w != nil {
-		return w
+		return withMirror(w)
 	}
 	if JSONOutput {
-		return os.Stderr
+		return withMirror(os.Stderr)
 	}
-	return os.Stdout
+	return withMirror(os.Stdout)
 }

--- a/utils/redact.go
+++ b/utils/redact.go
@@ -1,0 +1,31 @@
+package utils
+
+import "regexp"
+
+var (
+	redactAssignRe  = regexp.MustCompile(`(?i)([A-Za-z0-9_.-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|anon[_-]?key|service[_-]?role|credential)[A-Za-z0-9_.-]*)(\s*[:=]\s*)("?)([^"\s]{4,})`)
+	redactURLCredRe = regexp.MustCompile(`([a-z][a-z0-9+.-]*://[^/\s:@]*:)([^@/\s]{3,})(@)`)
+	redactAWSKeyRe  = regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)
+	redactJWTRe     = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+`)
+	redactPEMRe     = regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----.*`)
+)
+
+const redactMask = "****"
+
+func RedactLine(s string) string {
+	s = redactPEMRe.ReplaceAllString(s, "-----BEGIN PRIVATE KEY----- "+redactMask)
+	s = redactAssignRe.ReplaceAllString(s, "${1}${2}${3}"+redactMask)
+	s = redactURLCredRe.ReplaceAllString(s, "${1}"+redactMask+"${3}")
+	s = redactAWSKeyRe.ReplaceAllString(s, redactMask)
+	s = redactJWTRe.ReplaceAllString(s, redactMask)
+	return s
+}
+
+func RedactBytes(b []byte) []byte {
+	s := string(b)
+	out := RedactLine(s)
+	if out == s {
+		return b
+	}
+	return []byte(out)
+}

--- a/utils/redact_test.go
+++ b/utils/redact_test.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactLineMasksCredentials(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		leaked  string
+		wantSub string
+	}{
+		{
+			name:    "assignment with secret-named key",
+			in:      "POSTGRES_PASSWORD=sup3rs3cretvalue",
+			leaked:  "sup3rs3cretvalue",
+			wantSub: "POSTGRES_PASSWORD=****",
+		},
+		{
+			name:    "colon form",
+			in:      "  api_key: abcd1234efgh5678",
+			leaked:  "abcd1234efgh5678",
+			wantSub: "api_key: ****",
+		},
+		{
+			name:    "service role key",
+			in:      "SERVICE_ROLE_KEY=zzzzzzzzzzzz",
+			leaked:  "zzzzzzzzzzzz",
+			wantSub: "****",
+		},
+		{
+			name:    "connection string password",
+			in:      "connecting to postgres://corgi:hunter2pass@localhost:5432/api",
+			leaked:  "hunter2pass",
+			wantSub: "postgres://corgi:****@localhost:5432/api",
+		},
+		{
+			name:    "aws access key id",
+			in:      "using AKIAIOSFODNN7EXAMPLE for s3",
+			leaked:  "AKIAIOSFODNN7EXAMPLE",
+			wantSub: "using **** for s3",
+		},
+		{
+			name:    "jwt",
+			in:      "anon key eyJhbGciOiJub25lIn0.eyJzdWIiOiJmYWtlIn0.AAAAAAAAAAAAAAAAAAAAAA",
+			leaked:  "AAAAAAAAAAAAAAAAAAAAAA",
+			wantSub: "anon key ****",
+		},
+		{
+			name:    "pem block",
+			in:      "-----BEGIN RSA PRIVATE KEY-----MIIEowIBAAKCAQEA",
+			leaked:  "MIIEowIBAAKCAQEA",
+			wantSub: "****",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactLine(tc.in)
+			if strings.Contains(got, tc.leaked) {
+				t.Fatalf("secret %q survived redaction: %q", tc.leaked, got)
+			}
+			if !strings.Contains(got, tc.wantSub) {
+				t.Fatalf("want %q in %q", tc.wantSub, got)
+			}
+		})
+	}
+}
+
+func TestRedactLineLeavesOrdinaryLinesAlone(t *testing.T) {
+	for _, in := range []string{
+		"api listening on http://localhost:3000",
+		"✗ [E_DANGLING_DEP] service \"web\" depends on unknown service \"api\"",
+		"port 3000 busy (services.web) — held by node(pid=4242)",
+		"feature: api -> feature/add-metrics",
+		"GET /health 200 in 4ms",
+	} {
+		if got := RedactLine(in); got != in {
+			t.Fatalf("ordinary line rewritten:\n in: %q\nout: %q", in, got)
+		}
+	}
+}
+
+func TestRedactLineMaskIsFixedWidth(t *testing.T) {
+	short := RedactLine("PASSWORD=abcd")
+	long := RedactLine("PASSWORD=abcdefghijklmnopqrstuvwxyz0123456789")
+	if short != long {
+		t.Fatalf("mask leaks secret length: %q vs %q", short, long)
+	}
+}

--- a/utils/runstate.go
+++ b/utils/runstate.go
@@ -34,6 +34,16 @@ func RunStatePath(composeDir string) string {
 	return filepath.Join(composeDir, "corgi_services", ".state.json")
 }
 
+func RunStateLastPath(composeDir string) string {
+	return filepath.Join(composeDir, "corgi_services", ".state.last.json")
+}
+
+func EnsureRunStateGitignored(composeDir string) {
+	dir := filepath.Join(composeDir, "corgi_services")
+	EnsureCorgiServicesIgnore(dir, ".state.json")
+	EnsureCorgiServicesIgnore(dir, ".state.last.json")
+}
+
 // LockRunState takes an advisory lock so concurrent state mutations (restart,
 // stop --service) don't clobber each other. Returns an unlock func. A lock held
 // longer than the timeout is assumed stale and reclaimed.
@@ -66,6 +76,7 @@ func WriteRunState(path string, s RunState) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
+	EnsureRunStateGitignored(filepath.Dir(filepath.Dir(path)))
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return err

--- a/utils/serviceWorktree.go
+++ b/utils/serviceWorktree.go
@@ -621,19 +621,31 @@ func ApplyServiceWorkdirsWithFeature(corgi *CorgiCompose, dirPairs, branchPairs,
 	return ApplyFeatureBranch(corgi, feature, pinnedServices(dirPairs, branchPairs, checkoutPairs), nil)
 }
 
-// CleanCorgiWorktrees removes every corgi-created worktree (git worktree remove,
+func WorktreeIsDirty(dest string) bool {
+	out, err := gitOut(dest, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return true
+	}
+	return strings.TrimSpace(out) != ""
+}
+
 // falling back to rm) and prunes the admin entries in each source repo.
-func CleanCorgiWorktrees() error {
+func CleanCorgiWorktrees(force bool) ([]string, error) {
 	base := filepath.Join(CorgiComposePathDir, "corgi_services", ".worktrees")
 	entries, err := os.ReadDir(base)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
+	var skipped []string
 	for _, e := range entries {
 		dest := filepath.Join(base, e.Name())
+		if !force && WorktreeIsDirty(dest) {
+			skipped = append(skipped, dest)
+			continue
+		}
 		common, cerr := gitOut(dest, gitRevParse, "--path-format=absolute", "--git-common-dir")
 		if cerr == nil && common != "" {
 			repo := filepath.Dir(common)
@@ -644,5 +656,8 @@ func CleanCorgiWorktrees() error {
 		}
 		_ = os.RemoveAll(dest)
 	}
-	return os.RemoveAll(base)
+	if len(skipped) > 0 {
+		return skipped, nil
+	}
+	return nil, os.RemoveAll(base)
 }

--- a/utils/serviceWorktree_test.go
+++ b/utils/serviceWorktree_test.go
@@ -143,7 +143,7 @@ func TestEnsureServiceWorktreeReuseDirtyClean(t *testing.T) {
 		t.Fatal("modified tracked file should be dirty")
 	}
 
-	if err := CleanCorgiWorktrees(); err != nil {
+	if _, err := CleanCorgiWorktrees(false); err != nil {
 		t.Fatalf("clean: %v", err)
 	}
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
@@ -227,7 +227,7 @@ func TestApplyFeatureBranchOnlyWhereBranchExists(t *testing.T) {
 	if corgi.Services[1].CacheScope != "" {
 		t.Error("untouched service must keep an empty cache scope")
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestApplyFeatureBranchSkipsPinnedAndEmpty(t *testing.T) {
@@ -290,7 +290,7 @@ func TestEnsureFeatureWorktreeFromRemoteOnlyBranch(t *testing.T) {
 	if cur, _ := gitOut(dest, "rev-parse", "--abbrev-ref", "HEAD"); cur != "feature/x" {
 		t.Fatalf("worktree HEAD = %q, want feature/x", cur)
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestEnsureFeatureWorktreeUnknownBranchIsNoop(t *testing.T) {
@@ -360,7 +360,7 @@ func TestMaterializeServiceWorktreesFeatureFlag(t *testing.T) {
 	if corgi.Services[0].AbsolutePath != worktreeDest("api", "feature/x") {
 		t.Errorf("--feature did not relocate the service, got %s", corgi.Services[0].AbsolutePath)
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestMaterializeServiceWorktreesFeatureAbsentFlag(t *testing.T) {
@@ -406,7 +406,7 @@ func TestApplyServiceWorkdirsWithFeatureExplicitWins(t *testing.T) {
 	if empty.Services[0].AbsolutePath != repo {
 		t.Error("no inputs must be a no-op")
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestAddWorktreeUnknownBranchErrors(t *testing.T) {
@@ -519,7 +519,7 @@ func TestApplyFeatureBranchSharesOneWorktreePerRepo(t *testing.T) {
 	if corgi.Services[0].AbsolutePath == repo {
 		t.Error("expected a worktree, not the main checkout")
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestIsRepoRootThroughSymlink(t *testing.T) {
@@ -591,7 +591,7 @@ func TestApplyFeatureBranchHonoursServiceSelection(t *testing.T) {
 	if corgi.Services[1].AbsolutePath != other {
 		t.Errorf("an unselected service must not get a worktree, got %s", corgi.Services[1].AbsolutePath)
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestSelectedServices(t *testing.T) {
@@ -640,7 +640,7 @@ func TestEnsureServiceWorktreeReusesDifferentlyNamedWorktree(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(second, "f.txt")); err != nil {
 		t.Errorf("the reused path must be a usable checkout: %v", err)
 	}
-	t.Cleanup(func() { _ = CleanCorgiWorktrees() })
+	t.Cleanup(func() { _, _ = CleanCorgiWorktrees(false) })
 }
 
 func TestWorktreeForBranchAbsent(t *testing.T) {
@@ -710,5 +710,64 @@ func TestCheckoutFeatureBranchFromRemoteOnly(t *testing.T) {
 	}
 	if cur, _ := gitOut(clone, "rev-parse", "--abbrev-ref", "HEAD"); cur != "feature/x" {
 		t.Errorf("HEAD = %q, want feature/x", cur)
+	}
+}
+
+func TestCleanCorgiWorktreesKeepsDirtyWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	repo := filepath.Join(root, "api")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "f.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "init")
+	git(t, repo, "branch", "feature/x")
+
+	prev := CorgiComposePathDir
+	CorgiComposePathDir = root
+	t.Cleanup(func() { CorgiComposePathDir = prev })
+
+	dest := worktreeDest("api", "feature/x")
+	if _, err := EnsureServiceWorktree(repo, "feature/x", dest); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if WorktreeIsDirty(dest) {
+		t.Fatal("fresh worktree reported dirty")
+	}
+
+	if err := os.WriteFile(filepath.Join(dest, "wip.txt"), []byte("unsaved\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !WorktreeIsDirty(dest) {
+		t.Fatal("untracked file should count as dirty")
+	}
+
+	skipped, err := CleanCorgiWorktrees(false)
+	if err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	if len(skipped) != 1 || skipped[0] != dest {
+		t.Fatalf("expected %s to be skipped, got %v", dest, skipped)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "wip.txt")); err != nil {
+		t.Fatalf("uncommitted work was destroyed: %v", err)
+	}
+
+	skipped, err = CleanCorgiWorktrees(true)
+	if err != nil {
+		t.Fatalf("force clean: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("force must skip nothing, got %v", skipped)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatal("force clean left the worktree behind")
 	}
 }

--- a/utils/sessionlog_test.go
+++ b/utils/sessionlog_test.go
@@ -1,0 +1,195 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newSessionLogRoot(t *testing.T) string {
+	t.Helper()
+	prev := CorgiComposePathDir
+	CorgiComposePathDir = t.TempDir()
+	t.Cleanup(func() { CorgiComposePathDir = prev })
+	return CorgiServicesDir()
+}
+
+func readSessionLog(t *testing.T, base string) string {
+	t.Helper()
+	runs, err := ListServiceRuns(base, SessionLogDir)
+	if err != nil {
+		t.Fatalf("list session runs: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatal("no session log file was created")
+	}
+	b, err := os.ReadFile(runs[0])
+	if err != nil {
+		t.Fatalf("read session log: %v", err)
+	}
+	return string(b)
+}
+
+func TestSessionLogCapturesConsoleOutput(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	t.Cleanup(CloseSessionLog)
+
+	Infof("%s\n", "✗ [E_DANGLING_DEP] service \"web\" depends on unknown service \"api\"")
+	Info("port 3000 busy (services.web)")
+	CloseSessionLog()
+
+	got := readSessionLog(t, base)
+	if !strings.Contains(got, "E_DANGLING_DEP") {
+		t.Fatalf("validation error missing from session log:\n%s", got)
+	}
+	if !strings.Contains(got, "port 3000 busy") {
+		t.Fatalf("port conflict missing from session log:\n%s", got)
+	}
+}
+
+func TestSessionLogRedactsCredentials(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	t.Cleanup(CloseSessionLog)
+
+	Infof("DATABASE_URL=postgres://corgi:hunter2pass@localhost:5432/api\n")
+	Infof("POSTGRES_PASSWORD=sup3rs3cretvalue\n")
+	CloseSessionLog()
+
+	got := readSessionLog(t, base)
+	for _, leaked := range []string{"hunter2pass", "sup3rs3cretvalue"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("credential %q written to disk:\n%s", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "****") {
+		t.Fatalf("expected a mask in the session log:\n%s", got)
+	}
+}
+
+func TestSessionLogDoesNotChangeConsoleRouting(t *testing.T) {
+	base := newSessionLogRoot(t)
+	var sink strings.Builder
+	SetConsoleOverride(&sink)
+	t.Cleanup(ClearConsoleOverride)
+
+	StartSessionLog()
+	t.Cleanup(CloseSessionLog)
+	Info("hello console")
+	CloseSessionLog()
+
+	if !strings.Contains(sink.String(), "hello console") {
+		t.Fatalf("console lost the line, mirror must tee not divert: %q", sink.String())
+	}
+	if !strings.Contains(readSessionLog(t, base), "hello console") {
+		t.Fatal("session log did not receive the line")
+	}
+}
+
+func TestSessionLogIsNotOfferedAsAService(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	CloseSessionLog()
+	if _, err := OpenLogWriter(base, "api"); err != nil {
+		t.Fatalf("open api log: %v", err)
+	}
+
+	services, err := ListLoggedServices(base)
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	for _, s := range services {
+		if s == SessionLogDir {
+			t.Fatalf("%s must not appear in the service picker: %v", SessionLogDir, services)
+		}
+	}
+
+	streams, err := ListLoggedStreams(base)
+	if err != nil {
+		t.Fatalf("list streams: %v", err)
+	}
+	var found bool
+	for _, s := range streams {
+		if s == SessionLogDir {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("%s must be included in --all/--dump streams: %v", SessionLogDir, streams)
+	}
+}
+
+func TestNoMirrorLeavesWritersUntouched(t *testing.T) {
+	ClearConsoleMirror()
+	if MirrorWriter() != nil {
+		t.Fatal("mirror should be unset")
+	}
+	if got := withMirror(os.Stdout); got != os.Stdout {
+		t.Fatalf("withMirror must return the base writer unchanged when unset")
+	}
+}
+
+func TestStartSessionLogIsIdempotent(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	StartSessionLog()
+	t.Cleanup(CloseSessionLog)
+	Info("one line")
+	CloseSessionLog()
+
+	runs, err := ListServiceRuns(base, SessionLogDir)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 session log, got %d: %v", len(runs), runs)
+	}
+}
+
+func TestSessionLogDirIsUnderLogsDir(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	CloseSessionLog()
+	want := filepath.Join(base, ".logs", SessionLogDir)
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected session log dir at %s: %v", want, err)
+	}
+	stray := filepath.Join(CorgiComposePathDir, ".logs")
+	if _, err := os.Stat(stray); !os.IsNotExist(err) {
+		t.Fatalf("session log leaked a .logs dir into the project root at %s", stray)
+	}
+}
+
+func TestCloseSessionLogDropsEmptyFile(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	CloseSessionLog()
+
+	runs, err := ListServiceRuns(base, SessionLogDir)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("a run that logged nothing must not leave a file: %v", runs)
+	}
+}
+
+func TestWithMirrorTeesToSessionLog(t *testing.T) {
+	base := newSessionLogRoot(t)
+	StartSessionLog()
+	t.Cleanup(CloseSessionLog)
+
+	var terminal strings.Builder
+	fmt.Fprintln(WithMirror(&terminal), "E_PORT_CONFLICT: port 3000 busy")
+	CloseSessionLog()
+
+	if !strings.Contains(terminal.String(), "E_PORT_CONFLICT") {
+		t.Fatalf("terminal lost the line: %q", terminal.String())
+	}
+	if !strings.Contains(readSessionLog(t, base), "E_PORT_CONFLICT") {
+		t.Fatal("exit-path error missing from session log")
+	}
+}


### PR DESCRIPTION
A failed `corgi run` was hard to diagnose after the fact. Three gaps, each fixed here.

## 1. corgi's own output was never persisted

Service stdout has always been captured to `.logs/<service>/`. corgi's own voice was not — `OpenLogWriter` had exactly one caller, per service.

So everything worth a post-mortem went to the terminal and nowhere else:

- validation errors (`E_DANGLING_DEP`, `E_DUPLICATE_NAME`, …)
- port conflicts
- which branch each service resolved to under `--service-branch`
- spawn failures

All of those happen **before** any service starts, so a detached run that failed there left **zero** files on disk and `corgi logs` had nothing to show. You had to re-run to see the error again.

Now mirrored into `.logs/_corgi/<timestamp>.log`:

```
corgi logs --session          # corgi's own output for the last run
corgi logs --all              # merged stream now includes it
corgi logs --dump ./artifacts # CI artifact now includes it
```

The mirror **tees, it never diverts**. `infoWriter()`/`ConsoleOut()` keep their existing stdout-vs-stderr logic and gain a second sink, so the terminal sees the same bytes and the pure-JSON-on-stdout contract is unchanged. A run that logs nothing leaves no empty file behind.

Verified end to end against both original failures:

```
2026-08-18T08:38:46.303Z ✗ corgi-compose.yml has 1 validation error(s):
2026-08-18T08:38:46.303Z   ✗ [E_DANGLING_DEP] service "web" depends on unknown service "api"

2026-08-18T08:39:33.251Z ❌ port conflict (use --kill-port to reclaim):
2026-08-18T08:39:33.251Z   port 3000 busy (services.web) — held by node(pid=4242)
```

The port-conflict half needed `exitWithErrorPrefix` routed through the mirror too — it wrote straight to `os.Stderr`, which is the exit path most structured errors take.

### It is redacted

corgi resolves DB credentials, S3 endpoints and provider keys during a run, and a log file is much easier to paste into an issue than a terminal scrollback. The session log masks credential-shaped spans before anything reaches disk: secret-named assignments, `scheme://user:pass@host`, AWS access-key ids, JWTs, PEM blocks. Service logs are untouched.

The mask is fixed-width, so it does not encode the secret's length. Redaction happens on the whole logical line, after partial chunks are joined — a credential split across two writes still gets caught.

## 2. `stop` deleted the only record of the run

`.state.json` holds, per service: resolved `Command`, `Port`, `LogFile`, `Status`, `StartedAt`, `ExitCode`. `corgi stop` unlinked it.

The `.log` files it indexes **outlive it**, so deleting it orphaned them. After a stop you could not answer:

- which log file belongs to which service from that run
- did it exit clean or crash
- which branch actually ran (`Command` was the only trace)

Kept as `.state.last.json` instead. Every reader (`ps`, `restart`, `stop`, `mcp`) still keys off `.state.json`, so a kept copy can never read as a running stack and `E_ALREADY_RUNNING` cannot false-fire. Both files are added to `corgi_services/.gitignore` — they record spawn commands and are workspace-local by contract.

## 3. `worktree prune` discarded uncommitted work

`CleanCorgiWorktrees` ran `git worktree remove --force` on every corgi worktree. A corgi worktree is a real branch checkout someone may still be editing, and `--force` drops uncommitted and untracked files with no prompt and no reflog to recover from.

Now a dirty worktree is kept and named:

```
🗑️ pruned corgi worktrees
kept 1 with uncommitted changes (--force to drop):
  corgi_services/.worktrees/api-feature-add-metrics
```

`--force` restores the old behaviour. `corgi clean` / `--fromScratch` behave the same way — dropping generated corgi state should not mean throwing away a branch. An unreadable worktree counts as dirty: refusing to delete what we cannot inspect is the safe default.

## Tests

`go vet` clean, `gofmt` clean, **11 packages ok / 0 fail** — identical to the baseline on `main`.

New coverage:

- redaction: each credential shape masked, ordinary corgi log lines left byte-identical, mask width independent of secret length
- session log: captures validation errors and port conflicts, redacts before disk, does not change console routing, idempotent, not offered as a phantom service in the picker but present in `--all`/`--dump`
- worktree: untracked file counts as dirty, dirty worktree survives a normal prune, `--force` removes it
- state: `removeStateLocked` keeps the spawn command and log index

Two bugs were found by running the real binary against a real failing stack, not by the unit tests:

1. `StartSessionLog` was passed the compose dir instead of `corgi_services`, so it created a stray `.logs/` in the **project root** and the real log was never written. Both callers now share `utils.CorgiServicesDir()`, and there is a regression test asserting no stray dir — confirmed red without the fix.
2. Port conflicts bypassed the mirror via the direct-stderr exit path.

## Separate commit

`Use a placeholder ticket key in the review skill` is unrelated to the above: the branch-name example in `plugins/corgi/skills/review/SKILL.md` shipped a real tracker key from a private workspace. Every other example in that file already uses `ABC-123`.
