### PR TITLE
Add corgi env check, cache restore-keys, and CI skill hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ corgi is meant to be driven by AI agents and CI, not just typed by hand — a sm
 
 - **It never blocks on a prompt.** corgi notices it's running in an agent or pipeline and either skips the question or fails with a clear error instead of hanging. That same non-interactive contract is exactly what a CI job needs.
 - **It speaks machine.** Clean JSON with `--json`, predictable exit codes (`0` ok, `1` failed, `2` bad usage), and a documented [error-code list](docs/agents.md) — so a tool can read what happened and react, instead of parsing log noise.
-- **Quiet, scriptable entry points.** `corgi env <service>` shows the exact env a service will get and where each value came from; `corgi exec` and `corgi test` run commands and tests in that same env; `corgi run --dry-run --json` previews a whole run without touching anything.
+- **Quiet, scriptable entry points.** `corgi env <service>` shows the exact env a service will get and where each value came from; `corgi env check` fails when a service's env file misses keys its `.env-example` declares (keys corgi generates are excluded, `--file .env.ci` checks a committed CI env file); `corgi exec` and `corgi test` run commands and tests in that same env; `corgi run --dry-run --json` previews a whole run without touching anything.
 - **One-glance state.** `corgi mission-control` (alias `mc`) shows the live stack plus each service's git/PR/CI state — `--json` for a single snapshot, `--watch` to follow along.
 - **Workspace memory.** `corgi memory` is an opt-in, committed `.corgi/memory/` store of stack decisions and recurring fixes (with a `corgi memory lint` secret-scan) that the skills read before acting — so lessons survive between sessions.
 

--- a/action.yml
+++ b/action.yml
@@ -51,24 +51,40 @@ outputs:
   cache-1-paths:
     description: Group 1's newline-separated paths, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-1-paths }}
+  cache-1-restore-keys:
+    description: >-
+      Group 1's restore-keys prefix (corgi-deps-<ecosystem>-), so a lockfile
+      change restores the previous packages instead of starting empty. Empty
+      when there is no such group, and for the markers group, which is
+      exact-key only.
+    value: ${{ steps.setup.outputs.cache-1-restore-keys }}
   cache-2-key:
     description: Group 2's key, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-2-key }}
   cache-2-paths:
     description: Group 2's newline-separated paths, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-2-paths }}
+  cache-2-restore-keys:
+    description: Group 2's restore-keys prefix, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-2-restore-keys }}
   cache-3-key:
     description: Group 3's key, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-3-key }}
   cache-3-paths:
     description: Group 3's newline-separated paths, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-3-paths }}
+  cache-3-restore-keys:
+    description: Group 3's restore-keys prefix, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-3-restore-keys }}
   cache-4-key:
     description: Group 4's key, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-4-key }}
   cache-4-paths:
     description: Group 4's newline-separated paths, empty when there is no such group.
     value: ${{ steps.setup.outputs.cache-4-paths }}
+  cache-4-restore-keys:
+    description: Group 4's restore-keys prefix, empty when there is no such group.
+    value: ${{ steps.setup.outputs.cache-4-restore-keys }}
   cache-overflow:
     description: >-
       How many ecosystems did not fit the four slots. The action already warns
@@ -157,6 +173,9 @@ runs:
           for i in 1 2 3 4; do
             key="$(jq -r --argjson i "$i" '.[$i-1].key // ""' <<<"$groups")"
             echo "cache-$i-key=$key" >> "$GITHUB_OUTPUT"
+            # `// ""` keeps this working against a corgi predating restorePrefix.
+            restore="$(jq -r --argjson i "$i" '.[$i-1].restorePrefix // ""' <<<"$groups")"
+            echo "cache-$i-restore-keys=$restore" >> "$GITHUB_OUTPUT"
             {
               echo "cache-$i-paths<<CORGI_ACTION_EOF"
               jq -r --argjson i "$i" '.[$i-1].pathsText // ""' <<<"$groups"
@@ -174,6 +193,7 @@ runs:
           for i in 1 2 3 4; do
             echo "cache-$i-key=" >> "$GITHUB_OUTPUT"
             echo "cache-$i-paths=" >> "$GITHUB_OUTPUT"
+            echo "cache-$i-restore-keys=" >> "$GITHUB_OUTPUT"
           done
           echo "cache-overflow=0" >> "$GITHUB_OUTPUT"
         fi

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -195,6 +195,19 @@ on:
         required: true
         type: string
   pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to boot the stack from
+        required: false
+        # Keep the default empty: a non-empty one silently beats the
+        # || fallbacks below, booting main while claiming to test a branch.
+        default: ""
+        type: string
+  # A daily default-branch run keeps the dependency caches warm: GitHub
+  # scopes caches per ref, so a fresh PR restores from the base branch.
+  # schedule:
+  #   - cron: "0 6 * * *"
 
 concurrency:
   group: stack-e2e-${{ github.repository }}-${{ inputs.branch || github.head_ref }}
@@ -207,7 +220,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      BRANCH: ${{ inputs.branch || github.head_ref || 'main' }}
+      # head_ref covers PRs; ref_name covers dispatch/schedule runs.
+      BRANCH: ${{ inputs.branch || github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v5
 
@@ -221,26 +235,35 @@ jobs:
         with:
           path: ${{ steps.corgi.outputs.cache-1-paths }}
           key: ${{ steps.corgi.outputs.cache-1-key }}
+          restore-keys: ${{ steps.corgi.outputs.cache-1-restore-keys }}
       - uses: actions/cache@v4
         if: steps.corgi.outputs.cache-2-key != ''
         with:
           path: ${{ steps.corgi.outputs.cache-2-paths }}
           key: ${{ steps.corgi.outputs.cache-2-key }}
+          restore-keys: ${{ steps.corgi.outputs.cache-2-restore-keys }}
       - uses: actions/cache@v4
         if: steps.corgi.outputs.cache-3-key != ''
         with:
           path: ${{ steps.corgi.outputs.cache-3-paths }}
           key: ${{ steps.corgi.outputs.cache-3-key }}
+          restore-keys: ${{ steps.corgi.outputs.cache-3-restore-keys }}
       - uses: actions/cache@v4
         if: steps.corgi.outputs.cache-4-key != ''
         with:
           path: ${{ steps.corgi.outputs.cache-4-paths }}
           key: ${{ steps.corgi.outputs.cache-4-key }}
+          restore-keys: ${{ steps.corgi.outputs.cache-4-restore-keys }}
 
       - run: corgi init --depth 1 --feature "$BRANCH"
 
       # Fails in seconds on a missing env file, busy port or missing tool.
       - run: corgi doctor
+
+      # Optional: fail here, not at the first request, when a service's env
+      # file misses keys its .env-example declares (corgi-generated keys are
+      # excluded automatically).
+      # - run: corgi env check
 
       - run: corgi run --feature "$BRANCH" --detach --wait --wait-timeout 25m --follow
         timeout-minutes: 30
@@ -258,6 +281,9 @@ jobs:
           name: stack-e2e-${{ github.run_id }}
           path: ci-artifacts/
           retention-days: 7
+          # error, not warn: a wrong path otherwise uploads an empty
+          # artifact on every run and nobody notices until a red one.
+          if-no-files-found: error
 
       - if: always()
         run: corgi stop || true

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -210,7 +210,9 @@ on:
   #   - cron: "0 6 * * *"
 
 concurrency:
-  group: stack-e2e-${{ github.repository }}-${{ inputs.branch || github.head_ref }}
+  # Same fallback chain as BRANCH below, or every dispatch/schedule run lands
+  # in one empty-suffix group and cancels the others.
+  group: stack-e2e-${{ github.repository }}-${{ inputs.branch || github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -272,8 +274,11 @@ jobs:
 
       - run: corgi test --e2e
 
+      # mkdir keeps the upload below meaningful: without it, a run that dies
+      # before the dump leaves no directory and the upload's error points at
+      # artifacts instead of the real cause.
       - if: always()
-        run: corgi logs --dump ./ci-artifacts/logs || true
+        run: mkdir -p ci-artifacts && { corgi logs --dump ./ci-artifacts/logs || true; }
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -29,7 +29,8 @@ and cross-service references), with the source of each variable. Writes nothing.
 func init() {
 	envCmd.Flags().Bool("export", false, "Emit eval-able 'export KEY=VALUE' lines (real values)")
 	envCmd.Flags().Bool("reveal", false, "Do not mask secret values in the human view (human view only)")
-	envCmd.Flags().StringVar(&utils.EnvTierFromFlag, "tier", "", "Resolve env for this compose envTier (e.g. staging, prod)")
+	// Persistent so `env check` inherits it (and its shell completion).
+	envCmd.PersistentFlags().StringVar(&utils.EnvTierFromFlag, "tier", "", "Resolve env for this compose envTier (e.g. staging, prod)")
 	rootCmd.AddCommand(envCmd)
 }
 

--- a/cmd/env_check.go
+++ b/cmd/env_check.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	"andriiklymiuk/corgi/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var envCheckCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Fail when a service's env file misses keys its .env-example declares",
+	Long: `Diff each service's env source against the example file its repo commits
+(.env-example or .env.example), subtracting every key corgi generates itself
+(db and service dependencies, ports, environment literals). What remains is a
+key the service expects and nothing provides — the kind that fails at the
+first request, thousands of log lines from the cause.
+
+Exits non-zero on any missing key, on a declared env source that does not
+exist, and when nothing could be checked at all — a vacuous pass would read
+as coverage.
+
+Empty values are not findings: an empty key is often a deliberate off switch.
+
+Examples:
+  corgi env check                  # each service's resolved env source
+  corgi env check --file .env.ci   # a committed CI env file in each repo
+  corgi env check --json`,
+	RunE: runEnvCheck,
+}
+
+func init() {
+	envCheckCmd.Flags().String("file", "", "Check this file inside each service repo instead of the resolved env source")
+	envCheckCmd.Flags().StringVar(&utils.EnvTierFromFlag, "tier", "", "Resolve env for this compose envTier (e.g. staging, prod)")
+	envCmd.AddCommand(envCheckCmd)
+}
+
+func runEnvCheck(cmd *cobra.Command, _ []string) error {
+	utils.PayloadOnStdout = true
+
+	corgi, err := utils.GetCorgiServices(cmd)
+	if err != nil {
+		return fmt.Errorf("%s: %v", utils.ErrComposeNotFound, err)
+	}
+
+	fileOverride, _ := cmd.Flags().GetString("file")
+	rows, err := utils.EnvCheckAll(corgi, fileOverride)
+	if err != nil {
+		return err
+	}
+
+	summary, findings := utils.EnvCheckSummary(rows)
+	if utils.JSONOutput {
+		utils.PrintJSON(map[string]any{"ok": !findings, "services": rows})
+	} else {
+		// The verdict is the payload; Info would land on stderr here.
+		fmt.Print(summary)
+	}
+	if findings {
+		utils.CloseSessionLog()
+		osExit(1)
+	}
+	return nil
+}

--- a/cmd/env_check.go
+++ b/cmd/env_check.go
@@ -9,7 +9,7 @@ import (
 )
 
 var envCheckCmd = &cobra.Command{
-	Use:   "check",
+	Use:   "check [service...]",
 	Short: "Fail when a service's env file misses keys its .env-example declares",
 	Long: `Diff each service's env source against the example file its repo commits
 (.env-example or .env.example), subtracting every key corgi generates itself
@@ -18,13 +18,14 @@ key the service expects and nothing provides — the kind that fails at the
 first request, thousands of log lines from the cause.
 
 Exits non-zero on any missing key, on a declared env source that does not
-exist, and when nothing could be checked at all — a vacuous pass would read
-as coverage.
+exist while the example still needs keys, and when nothing could be checked
+at all — a vacuous pass would read as coverage.
 
 Empty values are not findings: an empty key is often a deliberate off switch.
 
 Examples:
   corgi env check                  # each service's resolved env source
+  corgi env check api              # just one service
   corgi env check --file .env.ci   # a committed CI env file in each repo
   corgi env check --json`,
 	RunE: runEnvCheck,
@@ -32,11 +33,10 @@ Examples:
 
 func init() {
 	envCheckCmd.Flags().String("file", "", "Check this file inside each service repo instead of the resolved env source")
-	envCheckCmd.Flags().StringVar(&utils.EnvTierFromFlag, "tier", "", "Resolve env for this compose envTier (e.g. staging, prod)")
 	envCmd.AddCommand(envCheckCmd)
 }
 
-func runEnvCheck(cmd *cobra.Command, _ []string) error {
+func runEnvCheck(cmd *cobra.Command, args []string) error {
 	utils.PayloadOnStdout = true
 
 	corgi, err := utils.GetCorgiServices(cmd)
@@ -49,17 +49,45 @@ func runEnvCheck(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	if rows, err = filterEnvCheckRows(rows, args); err != nil {
+		return err
+	}
 
-	summary, findings := utils.EnvCheckSummary(rows)
+	checked, findings := utils.EnvCheckStats(rows)
 	if utils.JSONOutput {
-		utils.PrintJSON(map[string]any{"ok": !findings, "services": rows})
+		doc := map[string]any{"ok": !findings, "services": rows}
+		if checked == 0 {
+			doc["reason"] = utils.EnvCheckNothingChecked
+		}
+		utils.PrintJSON(doc)
 	} else {
+		summary, _ := utils.EnvCheckSummary(rows)
 		// The verdict is the payload; Info would land on stderr here.
 		fmt.Print(summary)
 	}
 	if findings {
-		utils.CloseSessionLog()
-		osExit(1)
+		exitProcess(1)
 	}
 	return nil
+}
+
+// filterEnvCheckRows narrows to the named services, erroring on unknown names
+// so a typo cannot read as a pass.
+func filterEnvCheckRows(rows []utils.EnvCheckRow, names []string) ([]utils.EnvCheckRow, error) {
+	if len(names) == 0 {
+		return rows, nil
+	}
+	byName := map[string]utils.EnvCheckRow{}
+	for _, row := range rows {
+		byName[row.Service] = row
+	}
+	out := make([]utils.EnvCheckRow, 0, len(names))
+	for _, name := range names {
+		row, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("%s: service %q not found", utils.ErrServiceNotFound, name)
+		}
+		out = append(out, row)
+	}
+	return out, nil
 }

--- a/cmd/env_check_test.go
+++ b/cmd/env_check_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+func TestFilterEnvCheckRowsKeepsRequestedOrder(t *testing.T) {
+	rows := []utils.EnvCheckRow{
+		{Service: "api"}, {Service: "web"}, {Service: "worker"},
+	}
+	got, err := filterEnvCheckRows(rows, []string{"worker", "api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Service != "worker" || got[1].Service != "api" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestFilterEnvCheckRowsNoNamesReturnsAll(t *testing.T) {
+	rows := []utils.EnvCheckRow{{Service: "api"}}
+	got, err := filterEnvCheckRows(rows, nil)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("got %+v, err %v", got, err)
+	}
+}
+
+// A typo'd service name must error — silently checking everything (or
+// nothing) would let the caller read the exit code as their service's verdict.
+func TestFilterEnvCheckRowsRejectsUnknownService(t *testing.T) {
+	rows := []utils.EnvCheckRow{{Service: "api"}}
+	_, err := filterEnvCheckRows(rows, []string{"apo"})
+	if err == nil || !strings.Contains(err.Error(), "apo") {
+		t.Fatalf("expected an error naming the unknown service, got %v", err)
+	}
+}

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -24,6 +24,12 @@ func exitWithErrorPrefix(jsonCode, stderrPrefix string, err error, exitCode int)
 	} else {
 		fmt.Fprintln(utils.WithMirror(os.Stderr), err)
 	}
+	exitProcess(exitCode)
+}
+
+// exitProcess is the one exit sequence: close the session log, then exit.
+// Commands ending without an error message use it directly.
+func exitProcess(code int) {
 	utils.CloseSessionLog()
-	osExit(exitCode)
+	osExit(code)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.20.35"
+var APP_VERSION = "1.20.36"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.20.35",
+  "version": "1.20.36",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/skills/ci/SKILL.md
+++ b/plugins/corgi/skills/ci/SKILL.md
@@ -42,6 +42,7 @@ from `references/github-actions.md` / `references/gitlab-ci.md` instead.
    Also check `corgi test --help | grep e2e` and `corgi cache --help` — recent corgi
    adds `corgi test --e2e` (runs the compose's `e2e:` block against the live stack)
    and `corgi cache paths` (derives the CI cache plan from the compose file).
+   `corgi env check --help` working means the env-drift gate below is available too.
 2. **Read `corgi-compose.yml`.** Count `db_services` (each is containers + disk) and
    services. Note every `required:` tool and which are human-only. Check for a
    top-level `e2e:` block — if there is one, the e2e step is `corgi test --e2e`,
@@ -50,6 +51,14 @@ from `references/github-actions.md` / `references/gitlab-ci.md` instead.
 3. **Find where secrets come from.** `copyEnvFromFilePath:` points at files that are
    almost always gitignored. CI has none of them. This is the single most common
    reason a first attempt never boots — settle it before writing YAML.
+   A CI env file usually needs no real secrets at all: placeholders plus the
+   third-party feature flags off (an empty key is often the off switch), and a
+   local sink for anything like mail — which lets each repo commit its CI env
+   file instead of holding it in the forge's secret store. `corgi env check`
+   makes completeness a failing step, not a first-request surprise: it diffs
+   each service's env file against the `.env-example` its repo commits,
+   excluding every key corgi generates; `--file .env.ci` validates a committed
+   CI env file before anything copies it into place.
 4. **Ask which repos participate** if the workspace has more than a handful, and
    whether the job blocks merge or only reports.
 
@@ -130,6 +139,20 @@ until the step times out.
 **The dependency cache only saves on a successful job.** Until one run goes green
 you pay every install every time — do not read early runs as the steady state.
 
+**When every service goes silent at once, it is memory, not the tests.** A full
+stack of containers next to several dev servers can exceed a hosted runner's few
+GB, and the failure reads as the runner losing contact or a container `Killed` —
+never as an OOM message. Print free memory before the boot, cap any test
+runner's worker count (a per-CPU default can OOM a shared runner by itself),
+and move to a larger runner before chasing ghost failures.
+
+**A headless browser-driving runner can silently drop its screenshots.** One
+suite's in-flow screenshot command is a documented no-op under its headless
+mode — proven only by counting zero images after a red run. Verify one artifact
+actually lands before trusting the pipeline's evidence; collect the runner's
+own debug directory as a fallback, or run headed under a virtual display
+(xvfb) when the screenshots are the point.
+
 ## Non-negotiables
 
 - **Never run the job inside a container** (`jobs.<id>.container:` on GitHub,
@@ -165,8 +188,14 @@ so it cannot drift as services come and go. `--key` prints the matching cache ke
 so one lockfile change doesn't evict every other language's packages. On GitHub
 the `Andriiklymiuk/corgi@v1` action exposes all of this as step outputs
 (`cache-paths`, `cache-key`, `cache-groups`) ready to feed `actions/cache`, plus
-four fixed slots (`cache-1-key`/`cache-1-paths` … `cache-4-*`) so a workflow
-writes four plain cache steps instead of `fromJSON(...)[i]` indexing. Neither a
+four fixed slots (`cache-1-key`/`cache-1-paths`/`cache-1-restore-keys` …
+`cache-4-*`) so a workflow writes four plain cache steps instead of
+`fromJSON(...)[i]` indexing. The `restore-keys` slot is the group's
+`corgi-deps-<ecosystem>-` prefix, so a lockfile change restores the previous
+packages instead of starting empty; the markers slot stays exact-match on
+purpose. GitHub also scopes caches per ref — a fresh PR restores only what its
+base branch saved, so a scheduled default-branch run is what keeps new PRs
+warm. Neither a
 workflow expression nor a composite action can loop, so the copies stay — but
 the action warns by itself when an ecosystem does not fit, which used to be a
 hand-written step.
@@ -263,6 +292,15 @@ Worth telling the user up front, because it decides how much the job is worth:
   answer.
 - **Anything costing money or rate-limited per call** (third-party model APIs)
   should be flag-disabled or stubbed, not called for real on every PR.
+
+Two suites, one entry point: the merge gate runs against the stack built from
+the branches under review; a scheduled run points the *same* suite — same
+command, same env names, only the base URL differs — at the deployed
+environment. Keep one runner script for local and CI so they cannot drift, and
+make it print every scenario as pass/fail/skip: a quarantined test hidden
+inside a green pass count is coverage you no longer have. A deployed
+environment can lag the default branch — before debugging a red scheduled run,
+check the change under test has actually shipped there.
 
 ## Verify before claiming it works
 

--- a/plugins/corgi/skills/ci/references/github-actions.md
+++ b/plugins/corgi/skills/ci/references/github-actions.md
@@ -56,8 +56,11 @@ jobs:
 
       # The plan covers each service's dependency dir + corgi_services/.cache
       # (the beforeStart skip markers). On a polyglot stack, prefer one
-      # actions/cache step per slot (cache-1-key/paths … cache-4-key/paths) so one
-      # lockfile change doesn't evict every other language's packages.
+      # actions/cache step per slot (cache-1-key/paths/restore-keys …
+      # cache-4-*) so one lockfile change doesn't evict every other language's
+      # packages — the restore-keys slot (corgi ≥ 1.20.36) is the group's
+      # corgi-deps-<ecosystem>- prefix, so a changed lockfile starts from the
+      # previous packages instead of empty.
       - name: Restore dependency caches
         uses: actions/cache@v4
         with:
@@ -154,3 +157,15 @@ jobs:
   commit-status API.
 - `concurrency` on the caller cancels superseded runs; without it every push to a
   PR starts another full stack.
+- A `workflow_dispatch` branch input must default to `""`, never to a branch
+  name: a non-empty default beats every `||` fallback, so a manual run silently
+  boots the default branch while claiming to test yours.
+- Add a daily `schedule:` run on the default branch. GitHub scopes caches per
+  ref, so a fresh PR restores from its base branch — the scheduled run is what
+  keeps that base warm (and doubles as a drift alarm for the suite itself).
+- `if-no-files-found: error` on the artifact upload. With the default `warn`, a
+  wrong path uploads an empty artifact on every run and nobody notices until
+  the red run whose evidence is missing.
+- `package-manager-cache: false` on `actions/setup-node` (and its analogues):
+  corgi already says what to cache, and two cachers over the same directories
+  race each other's restores.

--- a/plugins/corgi/skills/ci/references/gitlab-ci.md
+++ b/plugins/corgi/skills/ci/references/gitlab-ci.md
@@ -83,6 +83,11 @@ stack-e2e:
   GitLab's equivalent of GitHub's `concurrency` group.
 - `GIT_DEPTH: "1"` shallow-clones the *caller*; `corgi init --depth 1` handles
   the service repos.
+- **Sharding e2e by feature-domain folder** (`parallel: matrix:` over a folder
+  list) keeps wall clock flat as the suite grows — but a `needs:` gate on that
+  job must then name every matrix permutation by hand, and a newly added shard
+  silently falls out of the gate. Gate on the stage where possible, and add a
+  lint job that fails when the domain folders and the matrix list drift apart.
 
 ## Caching
 

--- a/plugins/corgi/skills/corgi/references/healthchecks.md
+++ b/plugins/corgi/skills/corgi/references/healthchecks.md
@@ -70,6 +70,7 @@ Output is colored text — results to stdout, load/config errors to stderr (no J
 
 ## When to add healthCheck
 
+- **A `sleep` in `beforeStart`/`start` is a readiness gap wearing a costume.** Replace it with the real primitive: `healthCheck:` (or a `warmup:` block for a server that builds on first request), `corgi db --upAll --wait` for databases, `corgi run --wait` in scripts. A sleep tuned on one machine fails on a slower one and wastes time on a faster one.
 - **Add it for services** where "port open" isn't enough — e.g. a Rails server binds the port long before migrations finish.
 - **Skip it for databases** unless you have a specific readiness endpoint. TCP probing is usually sufficient for postgres/mysql/redis/etc.
 - **Always set it on localstack** if you've overridden the default port or disabled the health service, to avoid probing a non-existent endpoint.

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -108,6 +108,10 @@ per-story review, draft PR, grouped report.
 - **Minimal code comments.** Don't narrate the change in code comments — it reads from
   the diff and the PR/commit. Add one only for a genuinely non-obvious invariant that
   would otherwise be lost, and only where the file already comments. No "// added X" notes.
+- **Read the repo's own agent docs before running anything in it.** A service's
+  CLAUDE.md/AGENTS.md may forbid specific commands (a dev server that breaks the build,
+  a script that mutates state). A triage produced by a forbidden command is noise —
+  rerun it the documented way before believing it.
 - **Don't spam the ticket.** One comment per story (spec, with its QA section folded in),
   updated in place on re-runs — never a pile of new comments.
 
@@ -317,6 +321,9 @@ file; the `## Spec` comment is the spec — _Express lane_):
   non-testable stories.
 - **Blocked → do NOT post.** Spec local only; mark `Status: BLOCKED` + **Decision
   needed**; surface the choice. Hold it; rest of batch proceeds.
+- **Env-gated dependency = blocked, not guessed.** A registry behind VPN/auth, a
+  build that needs credentials only a human holds — mark the story blocked naming
+  exactly what's missing; never fake the verification or report it as run.
 
 `superpowers:brainstorming` / `superpowers:systematic-debugging` (if installed) to
 resolve ambiguity before blocking.

--- a/utils/cachepaths.go
+++ b/utils/cachepaths.go
@@ -34,6 +34,12 @@ type CacheGroup struct {
 	// build a newline-separated string, and that is the only separator
 	// actions/cache accepts, so the join has to happen here.
 	PathsText string `json:"pathsText"`
+	// RestorePrefix feeds actions/cache's restore-keys: it matches any earlier
+	// key of the same ecosystem, so a lockfile change starts from the previous
+	// packages instead of empty. Empty for the markers group — corgi re-hashes
+	// every cacheKey before trusting a marker, so restoring stale ones buys
+	// nothing.
+	RestorePrefix string `json:"restorePrefix,omitempty"`
 }
 
 // ecosystem maps a lockfile to the directories a build of it produces: one
@@ -148,10 +154,11 @@ func (acc *cacheAccumulator) cacheGroups() []CacheGroup {
 	for _, id := range sortedGroupIDs(acc.groupPaths) {
 		p := sortedPathSet(acc.groupPaths[id])
 		groups = append(groups, CacheGroup{
-			ID:        id,
-			Paths:     p,
-			Key:       fmt.Sprintf("corgi-deps-%s-%s", id, hex.EncodeToString(acc.groupHash[id].Sum(nil))[:16]),
-			PathsText: strings.Join(p, "\n"),
+			ID:            id,
+			Paths:         p,
+			Key:           fmt.Sprintf("corgi-deps-%s-%s", id, hex.EncodeToString(acc.groupHash[id].Sum(nil))[:16]),
+			PathsText:     strings.Join(p, "\n"),
+			RestorePrefix: fmt.Sprintf("corgi-deps-%s-", id),
 		})
 	}
 	return groups

--- a/utils/cachepaths_test.go
+++ b/utils/cachepaths_test.go
@@ -167,6 +167,32 @@ func TestCacheGroupsAreIndependentPerEcosystem(t *testing.T) {
 	}
 }
 
+// restore-keys lets a changed lockfile start from the previous packages; the
+// markers stay exact-match because corgi re-hashes them anyway.
+func TestCacheGroupRestorePrefix(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{"v":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	svc := []Service{{
+		ServiceName: "web", Path: "./web", AbsolutePath: dir,
+		BeforeStart: BeforeStartSteps{{Run: "npm ci", CacheKey: []string{"package-lock.json"}}},
+	}}
+
+	plan := planFor(t, svc)
+	for _, g := range plan.Groups {
+		if g.ID == "markers" {
+			if g.RestorePrefix != "" {
+				t.Errorf("markers group must have no restore prefix, got %q", g.RestorePrefix)
+			}
+			continue
+		}
+		if g.RestorePrefix == "" || !strings.HasPrefix(g.Key, g.RestorePrefix) {
+			t.Errorf("group %s: key %q must start with its restore prefix %q", g.ID, g.Key, g.RestorePrefix)
+		}
+	}
+}
+
 // A restored step marker next to a dependency directory that did not come back
 // would make corgi skip an install whose output is missing.
 func TestCacheMarkersAreKeyedOnEveryLockfile(t *testing.T) {

--- a/utils/envcheck.go
+++ b/utils/envcheck.go
@@ -45,97 +45,106 @@ func EnvCheckAll(corgi *CorgiCompose, fileOverride string) ([]EnvCheckRow, error
 
 	rows := make([]EnvCheckRow, 0, len(corgi.Services))
 	for _, svc := range sortedServices(corgi) {
-		rows = append(rows, envCheckService(svc, all[svc.ServiceName], fileOverride))
+		row, err := envCheckService(svc, all[svc.ServiceName], fileOverride)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
 	}
 	return rows, nil
 }
 
-func envCheckService(svc Service, resolved []EnvVar, fileOverride string) EnvCheckRow {
+func envCheckService(svc Service, resolved []EnvVar, fileOverride string) (EnvCheckRow, error) {
 	row := EnvCheckRow{Service: svc.ServiceName}
 	if svc.IgnoreEnv {
 		row.Skipped = "ignore_env is set"
-		return row
+		return row, nil
 	}
 
 	example := exampleEnvFile(svc)
 	if example == "" {
 		row.Skipped = "no .env-example / .env.example in the service repo"
-		return row
+		return row, nil
 	}
 	row.Example = displayPath(example)
+
+	exampleKeys, err := envFileKeys(example)
+	if err != nil {
+		return row, err
+	}
+	generated := map[string]bool{}
+	for _, e := range resolved {
+		if e.IsGenerated() {
+			generated[e.Key] = true
+		}
+	}
+	missingFrom := func(provided map[string]bool) []string {
+		var missing []string
+		for key := range exampleKeys {
+			if !provided[key] && !generated[key] {
+				missing = append(missing, key)
+			}
+		}
+		sort.Strings(missing)
+		return missing
+	}
+	// An absent source is only a finding when the example declares keys corgi
+	// does not generate — an example of purely generated keys needs no file.
+	absentSource := func(display string) EnvCheckRow {
+		if missing := missingFrom(nil); len(missing) > 0 {
+			row.Source = display
+			row.Missing = missing
+			row.SourceAbsent = true
+		}
+		return row
+	}
 
 	var source string
 	if fileOverride != "" {
 		candidate := filepath.Join(svc.AbsolutePath, fileOverride)
 		if !fileExists(candidate) {
-			row.Source = displayPath(candidate)
-			row.SourceAbsent = true
-			return row
+			return absentSource(displayPath(candidate)), nil
 		}
 		source = candidate
 	} else {
-		rel := resolveCopyEnvPath(svc, "")
-		if rel == "" {
-			row.Skipped = "no copyEnvFromFilePath — env comes from the example file itself"
-			return row
+		// The same resolution corgi run uses, so check and run can never
+		// disagree about which file a service's env comes from.
+		resolvedSrc := resolveEnvSourceFile(CorgiComposePathDir, svc, "", ActiveTierName, ActiveTierDir)
+		if resolvedSrc == "" || sameFile(resolvedSrc, example) {
+			// Resolution fell through to the example (or nothing): diffing
+			// the example against itself proves nothing.
+			if svc.CopyEnvFromFilePath == "" {
+				row.Skipped = "no copyEnvFromFilePath — env comes from the example file itself"
+				return row, nil
+			}
+			return absentSource(svc.CopyEnvFromFilePath), nil
 		}
-		if ActiveTierName != "" {
-			rel = strings.ReplaceAll(rel, "${tier}", ActiveTierName)
-		}
-		candidate := filepath.Join(CorgiComposePathDir, rel)
-		if !fileExists(candidate) {
-			row.Source = rel
-			row.SourceAbsent = true
-			return row
-		}
-		source = candidate
-	}
-	if sameFile(source, example) {
-		// Diffing the example against itself proves nothing.
-		row.Skipped = "env source is the example file itself — nothing to diff"
-		return row
+		source = resolvedSrc
 	}
 	row.Source = displayPath(source)
 
-	provided := envFileKeys(source)
-	generated := map[string]bool{}
-	for _, e := range resolved {
-		// file:* entries come from the copied env file; everything else
-		// (db:, service:, self:port, literal) corgi generates at run time.
-		if !strings.HasPrefix(e.Source, "file:") {
-			generated[e.Key] = true
-		}
+	provided, err := envFileKeys(source)
+	if err != nil {
+		return row, err
 	}
-
-	for key := range envFileKeys(example) {
-		if !provided[key] && !generated[key] {
-			row.Missing = append(row.Missing, key)
-		}
-	}
-	sort.Strings(row.Missing)
-	return row
+	row.Missing = missingFrom(provided)
+	return row, nil
 }
 
-func exampleEnvFile(svc Service) string {
-	for _, name := range []string{".env-example", ".env.example"} {
-		candidate := filepath.Join(svc.AbsolutePath, name)
-		if fileExists(candidate) {
-			return candidate
-		}
-	}
-	return ""
-}
-
-func envFileKeys(path string) map[string]bool {
+// envFileKeys errors instead of returning an empty set: an unreadable file
+// silently treated as "declares nothing" would pass exactly the check it
+// should fail.
+func envFileKeys(path string) (map[string]bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return map[string]bool{}
+		return nil, fmt.Errorf("env check: %w", err)
 	}
 	keys := map[string]bool{}
 	for _, e := range parseChunkInOrder(string(data), "") {
-		keys[e.Key] = true
+		// Shell-sourceable files write `export KEY=value`; the key is KEY.
+		keys[strings.TrimPrefix(e.Key, "export ")] = true
 	}
-	return keys
+	return keys, nil
 }
 
 func sameFile(a, b string) bool {
@@ -160,36 +169,58 @@ func displayPath(path string) string {
 	return rel
 }
 
+// EnvCheckStats counts the rows that were actually checked and whether any
+// finding exists. Zero checked rows count as a finding — a vacuous pass
+// would read as coverage.
+func EnvCheckStats(rows []EnvCheckRow) (checked int, findings bool) {
+	for _, row := range rows {
+		if row.Skipped != "" {
+			continue
+		}
+		checked++
+		if !row.OK() {
+			findings = true
+		}
+	}
+	if checked == 0 {
+		findings = true
+	}
+	return checked, findings
+}
+
+// EnvCheckNothingChecked is the shared explanation for a vacuous run, used by
+// both the human summary and the JSON reason field.
+const EnvCheckNothingChecked = "nothing was checked — no service pairs an env source with a committed .env-example / .env.example"
+
 // EnvCheckSummary renders the human view and says whether findings exist.
 func EnvCheckSummary(rows []EnvCheckRow) (string, bool) {
 	var b strings.Builder
-	checked, findings := 0, false
 	for _, row := range rows {
 		switch {
 		case row.Skipped != "":
 			fmt.Fprintf(&b, "⏭️  %s: %s\n", row.Service, row.Skipped)
 		case row.SourceAbsent:
-			findings = true
-			checked++
-			fmt.Fprintf(&b, "❌ %s: env source %s does not exist — a run would fall back to %s's placeholder values\n",
+			fmt.Fprintf(&b, "❌ %s: env source %s does not exist, and %s declares keys corgi does not generate:\n",
 				row.Service, row.Source, row.Example)
+			for _, key := range row.Missing {
+				fmt.Fprintf(&b, "     %s\n", key)
+			}
 		case len(row.Missing) > 0:
-			findings = true
-			checked++
 			fmt.Fprintf(&b, "❌ %s: %s is missing keys that %s declares and corgi does not generate:\n",
 				row.Service, row.Source, row.Example)
 			for _, key := range row.Missing {
 				fmt.Fprintf(&b, "     %s\n", key)
 			}
+		case row.Source == "":
+			fmt.Fprintf(&b, "✅ %s: %s declares only keys corgi generates — no env file needed\n",
+				row.Service, row.Example)
 		default:
-			checked++
 			fmt.Fprintf(&b, "✅ %s: %s covers %s\n", row.Service, row.Source, row.Example)
 		}
 	}
+	checked, findings := EnvCheckStats(rows)
 	if checked == 0 {
-		// A vacuous pass would read as coverage; refuse it.
-		findings = true
-		b.WriteString("nothing was checked — no service pairs an env source with a committed .env-example / .env.example\n")
+		b.WriteString(EnvCheckNothingChecked + "\n")
 	}
 	return b.String(), findings
 }

--- a/utils/envcheck.go
+++ b/utils/envcheck.go
@@ -1,0 +1,195 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// EnvCheckRow is one service's drift verdict: which example keys the resolved
+// env (or --file override) neither provides nor corgi generates.
+type EnvCheckRow struct {
+	Service string `json:"service"`
+	// Example is the reference file the service repo commits
+	// (.env-example / .env.example), relative to the compose dir.
+	Example string `json:"example,omitempty"`
+	// Source is the file whose keys were checked against the example,
+	// relative to the compose dir. Empty when it does not exist.
+	Source string `json:"source,omitempty"`
+	// Missing are keys the example declares that the source file does not
+	// provide and corgi does not generate (db/service deps, port, literals).
+	Missing []string `json:"missing,omitempty"`
+	// Skipped explains why this service was not checked.
+	Skipped string `json:"skipped,omitempty"`
+	// SourceAbsent: the service declares an env source but the file is not
+	// there, so a run would fall back to the example's placeholder values.
+	SourceAbsent bool `json:"sourceAbsent,omitempty"`
+}
+
+// OK reports whether this row is free of findings.
+func (r EnvCheckRow) OK() bool {
+	return !r.SourceAbsent && len(r.Missing) == 0
+}
+
+// EnvCheckAll diffs each service's env source against the example file its
+// repo commits, subtracting everything corgi generates itself. fileOverride
+// checks <service repo>/<fileOverride> instead of the resolved source —
+// useful for a committed CI env file before anything copies it into place.
+func EnvCheckAll(corgi *CorgiCompose, fileOverride string) ([]EnvCheckRow, error) {
+	all, err := ResolveAllEnv(corgi)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]EnvCheckRow, 0, len(corgi.Services))
+	for _, svc := range sortedServices(corgi) {
+		rows = append(rows, envCheckService(svc, all[svc.ServiceName], fileOverride))
+	}
+	return rows, nil
+}
+
+func envCheckService(svc Service, resolved []EnvVar, fileOverride string) EnvCheckRow {
+	row := EnvCheckRow{Service: svc.ServiceName}
+	if svc.IgnoreEnv {
+		row.Skipped = "ignore_env is set"
+		return row
+	}
+
+	example := exampleEnvFile(svc)
+	if example == "" {
+		row.Skipped = "no .env-example / .env.example in the service repo"
+		return row
+	}
+	row.Example = displayPath(example)
+
+	var source string
+	if fileOverride != "" {
+		candidate := filepath.Join(svc.AbsolutePath, fileOverride)
+		if !fileExists(candidate) {
+			row.Source = displayPath(candidate)
+			row.SourceAbsent = true
+			return row
+		}
+		source = candidate
+	} else {
+		rel := resolveCopyEnvPath(svc, "")
+		if rel == "" {
+			row.Skipped = "no copyEnvFromFilePath — env comes from the example file itself"
+			return row
+		}
+		if ActiveTierName != "" {
+			rel = strings.ReplaceAll(rel, "${tier}", ActiveTierName)
+		}
+		candidate := filepath.Join(CorgiComposePathDir, rel)
+		if !fileExists(candidate) {
+			row.Source = rel
+			row.SourceAbsent = true
+			return row
+		}
+		source = candidate
+	}
+	if sameFile(source, example) {
+		// Diffing the example against itself proves nothing.
+		row.Skipped = "env source is the example file itself — nothing to diff"
+		return row
+	}
+	row.Source = displayPath(source)
+
+	provided := envFileKeys(source)
+	generated := map[string]bool{}
+	for _, e := range resolved {
+		// file:* entries come from the copied env file; everything else
+		// (db:, service:, self:port, literal) corgi generates at run time.
+		if !strings.HasPrefix(e.Source, "file:") {
+			generated[e.Key] = true
+		}
+	}
+
+	for key := range envFileKeys(example) {
+		if !provided[key] && !generated[key] {
+			row.Missing = append(row.Missing, key)
+		}
+	}
+	sort.Strings(row.Missing)
+	return row
+}
+
+func exampleEnvFile(svc Service) string {
+	for _, name := range []string{".env-example", ".env.example"} {
+		candidate := filepath.Join(svc.AbsolutePath, name)
+		if fileExists(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func envFileKeys(path string) map[string]bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]bool{}
+	}
+	keys := map[string]bool{}
+	for _, e := range parseChunkInOrder(string(data), "") {
+		keys[e.Key] = true
+	}
+	return keys
+}
+
+func sameFile(a, b string) bool {
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(ai, bi)
+}
+
+// displayPath renders a path relative to the compose dir when possible, so
+// output stays portable between a laptop and a runner.
+func displayPath(path string) string {
+	rel, err := filepath.Rel(CorgiComposePathDir, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return path
+	}
+	return rel
+}
+
+// EnvCheckSummary renders the human view and says whether findings exist.
+func EnvCheckSummary(rows []EnvCheckRow) (string, bool) {
+	var b strings.Builder
+	checked, findings := 0, false
+	for _, row := range rows {
+		switch {
+		case row.Skipped != "":
+			fmt.Fprintf(&b, "⏭️  %s: %s\n", row.Service, row.Skipped)
+		case row.SourceAbsent:
+			findings = true
+			checked++
+			fmt.Fprintf(&b, "❌ %s: env source %s does not exist — a run would fall back to %s's placeholder values\n",
+				row.Service, row.Source, row.Example)
+		case len(row.Missing) > 0:
+			findings = true
+			checked++
+			fmt.Fprintf(&b, "❌ %s: %s is missing keys that %s declares and corgi does not generate:\n",
+				row.Service, row.Source, row.Example)
+			for _, key := range row.Missing {
+				fmt.Fprintf(&b, "     %s\n", key)
+			}
+		default:
+			checked++
+			fmt.Fprintf(&b, "✅ %s: %s covers %s\n", row.Service, row.Source, row.Example)
+		}
+	}
+	if checked == 0 {
+		// A vacuous pass would read as coverage; refuse it.
+		findings = true
+		b.WriteString("nothing was checked — no service pairs an env source with a committed .env-example / .env.example\n")
+	}
+	return b.String(), findings
+}

--- a/utils/envcheck_test.go
+++ b/utils/envcheck_test.go
@@ -165,6 +165,96 @@ func TestEnvCheck_FileOverride(t *testing.T) {
 	}
 }
 
+func TestEnvCheck_TierDirFallbackIsChecked(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"KEY=1\nTIER_ONLY=1\n",
+		"",
+		Service{ServiceName: "api"},
+	)
+	oldName, oldDir := ActiveTierName, ActiveTierDir
+	ActiveTierName, ActiveTierDir = "staging", "env/staging"
+	t.Cleanup(func() { ActiveTierName, ActiveTierDir = oldName, oldDir })
+
+	tierDir := filepath.Join(CorgiComposePathDir, "env/staging")
+	if err := os.MkdirAll(tierDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tierDir, "api.env"), []byte("KEY=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The run resolves env from the tier file, so the check must diff it —
+	// not skip the service for lacking copyEnvFromFilePath.
+	if rows[0].Skipped != "" {
+		t.Fatalf("tier-dir source must be checked, got skip: %+v", rows[0])
+	}
+	if len(rows[0].Missing) != 1 || rows[0].Missing[0] != "TIER_ONLY" {
+		t.Fatalf("missing = %v, want [TIER_ONLY]", rows[0].Missing)
+	}
+}
+
+func TestEnvCheck_AbsentSourceIsFineWhenExampleIsAllGenerated(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"PORT=3000\n", // corgi generates PORT from port:
+		"",            // declared env file never written
+		Service{ServiceName: "api", Port: 3000, CopyEnvFromFilePath: "api.env"},
+	)
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].SourceAbsent || !rows[0].OK() {
+		t.Fatalf("example of purely generated keys needs no env file, got %+v", rows[0])
+	}
+}
+
+func TestEnvCheck_ExportPrefixIsNormalized(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"export SECRET_KEY=change-me\n",
+		"export SECRET_KEY=real\n",
+		Service{ServiceName: "api", CopyEnvFromFilePath: "api.env"},
+	)
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows[0].Missing) != 0 {
+		t.Fatalf("export-style keys must match, got missing %v", rows[0].Missing)
+	}
+}
+
+func TestEnvCheck_UnreadableFileErrorsInsteadOfPassing(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"KEY=1\n",
+		"KEY=1\n",
+		Service{ServiceName: "api", CopyEnvFromFilePath: "api.env"},
+	)
+	example := filepath.Join(corgi.Services[0].AbsolutePath, ".env.example")
+	if err := os.Chmod(example, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(example, 0o644) })
+
+	if _, err := EnvCheckAll(corgi, ""); err == nil {
+		t.Fatal("unreadable example must error, not pass as declaring nothing")
+	}
+}
+
+func TestEnvVarIsGeneratedFailsClosedOnUnknownLabels(t *testing.T) {
+	for source, want := range map[string]bool{
+		"db:pg": true, "service:api": true, "self:port": true, "literal": true,
+		"file:api.env": false, "shell:override": false, "": false,
+	} {
+		if got := (EnvVar{Source: source}).IsGenerated(); got != want {
+			t.Errorf("IsGenerated(%q) = %v, want %v", source, got, want)
+		}
+	}
+}
+
 func TestEnvCheckSummary_RefusesVacuousPass(t *testing.T) {
 	summary, findings := EnvCheckSummary([]EnvCheckRow{
 		{Service: "api", Skipped: "no example"},
@@ -183,5 +273,27 @@ func TestEnvCheckSummary_CleanPass(t *testing.T) {
 	})
 	if findings {
 		t.Fatalf("clean row reported as finding:\n%s", summary)
+	}
+}
+
+func TestEnvCheckSummary_RendersEveryVerdict(t *testing.T) {
+	summary, findings := EnvCheckSummary([]EnvCheckRow{
+		{Service: "a", Example: "e", Source: "s", SourceAbsent: true, Missing: []string{"KEY"}},
+		{Service: "b", Example: "e", Source: "s", Missing: []string{"OTHER"}},
+		{Service: "c", Example: "e"}, // absent file, all keys generated
+		{Service: "d", Skipped: "no example"},
+	})
+	if !findings {
+		t.Fatal("rows with findings must report findings")
+	}
+	for _, want := range []string{
+		"does not exist", "KEY",
+		"is missing keys", "OTHER",
+		"no env file needed",
+		"no example",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary missing %q:\n%s", want, summary)
+		}
 	}
 }

--- a/utils/envcheck_test.go
+++ b/utils/envcheck_test.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// envCheckFixture builds a compose dir with one service repo holding an
+// example file, returning the compose and a cleanup-managed chdir.
+func envCheckFixture(t *testing.T, example, source string, svc Service) *CorgiCompose {
+	t.Helper()
+	dir := t.TempDir()
+	old := CorgiComposePathDir
+	CorgiComposePathDir = dir
+	t.Cleanup(func() { CorgiComposePathDir = old })
+
+	repo := filepath.Join(dir, svc.ServiceName)
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	svc.AbsolutePath = repo
+	if example != "" {
+		if err := os.WriteFile(filepath.Join(repo, ".env.example"), []byte(example), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if source != "" {
+		if err := os.WriteFile(filepath.Join(dir, svc.CopyEnvFromFilePath), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &CorgiCompose{Services: []Service{svc}}
+}
+
+func TestEnvCheck_MissingKeyFound(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"PORT=3000\nSECRET_KEY=change-me\nOTHER=1\n",
+		"OTHER=1\n",
+		Service{ServiceName: "api", Port: 3000, CopyEnvFromFilePath: "api.env"},
+	)
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	// PORT is corgi-generated, OTHER is provided; only SECRET_KEY is a finding.
+	if len(rows[0].Missing) != 1 || rows[0].Missing[0] != "SECRET_KEY" {
+		t.Fatalf("missing = %v, want [SECRET_KEY]", rows[0].Missing)
+	}
+	if rows[0].OK() {
+		t.Fatal("row with missing keys must not be OK")
+	}
+}
+
+func TestEnvCheck_GeneratedDbKeysExcluded(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"", // example written below, after the db keys are known
+		"",
+		Service{ServiceName: "api", Port: 3000, CopyEnvFromFilePath: "api.env",
+			DependsOnDb: []DependsOnDb{{Name: "pg"}}},
+	)
+	corgi.DatabaseServices = []DatabaseService{
+		{ServiceName: "pg", Driver: "postgres", Port: 5432, User: "u", Password: "p", DatabaseName: "d"},
+	}
+	// The example declares exactly what corgi generates for the db dep.
+	all, err := ResolveAllEnv(corgi)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var example strings.Builder
+	for _, e := range all["api"] {
+		example.WriteString(e.Key + "=x\n")
+	}
+	repo := corgi.Services[0].AbsolutePath
+	if err := os.WriteFile(filepath.Join(repo, ".env.example"), []byte(example.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(CorgiComposePathDir, "api.env"), []byte("UNRELATED=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows[0].Missing) != 0 {
+		t.Fatalf("generated keys reported missing: %v", rows[0].Missing)
+	}
+}
+
+func TestEnvCheck_SourceAbsent(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"KEY=1\n",
+		"", // declared env file never written
+		Service{ServiceName: "api", CopyEnvFromFilePath: "env/source/api.env"},
+	)
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rows[0].SourceAbsent {
+		t.Fatalf("want SourceAbsent, got %+v", rows[0])
+	}
+}
+
+func TestEnvCheck_NoCopyEnvSkips(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"KEY=1\n",
+		"",
+		Service{ServiceName: "api"},
+	)
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Skipped == "" || rows[0].SourceAbsent {
+		t.Fatalf("service without copyEnvFromFilePath should be skipped, got %+v", rows[0])
+	}
+}
+
+func TestEnvCheck_NoExampleSkips(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"",
+		"KEY=1\n",
+		Service{ServiceName: "api", CopyEnvFromFilePath: "api.env"},
+	)
+	rows, err := EnvCheckAll(corgi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Skipped == "" {
+		t.Fatalf("service without an example file should be skipped, got %+v", rows[0])
+	}
+}
+
+func TestEnvCheck_FileOverride(t *testing.T) {
+	corgi := envCheckFixture(t,
+		"KEY=1\nCI_ONLY=1\n",
+		"",
+		Service{ServiceName: "api", CopyEnvFromFilePath: "api.env"},
+	)
+	repo := corgi.Services[0].AbsolutePath
+	if err := os.WriteFile(filepath.Join(repo, ".env.ci"), []byte("KEY=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := EnvCheckAll(corgi, ".env.ci")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows[0].Missing) != 1 || rows[0].Missing[0] != "CI_ONLY" {
+		t.Fatalf("missing = %v, want [CI_ONLY]", rows[0].Missing)
+	}
+
+	// And the override being absent is a finding, not a skip.
+	rows, err = EnvCheckAll(corgi, ".env.staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rows[0].SourceAbsent {
+		t.Fatalf("absent override file should be SourceAbsent, got %+v", rows[0])
+	}
+}
+
+func TestEnvCheckSummary_RefusesVacuousPass(t *testing.T) {
+	summary, findings := EnvCheckSummary([]EnvCheckRow{
+		{Service: "api", Skipped: "no example"},
+	})
+	if !findings {
+		t.Fatal("zero checked services must count as a finding")
+	}
+	if !strings.Contains(summary, "nothing was checked") {
+		t.Fatalf("summary should say nothing was checked, got:\n%s", summary)
+	}
+}
+
+func TestEnvCheckSummary_CleanPass(t *testing.T) {
+	summary, findings := EnvCheckSummary([]EnvCheckRow{
+		{Service: "api", Example: ".env.example", Source: "api.env"},
+	})
+	if findings {
+		t.Fatalf("clean row reported as finding:\n%s", summary)
+	}
+}

--- a/utils/envsource.go
+++ b/utils/envsource.go
@@ -64,6 +64,13 @@ func resolveEnvSourceFile(composeDir string, service Service, copyEnvFilePath, t
 			return tierFile
 		}
 	}
+	return exampleEnvFile(service)
+}
+
+// exampleEnvFile is the one place that knows which filenames count as a
+// service's committed env example; resolution and `corgi env check` must
+// agree on it.
+func exampleEnvFile(service Service) string {
 	for _, name := range []string{".env-example", ".env.example"} {
 		candidate := filepath.Join(service.AbsolutePath, name)
 		if fileExists(candidate) {

--- a/utils/resolveEnv.go
+++ b/utils/resolveEnv.go
@@ -15,6 +15,19 @@ type EnvVar struct {
 	Source string `json:"source"` // db:<name> | service:<name> | self:port | literal | file:<path>
 }
 
+// IsGenerated reports whether corgi itself produces this variable at run time,
+// as opposed to reading it from a copied env file. A whitelist on purpose: a
+// future source label lands as not-generated until classified here, so
+// `corgi env check` fails closed instead of silently passing missing keys.
+func (e EnvVar) IsGenerated() bool {
+	for _, prefix := range []string{"db:", "service:", "self:", "literal"} {
+		if strings.HasPrefix(e.Source, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // parseChunkInOrder splits a corgi env chunk into ordered KEY=VALUE pairs,
 // tagging each with source. Blank/comment lines are skipped.
 func parseChunkInOrder(chunk, source string) []EnvVar {


### PR DESCRIPTION
## What

**`corgi env check`** — new opt-in command. Diffs each service's env file against the `.env-example` its repo commits, excluding every key corgi generates (db/service deps, ports, literals). Missing keys fail before the boot instead of at the first request. `--file .env.ci` validates a committed CI env file before anything copies it into place; positional args scope it to named services; a run with nothing to check fails too — a vacuous pass would read as coverage. Resolution goes through the same chain `corgi run` uses (including the tier-dir fallback), so check and run can never disagree about which file a service's env comes from.

**Cache restore-keys** — cache groups now carry a `restorePrefix` (`corgi-deps-<ecosystem>-`), published by the action as `cache-N-restore-keys`, so a lockfile change restores the previous packages instead of starting empty. Markers stay exact-match: corgi re-hashes every cacheKey before trusting one.

**Generated GitHub workflow** — `workflow_dispatch` with a deliberately empty branch default (a non-empty one silently beats the `||` fallbacks), `ref_name` fallback in both BRANCH and the concurrency group, `if-no-files-found: error` on the artifact upload with the dump step creating the directory first, and a commented daily schedule that keeps per-ref caches warm for fresh PRs.

**Skills** — ci, stories, and corgi skills gain the patterns two real multi-repo workspaces proved: the no-secrets CI env file, runner OOM reading as silence, headless screenshot no-ops, the two-suite e2e pattern (merge gate on the branch-built stack + schedule on the deployed env, one entry point, per-scenario pass/fail/skip), GitLab matrix-shard drift lint, and sleep-in-hooks as a readiness gap.

Version to 1.20.36: the template pins the action at `v<APP_VERSION>`, and the restore-keys outputs only exist from this release.

## Verification

- 2114 tests pass across all packages, `-race` clean, gofmt/vet clean
- Coverage 69.4% (floor 67.0%, previous total ~68.5%)
- `env check` exit codes verified against the built binary: missing key → 1, unknown service → 1, absent-but-unneeded env file → 0, `--json` stdout stays pure JSON
- Reviewed at high effort: 12 findings fixed in the last commit (tier fallback divergence, concurrency-group cancellation, fail-open key classification, export-prefix parsing, version-pin trap, artifact-upload masking, and more)