### PR TITLE
Remote launcher polish: permission-bypass opt-in, agent down, README/docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,16 @@
 
   # 🐶 CORGI 🐶
 
-  **Run your whole local stack from one file — repos, databases, env, every service. Let AI agents plan, build, and review work across it. Then run the same stack in CI, so your e2e finally tests all the repos together.** 
+  **Give your AI agents a whole workspace to build on.** corgi runs your whole stack from one file — cloning repos, seeding databases, wiring env between services (the parts docker-compose skips) — so your agents, you, and your CI all work from it.
 
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
   [![Homebrew](https://img.shields.io/badge/install-brew-orange.svg)](#install)
-  [![Platforms](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-blue.svg)](#install)
+  [![Platforms](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-blue.svg)](docs/install.md)
   [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-  [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
 
 </div>
 
-Corgi is how you run your project locally — every day, with one command. You describe the stack once in a `corgi-compose.yml`, and `corgi run` brings the whole thing up: repos cloned, databases seeded, `.env` files written, every service started. It even starts Docker for you, so the infra just happens and you stop thinking about it.
-
-Onboarding falls out for free: hand a teammate the same file and they go from nothing to a running stack in minutes — no setup call, no digging through old READMEs, no "works on my machine". And because corgi never blocks on a prompt and speaks plain JSON, an AI agent or a CI job can drive it exactly the way you do.
-
-Install it and take a ready-made example for a spin:
-
-```bash
-brew install andriiklymiuk/homebrew-tools/corgi
-corgi run -l      # browse runnable examples, pick one to try
-```
-
-Here's what `corgi run` does, end to end — one file in, whole stack out:
+Describe your stack once in a `corgi-compose.yml`. Then `corgi run` brings it all up:
 
 ```text
 corgi-compose.yml  ─►  corgi run
@@ -36,61 +24,58 @@ corgi-compose.yml  ─►  corgi run
                          whole stack running 🐶   (Ctrl-C tears it all down)
 ```
 
-That's the _running_ side — and the same file keeps paying off twice more. Because corgi already knows how your services fit together, its [Claude Code plugin](#ai-agents-mcp--claude-code) lets an agent **work across the stack**: read your Linear/Jira board, pick up ready tickets, turn them into draft PRs, and review them for you. And [CI can boot that exact same stack](#run-the-whole-stack-in-ci) from the branches under review and run e2e against it — so a change that spans repos gets caught before merge, not in production.
+Prefer watching? Here's the [2-minute showcase](https://youtu.be/rlMCjs4EoFs?si=o3SQaymM55zxBCUY).
 
-One file. Your laptop runs it, your agents build on it, your CI proves it. Prefer watching to reading? Here's the [2-minute showcase](https://youtu.be/rlMCjs4EoFs?si=o3SQaymM55zxBCUY).
+**Install:** `brew install andriiklymiuk/homebrew-tools/corgi` — or [other ways](docs/install.md).
 
-## Why corgi?
+## Why corgi
 
-Wiring up a multi-service project by hand is the same slog every time — joining a team, setting up a new laptop, or starting a fresh repo. You end up having to:
+Standing up a multi-repo project by hand is the same slog every time: clone four repos, install Postgres and Redis, seed the databases, copy `.env` files and point every service at the others, pick ports that don't clash, then start it all in the right order across a row of terminal tabs. A day gone — and it breaks again on the next laptop.
 
-- clone four different repos,
-- install Postgres, Redis, Kafka… and the right Go / Node / Yarn versions,
-- create the databases and fill them with test data,
-- copy `.env` files and point each service at the others,
-- pick ports that don't clash,
-- and finally start everything in the right order, across a row of terminal tabs.
+corgi puts all of that in **one committed file**. `corgi run` is the whole thing — not just on day one, but every day after. `docker-compose` runs your containers; corgi runs everything around them: the repos, the seeded data, the env wiring, the tools. And because that one file never blocks on a prompt, your agents and your CI drive it the exact same way you do.
 
-That's most of a day gone — and it breaks again on the next laptop.
+## Hand the whole workspace to an agent
 
-`docker-compose` handles the _containers_. Corgi handles everything around them too: the repos, the seeded data, the env wiring, the tools you need. Your databases run in Docker; your services run as normal processes (`go run .`, `yarn dev`). One file, one command — and it keeps paying off long after setup, because it's also how you run the stack from then on.
+corgi is built to be driven by agents, not just typed by hand. An agent gets the **whole workspace** — every repo, the databases, the env wiring — plus real `corgi` commands to drive it. So it can read your tracker, build a feature across several services, run the stack to check its own work, and open a draft PR per repo.
 
-In practice, a real multi-repo stack — backend, frontend, and a mobile app — can eat **more than a day** of cloning and debugging setup by hand. With corgi that drops to **~an hour** the first time someone uses it, and **~10 minutes** on the next project once they know the tool. And when you come back to a project months later and can't remember how to run it, the answer is just `corgi run` — no per-project setup scripts to write or keep alive.
+[Install corgi](#install), then add the [Claude Code](https://claude.com/claude-code) plugin (other agents: `npx skills add Andriiklymiuk/corgi`):
 
-## What corgi does for you
+```
+/plugin marketplace add Andriiklymiuk/corgi
+/plugin install corgi@corgi
+```
 
-- **Your repos** — Corgi clones each service from its Git URL the first time you run. It can also pull them all at once, fork them, or run one service on a branch in a throwaway worktree — without disturbing the checkout you're working in.
-- **Your databases** — 38 ready-to-go drivers. Corgi starts them in Docker and **seeds** them from a dump or a remote DB, so you get real data instead of an empty schema. Open a shell with `corgi db shell` and the password is already filled in. Need AWS or Supabase locally? LocalStack and Supabase come up from the same file.
-- **Your services** — Everything starts together with the env vars already wired between them. They boot in parallel by default; when one genuinely needs another up first, gate it with `condition: ready` on the dependency (or `--gate-deps` for all of them). Press `Ctrl-C` and it all winds down cleanly. Prefer the background? `corgi run -d`, then check on it with `corgi ps`.
-- **The fiddly bits** — A preflight that catches missing tools and busy ports _before_ they bite (`corgi doctor`), live health (`corgi status -w`), public HTTPS URLs for webhook testing (`corgi tunnel`), saved logs, and a desktop ping when something crashes.
-- **Your CI** — The same file boots a CI runner. The official [GitHub Action](#using-the-action) installs corgi and hands `actions/cache` a ready-made dependency-cache plan, `--feature` runs every repo carrying the PR's branch together, and `corgi test --e2e` drives one end-to-end suite across the live stack — the check that catches cross-repo breakage every per-repo pipeline misses. [Details below](#run-the-whole-stack-in-ci).
-- **Made for AI agents** — it speaks clean JSON, returns exit codes an agent can branch on, runs an MCP server, and ships a Claude Code plugin that plans from your Linear/Jira board, picks up ready tickets and turns them into draft PRs (and reviews them for you).
+Then just talk to it — slash-command or plain English, it routes on intent:
 
-## In your day-to-day
+```
+/corgi-run                      "run the todo stack, then show me the logs"
+/corgi-tracker                  "how's the team doing — anything stuck?"
+/corgi-queue                    "I just joined — what should I pick up first?"
+/corgi:stories ABC-123          "build a referral program across the services"
+/corgi:review <pr-url>          "fix the comments on this MR and answer them"
+```
 
-corgi flexes to whatever the day calls for:
+It never ships on its own — it only ever opens **draft** PRs, behind your go-ahead. New repo? `corgi run -l` grabs an example to try these against.
 
-- **The whole stack.** `corgi run` brings up every database and service together.
-- **Just the databases.** Running a service straight from your IDE or debugger? `corgi db -u` brings the databases up on their own and leaves the rest to you.
-- **Every PR, against the whole stack.** The same file runs in CI: push a branch and the pipeline boots every service from the branches under review, then runs your e2e suite against the live stack. The "green in every repo, broken together" kind of bug dies before merge instead of in production.
-- **A phone or another device on your LAN.** `corgi run --host auto` puts your machine's LAN IP into the service-URL env vars instead of `localhost`, so a real device or simulator can reach your dev API (pass an explicit IP instead of `auto` if you prefer). Databases stay on `localhost`.
-- **Local, staging, or a mix.** Define an env tier once — a folder of per-service env files, plus whether to skip the local databases:
-  ```yml
-  envTiers:
-    staging:
-      dir: env/staging   # you create env/staging/<service>.env with the staging URLs/keys
-      dbServices: none   # skip local databases — the staging env already points at staging's
-  ```
-  Then pick it with a flag — run everything locally, or just the frontend against staging:
-  ```bash
-  corgi run                                  # everything local
-  corgi run --tier staging --services web    # only the web app, talking to staging
-  ```
-  (A tier can also set `confirm: true` to prompt before you run against a sensitive one.)
-- **A new project.** The first thing to do in a fresh repo is write a `corgi-compose.yml` — `corgi create` or `/corgi-new` gets you one in a minute — so "how do I run this?" has a permanent answer.
-- **Hand work to Claude.** Drop a few tickets into `/corgi:stories` and Claude plans the feature across your services and opens a draft PR for each ([more below](#ai-agents-mcp--claude-code)).
+### Start a coding session from your phone 🪄
 
-The point isn't any single command — it's that you stop babysitting infrastructure and get back to building.
+Away from the laptop? Open corgi's launcher on your phone, tap a workspace, and a **Claude Code [Remote Control](https://code.claude.com/docs/en/remote-control) session starts on your machine** — in that workspace, under the right account. One command sets it up:
+
+```bash
+cd ~/dev/your-stack
+corgi agent up      # register this workspace, start the daemon + tunnel, print a QR to pair
+```
+
+Scan the QR to pair (per-device token, revocable), then tap any workspace to start. corgi keeps the session alive across network drops and crashes; run `corgi agent install` to start it at login so it survives reboots too. Opt-in, macOS & Linux. Full guide: [docs/agent.md](docs/agent.md).
+
+**Why agents like it:** it never blocks on a prompt, speaks clean JSON (`--json`), returns clear exit codes (`0` ok, `1` failed, `2` bad usage), and ships an **MCP server** so an agent drives the stack through real tools, not guessed shell commands:
+
+```bash
+corgi mcp                        # stdio, local, no network — point any MCP client at it
+corgi mcp --http :8765 --tunnel  # remote: a bearer-token-protected public URL
+```
+
+More: [agents & scripting](docs/agents.md) · [MCP server](docs/mcp.md) · [planning from your tracker](docs/tracker.md).
 
 ## Quick start
 
@@ -105,11 +90,13 @@ corgi run           # start every database + service, together
 corgi status -w     # watch each service turn healthy
 ```
 
-Don't have a `corgi-compose.yml` yet? `corgi create` scaffolds one — or let Claude write it with `/corgi-new` (see [AI agents](#ai-agents-mcp--claude-code)).
+> **Agents & CI:** use `corgi run --detach` then `corgi status --ready --timeout 2m` instead of the foreground commands above — they return instead of blocking. See [agents & scripting](docs/agents.md).
+
+No `corgi-compose.yml` yet? `corgi create` scaffolds one, or `/corgi-new` writes it with Claude. Hand a teammate that file and they get a running stack in minutes — no setup call, no "works on my machine."
 
 ## What the file looks like
 
-Here's the whole setup for a seeded Postgres, an auto-cloned Go API, and a web app — wired together:
+A seeded Postgres, an auto-cloned Go API, and a web app — wired together:
 
 ```yml
 db_services:
@@ -133,349 +120,58 @@ services:
     path: ./web
     depends_on_services:
       - name: api                           # puts api's URL in web/.env
-    beforeStart:
-      - yarn install
     start:
       - yarn dev
-
-e2e:                                        # optional: one test suite for the whole stack
-  workdir: ./e2e
-  run: maestro test flows/                  # any runner — Playwright, Cypress, a script
-
-required:                                   # corgi doctor checks these; --fix installs them
-  docker:
-    checkCmd: docker -v
-  go:
-    why:
-      - Build and run the api
-    checkCmd: go version
-    install:
-      - brew install go
 ```
 
-Run `corgi run` and it clones anything missing, starts Postgres in Docker and seeds it, writes the `.env` files (and sources them for you — no boilerplate), then runs `api` and `web` together. `Ctrl-C` shuts it all back down and runs any cleanup steps. And once the stack is up, `corgi test --e2e` runs that `e2e:` suite against it — same command on your laptop and [in CI](#run-the-whole-stack-in-ci).
+`corgi run` clones what's missing, seeds Postgres, writes the `.env` files, then runs `api` and `web` together. `Ctrl-C` shuts it all down. Want every field? Run `corgi docs`, or browse the [examples repo](https://github.com/Andriiklymiuk/corgi_examples).
 
-A service doesn't even need `start:` commands — if its repo ships a `Dockerfile` (or its own `docker-compose.yml`), `cloneFrom` + `port` is enough and corgi builds and runs the container for you. A service with both scripts and a Dockerfile runs its scripts by default; `corgi run --docker` flips it into a container. Details: [Dockerfile services](https://andriiklymiuk.github.io/corgi/docs/dockerfile_services).
+## What corgi does for you
 
-Want to see every field? Run `corgi docs`, or browse the [examples repo](https://github.com/Andriiklymiuk/corgi_examples).
+- **Repos** — clones each service on first run; can pull, fork, or run one on a branch in a throwaway worktree. [More](#working-across-many-repos).
+- **Databases** — 38 managed drivers, run in Docker and **seeded** with real data. `corgi db shell` opens a native shell, password filled in. Just the databases? `corgi db -u`. [All drivers](docs/databases.md).
+- **Services** — start together with env vars already wired between them. `Ctrl-C` stops all; `corgi run -d` runs in the background.
+- **The fiddly bits** — catches missing tools and busy ports before they bite (`corgi doctor`), live health (`corgi status -w`), public HTTPS for webhooks ([`corgi tunnel`](docs/tunnel.md)), saved logs, crash pings.
+- **CI** — the same file boots a CI runner and runs cross-repo e2e. [More](#run-the-whole-stack-in-ci).
 
-## Getting it running on a real project
-
-The examples use public repos. Real projects have private repos, prerequisites, and first-run hiccups — here's the honest version.
-
-**What you need:** `git`, and Docker (only if you declare `db_services`). Everything else lives in your project's `required:` block. Homebrew is just one way to install corgi itself, not a requirement. corgi runs on macOS, Linux, and Windows (PowerShell or WSL), so a mixed-OS team shares the same `corgi-compose.yml`.
-
-That `required:` block is more than a checklist — it's a committed, runnable record of everything the project needs. Each entry has `why:` (so teammates know what it's for), `checkCmd:` (how to verify it — check a specific version here if you want), and `install:` (the commands to get it). `install:` runs whatever it takes: a `brew install`, a `pyenv`/`rbenv` install to pin Python 3.12 or Ruby 3.4, a native lib, a cert via `mkcert -install`. `corgi doctor` runs every `checkCmd`; `corgi doctor --fix` runs the `install:` steps for you — so "what do I need installed?" is answered in the file, not a wiki.
-
-**Private repos just work.** corgi clones with plain `git`, so your existing SSH keys or credential helper are used as-is — private GitHub/GitLab services clone fine if your `git` is already set up. There's no corgi-specific auth to configure.
-
-**Joining a team that already uses corgi?** `git pull`, then `corgi run`. No `corgi-compose.yml` yet? You don't have to hand-write it — `corgi create` (or `/corgi-new` with Claude) inspects the repos and scaffolds one. Adding corgi is a single committed file, and teammates who don't use it aren't affected, since everything corgi generates is gitignored (see below).
-
-**When the first run trips up:**
-- _Port already in use_ — `corgi doctor` names the process holding it; `corgi run --kill-port` frees it.
-- _Missing tool, or Docker not running_ — `corgi doctor --fix`.
-- _A clone failed_ — you don't have git access to that repo yet; fix your SSH/token and re-run.
-- _Seeding failed_ — check the `seedFromFilePath` path and that the dump matches the driver.
-- _Want a clean slate?_ `corgi stop` tears down a detached run; `corgi clean -i db,corgi_services` drops the databases and generated files (add `services` to also remove the cloned repos).
-
-### Secrets & env files
-
-corgi writes each service's `.env` for you — DB host/port/credentials, sibling-service URLs — and sources it before your commands run. On first init it also adds `.env*` and `corgi_services/*` to your project's `.gitignore`, so **generated env files and any secrets in them never get committed**. Your own secrets (API keys, tokens) go in a service's env or a tier file like `env/staging/web.env` — also gitignored, also staying on your machine. The `corgi-compose.yml` itself holds config, not secrets, so it's safe to commit and share.
-
-**What gets wired.** A `depends_on_db` edge writes the database's connection vars — for Postgres that's `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`; other drivers use their own prefix (`REDIS_`, `MYSQL_`, `MONGO_`, …), and `envAlias:` renames it (`envAlias: DATABASE` → `DATABASE_HOST`, …). A `depends_on_services` edge writes `<SERVICE>_URL` (e.g. `API_URL=http://localhost:7012`). Run `corgi env <service>` to see the exact, fully-resolved set a service will get, and where each value came from.
-
-**Low lock-in:** your services stay ordinary git repos, your databases are standard Docker images (corgi even writes a plain `docker-compose.yml` per database under `corgi_services/db_services/`), and the wiring is just `.env` files. Stop using corgi and you keep all of it.
-
-## Supported databases & services
-
-In `services` you can run anything you like. In `db_services`, corgi ships managed drivers that handle the container, seeding, a native shell, and env vars for you. A couple are whole stacks rather than single containers — `localstack` stands up a fleet of AWS services, and `supabase` brings up auth, storage, and studio — all from the same file.
-
-<details>
-<summary><strong>38 database & infra drivers</strong> (click to expand)</summary>
-
-- [postgres](https://www.postgresql.org), [example](https://github.com/Andriiklymiuk/corgi_examples/tree/main/postgres)
-- [mongodb](https://www.mongodb.com), [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/mongodb/mongodb-go.corgi-compose.yml)
-- [rabbitmq](https://www.rabbitmq.com), [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/rabbitmq/rabbitmq-go-nestjs.corgi-compose.yml)
-- [sqs](https://docs.localstack.cloud/user-guide/aws/sqs/) — local AWS SQS, [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/aws_sqs/aws_sqs_postgres_go_deno.corgi-compose.yml)
-- [s3](https://docs.localstack.cloud/user-guide/aws/s3/) — local AWS S3 buckets
-- [redis](https://redis.io), [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/redis/redis-bun-expo.corgi-compose.yml)
-- [redis-server](https://redis.io)
-- [mysql](https://www.mysql.com)
-- [mariadb](https://mariadb.org)
-- [dynamodb](https://aws.amazon.com/dynamodb/)
-- [kafka](https://kafka.apache.org)
-- [mssql](https://www.microsoft.com/en-us/sql-server/sql-server-downloads)
-- [cassandra](https://cassandra.apache.org/_/index.html)
-- [cockroach](https://www.cockroachlabs.com)
-- [clickhouse](https://clickhouse.com)
-- [scylla](https://www.scylladb.com)
-- [keydb](https://docs.keydb.dev)
-- [influxdb](https://www.influxdata.com)
-- [surrealdb](https://surrealdb.com)
-- [neo4j](https://neo4j.com)
-- [arangodb](https://arangodb.com)
-- [elasticsearch](https://www.elastic.co/elasticsearch#)
-- [timescaledb](https://www.timescale.com)
-- [couchdb](https://couchdb.apache.org)
-- [dgraph](https://dgraph.io)
-- [meilisearch](https://www.meilisearch.com)
-- [mailpit](https://mailpit.axllent.org) — mail-mock SMTP + web UI (the local mail server Supabase uses); web UI port via `port2`
-- [faunadb](https://fauna.com)
-- [yugabytedb](https://www.yugabyte.com)
-- [skytable](https://skytable.io)
-- [dragonfly](https://www.dragonflydb.io)
-- [redict](https://redict.io)
-- [valkey](https://github.com/valkey-io/valkey)
-- [postgis](https://postgis.net)
-- [pgvector](https://github.com/pgvector/pgvector) — postgres + `pgvector` extension. Uses prefix `DB_`, same as plain `postgres`
-- [localstack](https://docs.localstack.cloud/) — single container for multiple AWS services (sqs, s3, sns, secretsmanager, ssm, kinesis), with `queues` / `buckets` / `topics` / `secrets` auto-created from config. Full docs: [docs/drivers/localstack.md](docs/drivers/localstack.md)
-- [supabase](https://supabase.com/docs/guides/local-development) — wraps `supabase init`/`start`. Emits `SUPABASE_*` + S3 vars, ports from config.toml. Seeds `buckets:` and `authUsers:` on `up`; `jwtSecret:` re-signs keys; `configTomlPath:` makes corgi own config.toml under `corgi_services/`; `port:`/`dbPort:`/`studioPort:`/`inbucketPort:` patch the matching `[section].port`. Full docs: [docs/drivers/supabase.md](docs/drivers/supabase.md)
-- `image` — generic docker-image driver for any public image (gotenberg, mailhog, jaeger, meilisearch, …). Set `image:` + `port:` + optional `containerPort:`/`environment:`/`volumes:`/`command:`. Full docs: [docs/drivers/image.md](docs/drivers/image.md)
-
-</details>
-
-**Once a database is up**, corgi keeps helping:
-
-- **Seed it** with real data from a file (`seedFromFilePath:`) or another database (`seedFromDb:`). `corgi run --seed` loads it; the dump format is chosen per driver automatically.
-- **Open a shell** with `corgi db shell [name]` — the right tool (`psql`, `mongosh`, `redis-cli`, …) with credentials already filled in. Add `-e '<query>'` to run one query and exit.
-- **Manage them** from the `corgi db` menu — bring containers up or down, seed, or dump.
+Real project (private repos, prerequisites, secrets, staging tiers)? The honest setup guide: [Getting it running on a real project](docs/getting-started.md).
 
 ## Working across many repos
 
-This is the part `docker-compose` leaves to you. Corgi treats your repos as part of the stack:
+This is the part `docker-compose` leaves to you.
 
-- **Auto-clone** — a service with `cloneFrom:` is cloned the first time its folder is missing. `cloneFrom:` is optional — a service with just a `path:` (a monorepo subfolder, or a repo you keep checked out yourself) is used in place, no cloning. Mix both freely in one file.
-- **`corgi pull`** — `git pull` everything at once, including nested corgi projects.
-- **`corgi fork`** — fork the cloned repos to your own GitHub/GitLab and update the file to match.
-- **Run a service on a branch** — point one service at a branch or another folder for a single run, no file edit needed:
+- **Auto-clone** — `cloneFrom:` clones a service when its folder is missing; just a `path:` (a monorepo subfolder, or a repo you keep yourself) runs in place. Mix both.
+- **`corgi pull`** pulls every repo at once. **`corgi fork`** forks them to your account.
+- **Run one service on a branch**, no file edit:
 
 ```bash
-# run api's feature branch in its own worktree — your checkout stays exactly as it is
-corgi run --service-branch api=feature/login
-
-# mix and match: api on a branch, web from a folder, everything else as usual
-corgi run --service-branch api=feature/login --service-dir web=/tmp/wt/web
-
-# or actually switch the checkout in place (refuses if you have uncommitted changes)
-corgi run --service-checkout api=hotfix/x
-
-# one change spanning several repos — every repo that has the branch joins in
-corgi run --feature ABC-123-checkout-flow
+corgi run --service-branch api=feature/login   # api's branch in its own worktree
+corgi run --feature ABC-123                     # every repo that has the branch joins in
 ```
 
-The worktrees live under `corgi_services/.worktrees/` and are reused between runs, so dependencies and uncommitted work stick around. List or clean them with `corgi worktree list` / `corgi worktree prune`. Great for trying a PR branch, comparing two branches side by side on different ports, or letting an agent work on a branch while you keep running `main`.
-
-`--feature` is the cross-repo version: pass one branch name and corgi asks every service's repo whether it has it (locally or on `origin`), running the ones that do from a worktree and leaving the rest on their default checkout. A missing branch isn't an error — a feature rarely touches the whole stack. Remote-only branches are fetched first, so it works on a fresh or shallow clone.
+`--feature` is the cross-repo hinge: pass one branch name, and each repo that has it runs from a worktree while the rest stay put. Great for a PR branch, or letting an agent work on a branch while you keep running `main`.
 
 ## Run the whole stack in CI
 
-Here's where the same file pays off a second time. Each repo's pipeline only proves that repo: a change that spans services — a schema field, a new event, an endpoint the frontend calls — can leave every individual pipeline green while the combination is broken. corgi closes that gap. A CI runner boots the whole stack the same way your laptop does, from the branches under review, then runs one e2e suite against the live stack.
+Each repo's own pipeline only proves that repo. A change that spans services can leave every pipeline green while the combination is broken. corgi closes that gap: CI boots the whole stack from the branches under review, then runs one e2e suite against it.
 
-corgi detects CI on its own (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, and friends) and goes quiet and non-interactive — no special flags. With the official action, the whole job is a handful of lines:
-
-```yaml
-- uses: Andriiklymiuk/corgi@v1                     # install corgi (checksum-verified) + a cache plan
-  id: corgi
-
-- uses: actions/cache@v4
-  with:
-    path: ${{ steps.corgi.outputs.cache-paths }}
-    key: ${{ steps.corgi.outputs.cache-key }}
-
-- run: corgi init --depth 1 --feature "$BRANCH"    # shallow-clone every repo carrying the change
-- run: corgi run --feature "$BRANCH" --detach --wait --wait-timeout 20m --follow
-- run: corgi test --e2e                            # the stack-level suite, against the live stack
-
-- run: corgi logs --dump ./ci-logs                 # a failure leaves every service's log as an artifact
-  if: always()
-```
-
-`corgi ci init` writes the starting point for either forge — it reads the git remote, drops the workflow (or `.gitlab-ci.yml` plus the generated cache plan) in place, and prints what your workspace still has to supply.
-
-On GitLab the same job is an include, since GitLab has no equivalent of an action:
+It detects CI on its own and goes non-interactive. With the official action the job is a few lines:
 
 ```yaml
-include:
-  - remote: https://raw.githubusercontent.com/Andriiklymiuk/corgi/main/gitlab/corgi.yml
-    inputs: { corgi_version: "1.20.17", runner_tags: [my-vm-runner] }
-  - local: .gitlab/corgi-cache.yml                 # corgi cache paths --gitlab --out .gitlab/corgi-cache.yml
-
-stack-e2e:
-  extends: [.corgi-stack-e2e, .corgi-cache]
+- uses: Andriiklymiuk/corgi@v1                     # install corgi + a cache plan
+- run: corgi init --depth 1 --feature "$BRANCH"    # shallow-clone every repo with the change
+- run: corgi run --feature "$BRANCH" --detach --wait   # boot the stack, block until healthy
+- run: corgi test --e2e                            # one e2e suite across the live stack
 ```
 
-It installs corgi the same verified way, refuses to run inside a container (where the db containers would publish to a localhost the job cannot see), and drives the same boot → gate → e2e → artifacts sequence. GitLab's cache config is static YAML, so the cache plan is generated and committed rather than read at runtime, with `corgi cache paths --gitlab --check` failing the pipeline once it drifts from the compose file.
-
-`--feature "$BRANCH"` is the cross-repo hinge: every service repo that has the PR's branch joins the run from a worktree, the rest stay on their default checkout — so each PR is tested against the exact combination it will ship into. `--wait` blocks until every service is actually healthy (no `sleep 60` guesswork) and `--wait-timeout` fails the job instead of hanging the runner. Tools only a human needs can be marked `skipInCi: true`. Full guide: [Run the stack in CI](https://andriiklymiuk.github.io/corgi/docs/ci).
-
-### One e2e suite for the whole stack
-
-Each service keeps its own `scripts.test` (run them with `corgi test`). But a suite that drives several services at once — a Maestro flow that signs up in the app, hits the api, and reads the confirmation mail out of the local SMTP sink — belongs to the stack, not to any one repo. Declare it once, next to the services it tests:
-
-```yml
-e2e:
-  workdir: ./e2e            # where the suite lives
-  install: npm ci           # optional setup, runs once before the suite
-  run: maestro test flows/  # or: npx playwright test · cypress run · ./e2e.sh
-```
-
-The suite is just a command — Maestro for a mobile app, Playwright or Cypress for the web, or a plain script; corgi doesn't care what drives the stack, only that it exits non-zero on failure.
-
-`corgi test --e2e` runs it against the already-running stack — deliberately never booting anything itself, so a red run always tells you which half failed: the boot or the tests. And it's the same two commands locally as in CI: `corgi run -d --wait`, then `corgi test --e2e` — your e2e stops being a CI-only ritual.
-
-### Using the action
-
-`Andriiklymiuk/corgi@v1` installs corgi, optionally enforces a minimum version, and tells `actions/cache` what to keep.
-
-| input | |
-|---|---|
-| `version` | corgi version to install, without the leading `v`. Omit to take the latest release. Pinning keeps a workflow reproducible. |
-| `working-directory` | Where `corgi-compose.yml` lives. Defaults to the repo root; the cache outputs are derived from it. |
-
-| output | |
-|---|---|
-| `version` | The corgi version that was installed. |
-| `cache-paths` | Newline-separated directories worth caching — pass straight to `actions/cache`'s `path`. |
-| `cache-key` | Key that changes whenever any `cacheKey` file changes — pass straight to its `key`. |
-| `cache-groups` | The same plan split per ecosystem, as JSON (`{id, key, paths, pathsText}` per group) — one `actions/cache` step per group, so a change to one language's lockfile doesn't evict every other language's packages. |
-
-The cache plan comes from `corgi cache paths`: it derives what to persist from each service's `beforeStart` `cacheKey`, so the list can never drift as services come and go — add a service and the cache follows automatically. On a polyglot stack, feed `cache-groups` into a small matrix instead of one big cache:
-
-```yaml
-- uses: actions/cache@v4
-  with:
-    path: ${{ fromJSON(steps.corgi.outputs.cache-groups)[0].pathsText }}
-    key: ${{ fromJSON(steps.corgi.outputs.cache-groups)[0].key }}
-```
-
-`@v1` moves with each release, so you get fixes without editing workflows. Pin an exact tag (`@v1.20.13`) if you would rather bump deliberately.
-
-The action downloads the release archive for the runner's platform and checks it against the published `checksums.txt` before installing, so a tampered or truncated download fails rather than executing.
-
-Two things worth knowing before you write the rest of the job:
-
-- **Do not run the job inside a container.** Database containers publish to `localhost`, which is what every generated connection string assumes; a containerised job no longer shares it, and the failure reads as "the api cannot reach postgres".
-- **Health checks are polled, so they must be cheap.** A dev server that compiles on demand rebuilds for every probe. Put the expensive check in `warmup:`, which corgi performs once when the port is live.
-
-## The rest of the toolbox
-
-**Check before you run.** `corgi doctor` confirms your required tools are installed, Docker is running, and the ports are free — and tells you which process is hogging a port if one isn't. Add `--fix` and it'll start Docker, install what's missing, and free the ports for you.
-
-**See the whole picture.** `corgi mission-control` (alias `corgi mc`) is the one view worth keeping open: every service's live health next to its git branch, open PR, and CI state — so "what's running, what's in review, what's red" is a single glance. `--watch` keeps it fresh, `--json` feeds a script.
-
-**Watch it stay healthy.** `corgi status` pings every service. Use `-w` to watch live, or `-r` to block until everything's ready (handy in scripts). Set a `healthCheck:` path on a service and corgi will hit it over HTTP instead of just checking the port.
-
-**Keep it running in the background.** `corgi run -d` starts everything detached and returns right away — no daemon, corgi just remembers what it started. Check in with `corgi ps`, restart one piece with `corgi restart --service api`, or stop it all with `corgi stop`.
-
-**Read the logs later.** `corgi run` saves each service's output by default (`--logs=false` turns it off); `corgi logs` lets you browse and follow past runs, with crashes clearly marked.
-
-**Get pinged on a crash.** `corgi notifications on` sends a desktop notification when a service falls over mid-run.
-
-**Share a local service over HTTPS.** `corgi tunnel` gives your services public URLs — perfect for testing webhooks (Stripe, GitHub apps, e-sign callbacks) without any signup:
-
-```bash
-corgi tunnel                       # tunnel every service that has a port
-corgi tunnel api                   # just one
-corgi tunnel --port 3030           # a raw port, skip the compose lookup
-corgi tunnel --provider ngrok      # default is cloudflared (free, no signup)
-```
-
-By default it uses [Cloudflare Quick Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/) — free and anonymous, but the URL changes every restart. For a stable URL, use a Cloudflare named tunnel (login required) or another provider. If a provider needs auth, corgi tells you the exact login command up front instead of failing halfway.
-
-## AI agents, MCP & Claude Code
-
-corgi is meant to be driven by AI agents and CI, not just typed by hand — a small single Go binary, no daemon, no runtime to install. What makes it a good tool for a tool to use:
-
-- **It never blocks on a prompt.** corgi notices it's running in an agent or pipeline and either skips the question or fails with a clear error instead of hanging. That same non-interactive contract is exactly what a CI job needs.
-- **It speaks machine.** Clean JSON with `--json`, predictable exit codes (`0` ok, `1` failed, `2` bad usage), and a documented [error-code list](docs/agents.md) — so a tool can read what happened and react, instead of parsing log noise.
-- **Quiet, scriptable entry points.** `corgi env <service>` shows the exact env a service will get and where each value came from; `corgi env check` fails when a service's env file misses keys its `.env-example` declares (keys corgi generates are excluded, `--file .env.ci` checks a committed CI env file); `corgi exec` and `corgi test` run commands and tests in that same env; `corgi run --dry-run --json` previews a whole run without touching anything.
-- **One-glance state.** `corgi mission-control` (alias `mc`) shows the live stack plus each service's git/PR/CI state — `--json` for a single snapshot, `--watch` to follow along.
-- **Workspace memory.** `corgi memory` is an opt-in, committed `.corgi/memory/` store of stack decisions and recurring fixes (with a `corgi memory lint` secret-scan) that the skills read before acting — so lessons survive between sessions.
-
-Full guide: [docs/agents.md](docs/agents.md).
-
-### MCP server
-
-Run `corgi mcp` and any MCP-speaking agent can control your stack through proper tools instead of guessing at shell commands. It runs over stdio by default (no network at all), or over HTTP with `--http` / `--tunnel` when you want it remote. It exposes around a dozen tools — bring up, tear down, status, env, exec, test, logs, db queries — plus read-only resources like the compose schema and live status. One caution: plain `--http` has no auth; corgi only adds a bearer token when you expose it through a public tunnel. Full docs: [docs/mcp.md](docs/mcp.md).
-
-### Agent mode — work on your stack from your phone
-
-Claude Code's [Remote Control](https://code.claude.com/docs/en/remote-control) already puts a session from your own machine on your phone. Two things stop it being the thing you actually want: its own docs say the local process must keep running, and that it exits after roughly ten minutes awake without network — so you have to remember to arm it. And it sees one directory, while a corgi stack is several repositories.
-
-`corgi agent` fixes exactly those two, and nothing else. It supervises `claude remote-control` so it survives reboots, crashes and that ten-minute exit (telling you when it restarted, because the new session starts clean), holds a wake lock so the machine does not sleep mid-session, and runs each workspace under its own Claude config directory. Then `corgi mcp` gains the tools a phone session needs: resolve "the todo app" to the right stack, materialize one branch across every repo in it, and read a single cross-repo diff — which needs no tunnel and no running stack, so it works on a train.
-
-```
-cd ~/dev/your-stack
-corgi agent init        # register this stack
-corgi agent install     # start at login
-corgi agent status      # what is running, and under which account
-```
-
-Opt-in: if you never run `corgi agent init`, nothing changes. macOS and Linux for now — on Windows `install` says so rather than half-working. If you keep work and personal Claude logins apart, read the multi-account section first: launchd never sources your shell aliases, so without `--config-dir` every session silently uses your default account. Full docs: [docs/agent.md](docs/agent.md).
-
-### Claude Code plugin
-
-If you use [Claude Code](https://claude.com/claude-code), install the plugin:
-
-```
-/plugin marketplace add Andriiklymiuk/corgi
-/plugin install corgi@corgi
-```
-
-Using another agent (Cursor, Codex, Copilot, …)? Install the skills via [skills.sh](https://www.skills.sh):
-
-```
-npx skills add Andriiklymiuk/corgi
-```
-
-Now Claude recognizes any project with a `corgi-compose.yml` and reaches for real `corgi run` / `corgi doctor` / `corgi status` commands instead of inventing its own. The plugin adds slash-commands plus auto-invoking skills that cover the whole loop — plan, run, debug, suggest, ship, review, and wiring up CI:
-
-- **Plan the work — `/corgi-tracker`.** Standup / status, triage, or decompose an epic into tickets — from Linear or Jira. Its edge over the tracker's own UI: it ties each ticket to its **real code state** — branch, draft/open/merged PR, CI — across every service, so drift like "In Progress but no branch" or "Todo but the PR already merged" surfaces. Read-only until one confirm gate guards any tracker write; hands the tickets it shapes to `/corgi:stories`.
-- **Drain the queue — `/corgi-queue`.** Pick up build-ready tickets and build them — pass explicit Linear/Jira links, or a scope in plain words (the **`agent`** queue by default; also _in ready_, _from backlog_, _most impactful/ROI_, _bugs_). It drift-skips anything already merged or in-flight, you confirm the picks, then `/corgi:stories` branches per service and opens draft PRs — moving each ticket to In-Progress as work starts (which stops a loop from grabbing it twice). `/loop 1h /corgi-queue` drains on a schedule; you approve each batch's specs in one sign-off.
-- **Autopilot the loop — `/corgi-autopilot`.** A supervised loop that drains the agent queue into draft PRs — one spec gate per batch, a heartbeat, and a kill switch (`corgi autopilot stop`/`pause`/`status`). Schedule it with `/loop` or `/schedule`; it never merges.
-- **Run it — `/corgi-run`.** "Run the stack" — or a slice, with a tunnel + logs, against a remote backend, for a mobile emulator, or a single service on a feature/PR branch or worktree (`--service-branch`/`--service-dir`, the reviewer "Run line"). Boots **detached**, waits until healthy, and flags anything stuck.
-- **Debug it — `/corgi-debug`.** A service won't start, or you're chasing a bug and need runtime/deployed data. Local-first (`ps` / `status` / `doctor` / `logs`), then your stack's own logs/analytics provider (Coralogix, CloudWatch/ECS, Datadog… — auto-detected from your README) on demand.
-- **Wire up CI — `/corgi-ci`.** Ask for "e2e across api + web on the PR branch" and it writes the GitHub Actions or GitLab CI pipeline that boots the whole stack and runs cross-repo e2e — caching, health gates, and log artifacts included. It also knows the failure modes that eat CI afternoons (containerised jobs, health checks that do work, silent `beforeStart` failures) and checks for them up front. Or hand it a red job: "each repo passes but the combination breaks".
-- **Suggest work — `/corgi-suggest`.** Ranked, evidence-backed product **and** engineering improvements, each tied to a measurable outcome; it specs the one you pick and can open a tracker story.
-- **Suggest on a schedule — `/corgi-suggest-proactive`.** The same ranking, pushed on a cadence: it takes the top idea, dedupes against open and recently-dismissed tickets (`corgi suggest-history`), and either proposes it or — only if you opt in — files exactly **one** rate-limited **draft** ticket. Never assigned, never built.
-- **Ship a batch — `/corgi:stories`.** Hand Claude some tracker issues (Linear or Jira) or just describe a feature. It investigates the codebase, writes a short spec for each item and waits for your sign-off, then branches per service, runs the tests, reviews its own changes, and opens **draft** PRs/MRs — each service in its own git worktree.
-- **Review the result — `/corgi:review`.** Point it at the PRs/MRs. It reviews them against your repo's standards and any linked ticket, checks that changes line up across services, and — after you preview — posts a summary plus inline suggestions. It also runs the **other way**: _"fix the comments on this MR and answer them"_ (or by story-id) — it applies the valid feedback, replies to and resolves the threads, and pushes the fixes to your branch.
-
-```
-/corgi-tracker                       # standup / triage / decompose, tied to real PR + CI state
-/corgi-queue                         # build the `agent` queue → draft PRs
-/corgi-queue most impactful          # or: in ready · from backlog · bugs · ABC-140 ABC-141
-/loop 1h /corgi-queue                # keep draining on a schedule (you approve each batch)
-/loop 1h /corgi-autopilot            # supervised loop: drain the queue → draft PRs (one gate/batch)
-/corgi-run                           # boot the stack detached, wait until healthy
-/corgi-debug                         # diagnose a service / pull deployed or CI logs
-/corgi-ci                            # generate (or fix) the full-stack e2e pipeline
-/corgi-suggest                       # ranked, measurable improvement ideas
-/corgi:stories ABC-123 ABC-124       # spec → branch per service → draft PRs
-/corgi:review  <pr-url>              # review a PR — or "fix the comments on this MR"
-```
-
-Ship and review wait for your go-ahead and only ever open **draft** PRs — they never merge or ship on their own. Two more helpers round things out: **`/corgi-new`** scaffolds a fresh `corgi-compose.yml` from a quick chat, and **`/corgi-describe`** writes a service map with a Mermaid diagram.
-
-#### Working the loop — say it however you'd say it
-
-No slash-commands or jargon needed — talk to it like a teammate; it routes on **intent, not exact words**. The four jobs, the way people actually ask:
-
-- _"How's the team doing — anything stuck?"_ → a status read leading with blockers and **drift** ("In Progress but no branch", "Done but the PR's still open").
-- _"Pile of new bug reports — sort and prioritize them?"_ → labels, priorities, duplicates, and what needs more info, behind one confirm (triage).
-- _"I want a referral program — break it into tasks across the services."_ → ordered, service-mapped tickets you approve, then build (decompose).
-- _"I just joined — what should I pick up first?"_ → it pulls the build-ready **`agent`** queue (or tickets you name), you confirm, and stories builds them into draft PRs.
-
-**What fires when you pick work.** Picking one ticket engages the loop: tracker correlates + drift-skips → stories builds (reads `corgi-compose.yml`, calls **debug** for runtime/staging or CI data, stands a producer up with **`corgi run`** so a consumer can verify, self-reviews, moves the ticket to In-Progress + assigns you, then Code Review when the draft PR opens) and points you to _review it_ / _run it_ / _debug it_ before you land it. **suggest** sits upstream — it proposes work before it's even a ticket. Full walkthrough: [docs/tracker.md](docs/tracker.md).
+`--feature` tests each PR against the exact combination it will ship into; `--wait` blocks until every service is healthy (no `sleep 60`). Full guide: [Run the stack in CI](https://andriiklymiuk.github.io/corgi/docs/ci).
 
 ## How it compares
-
-At a glance — what each tool takes off your plate:
 
 | | docker-compose | Tilt / Skaffold | Turborepo / Nx | process-compose | corgi |
 |---|:---:|:---:|:---:|:---:|:---:|
 | Databases in containers | ✓ | ✓ (k8s) | — | — | ✓ |
-| Services as host processes (your debugger, hot-reload) | — | — | ✓ | ✓ | ✓ |
+| Services as host processes (debugger, hot-reload) | — | — | ✓ | ✓ | ✓ |
 | Works across many repos | — | — | — | — | ✓ |
 | Clones & pulls the repos for you | — | — | — | — | ✓ |
 | Seeds databases with real data | — | — | — | — | ✓ |
@@ -484,179 +180,45 @@ At a glance — what each tool takes off your plate:
 | Cross-repo e2e in CI (`--feature`) | — | — | — | — | ✓ |
 | Built for AI agents (JSON, MCP, skills) | — | — | — | — | ✓ |
 
-And the honest version of "why not just use X":
+- **vs `docker-compose`** — Compose runs containers, and stops there. corgi runs the loop around them: repos, seeded databases, env wiring, tool checks — and runs your services as ordinary host processes. Already have a Compose file? Keep it; the two coexist.
+- **vs your own `dev.sh` / Makefile** — that script, until its author leaves and a new laptop breaks it. corgi is the declarative version — same on macOS/Linux/Windows, every service booting concurrently — plus `doctor`, logs, tunnels, worktrees, and CI for free.
 
-- **vs writing your own script** — Every team has one: a `dev.sh` or Makefile that clones, seeds, and starts everything — until its author changes teams, a new laptop breaks it, and nobody dares touch it again. That script _is_ the job corgi does, minus everything around it: a declarative file instead of imperative bash, with the same behavior on macOS/Linux/Windows. It's faster, too — corgi boots every service **concurrently**, each installing and starting in its own goroutine with readiness gates only where you declare them, instead of one `&&` at a time. You get `doctor`, `status`, saved logs, tunnels, worktrees, and CI for free — and `corgi-compose.yml` doubles as documentation of how the stack fits together, which the script never did.
-- **vs `docker-compose`** — Compose runs containers; that's where it stops. corgi runs your whole inner loop: it clones the repos, runs and seeds the databases (it even generates a real `docker-compose.yml` per database under the hood), wires the env between services, checks your tools, and runs your services as ordinary host processes — so you keep your usual debugger and hot-reload, and your laptop runs N processes instead of N containers (lighter on RAM). Already have a Compose file? Keep it — let corgi own the repos, env wiring, and tool checks while Compose runs your containers; the two coexist fine.
-- **vs Tilt / Skaffold** — Great when your inner loop is Kubernetes and you want live container rebuilds. corgi deliberately keeps your services out of containers — no image rebuild between edits — so it's lighter for a "repos + databases + processes" stack, and not the tool if you genuinely need k8s.
-- **vs Turborepo / Nx** — Brilliant inside one monorepo: cached builds, `turbo dev` running every package's dev server. But they stop at your package.json scripts — no databases, no seeding, no env wiring, and no second repo. corgi runs the world around them, and the two pair naturally: a corgi service whose `start:` is `turbo dev`.
-- **vs process-compose / mprocs (and older Procfile runners like foreman)** — They start a list of processes, and do it well. corgi does that _and_ the repos, databases, seeding, env wiring, and tool checks around them — and the same file then drives your agents and CI.
-- **vs devcontainers / Nix** — These give you a more isolated, prebuilt environment — Nix in particular is fully hermetic. corgi takes the opposite bet: it runs on your real machine with your real tools, and its `required:` block still installs and pins exactly what each service needs (a `pyenv`/`rbenv` version, native libs, certs). Simpler to live in day to day; it's not a hermetic sandbox, by design.
-
-**What corgi isn't:** a deploy tool. It runs and tests your stack — on your laptop and in CI — but shipping to staging/prod stays with your CI/CD: corgi proves the change works as a whole, your pipeline deploys it as usual. It's also not the fit if your dev loop must run _inside_ Kubernetes, or if you want a fully sandboxed, OS-level environment (devcontainers/Nix territory).
+**What corgi isn't:** a deploy tool. It runs and tests your stack — on your laptop and in CI — but shipping to staging/prod stays with your CI/CD.
 
 ## Security & scope
 
-corgi runs your stack on your own machine — the local inner loop — and can point local services at a staging or prod environment via env tiers. A few things worth knowing:
-
-- A `corgi-compose.yml` runs its `beforeStart` / `start` commands on your machine, so only run files you trust — especially `corgi run -t <url>`, which downloads and runs a remote one.
-- `corgi doctor --fix` starts Docker for you automatically, but **installing a tool or killing a port-holding process always asks first** (or needs `--yes` in CI).
-- `corgi mcp` runs over stdio (local, no network) by default. `--http` is **unauthenticated** — only expose it with `--tunnel`, which adds a bearer token. Its tools can start, stop, and run commands in your stack, so treat that URL + token like a credential.
-- `corgi tunnel` gives a local service a public HTTPS URL — exactly what you want for testing signing/webhook callbacks from an outside tool. The default Cloudflare quick-tunnel URL is public and ephemeral, so shut it down when you're done.
-- **No telemetry.** corgi collects no analytics and sends nothing about your usage anywhere — it runs entirely on your machine. The only outbound call it makes on its own is `corgi update` checking GitHub for a newer release.
-
-## Documentation
-
-- Full docs: https://andriiklymiuk.github.io/corgi/
-- Running the stack in CI (action, caching, cross-repo e2e): https://andriiklymiuk.github.io/corgi/docs/ci
-- 2-min video showcase: https://youtu.be/rlMCjs4EoFs?si=o3SQaymM55zxBCUY
-- Driving corgi from a script or agent? See [docs/agents.md](docs/agents.md) and [docs/mcp.md](docs/mcp.md).
-- Working on your stack from your phone, always-on? See [docs/agent.md](docs/agent.md).
-- Thinking about a companion mobile app? [docs/remote-app.md](docs/remote-app.md) explains what not to build.
-- Planning + picking up work from your tracker (Linear/Jira)? See [docs/tracker.md](docs/tracker.md).
-
-### VSCode users
-
-Install the [corgi extension](https://marketplace.visualstudio.com/items?itemName=corgi.corgi) for syntax highlighting, autocompletion, and one-click commands.
+- A `corgi-compose.yml` runs its `start` commands on your machine, so only run files you trust — especially `corgi run -t <url>`, which runs a remote one.
+- `corgi doctor --fix` starts Docker for you, but **installing a tool or killing a port-holder always asks first** (or `--yes` in CI).
+- `corgi mcp` is local stdio by default. `--http` is **unauthenticated** — only expose it with `--tunnel`, which adds a bearer token. Treat that URL + token like a credential.
+- **No telemetry.** The only call corgi makes on its own is `corgi update` checking GitHub for a newer release.
 
 ## Install
-
-Once installed, `corgi` works from any folder.
-
-### macOS / Linux — [Homebrew](https://brew.sh)
 
 ```bash
 brew install andriiklymiuk/homebrew-tools/corgi
 ```
 
-### macOS / Linux — install script
-
-No Homebrew? This one-liner grabs the right binary for your OS/arch from GitHub releases:
+No Homebrew? One line, checksum-verified:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Andriiklymiuk/corgi/main/install.sh | sh
 ```
 
-It verifies the release's sha256 checksum before installing, to `/usr/local/bin` if it can, otherwise `~/.local/bin` (and adds it to your PATH for zsh/bash/fish).
+Windows, Scoop, mise, pkgx, shell completion, VSCode extension: **[full install guide](docs/install.md)**. Then `corgi -h`.
 
-A few optional overrides:
+## Documentation
 
-- `CORGI_VERSION=1.10.0` — pin a version
-- `CORGI_INSTALL_DIR=$HOME/bin` — force a directory
-- `CORGI_NO_MODIFY_PATH=1` — don't touch shell rc files
+- Full docs site: https://andriiklymiuk.github.io/corgi/
+- [Agents & scripting](docs/agents.md) (JSON, exit codes, errors) · [MCP server](docs/mcp.md) · [Tracker planning](docs/tracker.md)
+- [Work from your phone](docs/agent.md) · [Databases & drivers](docs/databases.md) · [Real-project setup](docs/getting-started.md)
+- [Run in CI](https://andriiklymiuk.github.io/corgi/docs/ci) · [Tunnels](docs/tunnel.md) · [Install](docs/install.md)
 
-### Windows — PowerShell
-
-```powershell
-irm https://raw.githubusercontent.com/Andriiklymiuk/corgi/main/install.ps1 | iex
-```
-
-Installs to `%LOCALAPPDATA%\corgi\bin` and adds it to your user PATH.
-
-### Windows — [Scoop](https://scoop.sh)
-
-```powershell
-scoop bucket add corgi https://github.com/Andriiklymiuk/scoop-bucket
-scoop install corgi
-```
-
-### [mise](https://mise.jdx.dev) (tool/version manager)
-
-```bash
-mise use -g github:Andriiklymiuk/corgi
-```
-
-Reads corgi's GitHub releases directly — no registry config needed.
-
-### [pkgx](https://pkgx.sh)
-
-```bash
-pkgx corgi run        # one-off, no install
-pkgx install corgi    # to PATH
-```
-
-### Verify
-
-```bash
-corgi -h
-```
-
-`corgi update` (alias `corgi upgrade`) notices how you installed corgi and upgrades the same way. corgi is a single binary on a steady semver release train (1.x) — pin the whole team to one version with `CORGI_VERSION` (install script) or mise, so everyone runs the same corgi.
-
-Want to try it cold? Run the expo + hono example straight from a URL:
-
-```bash
-corgi run -t https://github.com/Andriiklymiuk/corgi_examples/blob/main/honoExpoTodo/hono-bun-expo.corgi-compose.yml
-```
-
-### Shell tab-completion
-
-Brew installs `_corgi` (zsh), `corgi.bash`, `corgi.fish` automatically. After that:
-
-- `corgi run --services <TAB>` → service names from `corgi-compose.yml`
-- `corgi run --dbServices <TAB>` → db_services
-- `corgi script -n <TAB>` → script names per service (filters by `--services` if set)
-- `corgi tunnel <TAB>` → tunnelable services
-- `corgi clean -i <TAB>` → clean targets — and completions are wired for `corgi tunnel --provider`, `corgi run --omit`, and the global `--dockerContext` / `--fromTemplateName` too
-
-<details>
-<summary><strong>Completion showing filenames instead of names? (zsh fpath / Linux setup)</strong></summary>
-
-**zsh users — if `<TAB>` shows files instead of names**, your shell isn't loading brew's site-functions dir. One-time fix in `~/.zshrc` (works for every brew CLI, not just corgi):
-
-```sh
-# macOS Apple Silicon
-FPATH="/opt/homebrew/share/zsh/site-functions:$FPATH"
-# macOS Intel
-FPATH="/usr/local/share/zsh/site-functions:$FPATH"
-# Linux (linuxbrew)
-FPATH="/home/linuxbrew/.linuxbrew/share/zsh/site-functions:$FPATH"
-
-autoload -Uz compinit && compinit
-```
-
-Add it BEFORE any existing `compinit` call. Then `rm -f ~/.zcompdump* && exec zsh`.
-
-Why: brew drops completions in `<brew-prefix>/share/zsh/site-functions/`, but plain zsh doesn't include that path in `$fpath` by default — so the file is installed but never loaded. Same gap affects `gh`, `kubectl`, `helm`, etc.
-
-**Linux native package managers** (apt/dnf/pacman) — corgi isn't packaged there yet. Use the install script (`curl ... install.sh | sh`), then generate the completion script manually:
-
-```sh
-# zsh
-mkdir -p ~/.zsh/completions
-corgi completion zsh > ~/.zsh/completions/_corgi
-# add once to ~/.zshrc:
-fpath=(~/.zsh/completions $fpath); autoload -Uz compinit && compinit
-
-# bash (needs bash-completion package)
-corgi completion bash | sudo tee /etc/bash_completion.d/corgi >/dev/null
-
-# fish
-corgi completion fish > ~/.config/fish/completions/corgi.fish
-```
-
-</details>
-
-## Project health
-
-Continuously analyzed by [SonarCloud](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi):
-
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=bugs)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Andriiklymiuk_corgi&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Andriiklymiuk_corgi)
 
 If corgi saved you a setup day, [a star](https://github.com/Andriiklymiuk/corgi) helps other teams find it. 🐶
 
-## Credits & thanks
+## Credits
 
-- `corgi tunnel` defaults to [cloudflared](https://github.com/cloudflare/cloudflared) ([Apache 2.0](https://github.com/cloudflare/cloudflared/blob/master/LICENSE)) and its free, no-signup [Quick Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/). Big thanks to Cloudflare for shipping this open and free — makes local webhook testing painless.
-- Optional providers: [ngrok](https://ngrok.com) (closed source, free tier with authtoken) and [localtunnel](https://github.com/localtunnel/localtunnel) ([MIT](https://github.com/localtunnel/localtunnel/blob/master/LICENSE)) — thanks to both projects for the alternatives.
+- `corgi tunnel` defaults to [cloudflared](https://github.com/cloudflare/cloudflared) and its free [Quick Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/) — thanks to Cloudflare. Optional: [ngrok](https://ngrok.com), [localtunnel](https://github.com/localtunnel/localtunnel).
 - <a href="https://www.freepik.com/free-vector/cute-corgi-dog-astronaut-floating-space-cartoon-vector-icon-illustration-animal-science-icon-concept-isolated-premium-vector-flat-cartoon-style_22271104.htm#query=corgi%20icon&position=7&from_view=keyword">Corgi image by catalyststuff</a> on Freepik
-</content>
-</invoke>

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -248,6 +249,7 @@ func spawnConfigFrom(w workspace.Workspace, r config.Resolved, foreground bool) 
 		ConfigDir:         r.ConfigDir,
 		InheritAPIKey:     r.InheritAPIKey,
 		InheritOAuthToken: r.InheritOAuthToken,
+		SkipPermissions:   r.DangerouslySkipPermissions,
 		WakeLock:          supervisor.WakeLockMode(r.WakeLock),
 		MirrorOutput:      foreground,
 	}
@@ -306,6 +308,9 @@ func printStartupDiagnostics(configs []supervisor.SpawnConfig) {
 		}
 		if c.InheritAPIKey {
 			utils.Infof("agent: %-20s WARNING inheriting ANTHROPIC_API_KEY — remote control refuses to start with one set\n", c.WorkspaceID)
+		}
+		if c.SkipPermissions {
+			utils.Infof("agent: %-20s ⚠ permissions: SKIPPED — this session runs without the prompts you answer from your phone\n", c.WorkspaceID)
 		}
 	}
 }
@@ -422,6 +427,62 @@ func runAgentStop(_ *cobra.Command, _ []string) {
 		exitWithError("agent_stop", fmt.Errorf("could not stop pid %d: %w", info.PID, err), 1)
 	}
 	utils.Infof("stopping corgi agent (pid %d)\n", info.PID)
+}
+
+// ---------------------------------------------------------------- down
+
+var agentDownCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Stop everything `corgi agent up` started — the daemon and the detached MCP + tunnel",
+	Long: `The mirror of ` + "`corgi agent up`" + `. Stops the agent daemon and the detached
+MCP server that serves the launcher and pairing over the tunnel, so the public
+URL goes down too. (` + "`corgi agent stop`" + ` stops only the daemon.)`,
+	Run: runAgentDown,
+}
+
+func runAgentDown(_ *cobra.Command, _ []string) {
+	dir, err := agentDir()
+	if err != nil {
+		exitWithError("agent_data_dir", err, 1)
+	}
+	stopped := false
+
+	if info, rerr := daemon.ReadInfo(dir); rerr == nil && info != nil {
+		if proc, ferr := os.FindProcess(info.PID); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+			utils.Infof("stopped agent daemon (pid %d)\n", info.PID)
+			stopped = true
+		}
+	}
+
+	// The detached MCP + tunnel that `agent up` recorded. Stopping it is what
+	// takes the public URL down; `agent stop` alone leaves it serving.
+	pidPath := filepath.Join(dir, mcpPidName)
+	if pid, ok := readAgentPidFile(pidPath); ok {
+		if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+			utils.Infof("stopped MCP + tunnel (pid %d)\n", pid)
+			stopped = true
+		}
+		_ = os.Remove(pidPath)
+	}
+	_ = os.Remove(filepath.Join(dir, "agent-up.lock"))
+
+	if !stopped {
+		utils.Info("corgi agent is not running")
+	}
+}
+
+// readAgentPidFile reads a pid written by spawnDetached. A missing or malformed
+// file just means there is nothing to stop.
+func readAgentPidFile(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
 }
 
 // ---------------------------------------------------------------- workspaces
@@ -646,6 +707,7 @@ func init() {
 		agentServeCmd,
 		agentStatusCmd,
 		agentStopCmd,
+		agentDownCmd,
 		agentSessionCmd,
 		agentWorkspacesCmd,
 		agentResolveCmd,

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -456,11 +456,19 @@ func runAgentDown(_ *cobra.Command, _ []string) {
 
 	// The detached MCP + tunnel that `agent up` recorded. Stopping it is what
 	// takes the public URL down; `agent stop` alone leaves it serving.
+	//
+	// PidAlive guards against a recycled pid: mcp.pid can outlive its process (an
+	// MCP crash, a reboot, an `agent stop` all leave it on disk), and the OS may
+	// hand that number to an unrelated process. PidAlive confirms the pid is still
+	// its own process-group leader — which the detached MCP is and a recycled pid
+	// almost never is — so a stale file cannot make `down` kill your editor.
 	pidPath := filepath.Join(dir, mcpPidName)
 	if pid, ok := readAgentPidFile(pidPath); ok {
-		if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
-			utils.Infof("stopped MCP + tunnel (pid %d)\n", pid)
-			stopped = true
+		if utils.PidAlive(pid, "") {
+			if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+				utils.Infof("stopped MCP + tunnel (pid %d)\n", pid)
+				stopped = true
+			}
 		}
 		_ = os.Remove(pidPath)
 	}

--- a/cmd/agent_profile.go
+++ b/cmd/agent_profile.go
@@ -42,9 +42,11 @@ var agentProfileAddCmd = &cobra.Command{
 		configDir, _ := cmd.Flags().GetString("config-dir")
 		bin, _ := cmd.Flags().GetString("bin")
 		permissionMode, _ := cmd.Flags().GetString("permission-mode")
+		skipPerms, _ := cmd.Flags().GetBool("dangerously-skip-permissions")
 		dir := mustAgentDir()
 		if err := addProfile(dir, args[0], config.WorkspaceConfig{
 			ConfigDir: configDir, Bin: bin, PermissionMode: permissionMode,
+			DangerouslySkipPermissions: skipPerms,
 		}); err != nil {
 			exitWithError("agent_profile_add", err, 1)
 		}
@@ -81,6 +83,9 @@ var agentProfileListCmd = &cobra.Command{
 			if p.PermissionMode != "" {
 				fmt.Printf(" permissionMode=%s", p.PermissionMode)
 			}
+			if p.DangerouslySkipPermissions {
+				fmt.Print(" ⚠ permissions=SKIPPED")
+			}
 			fmt.Println()
 		}
 	},
@@ -110,8 +115,8 @@ func addProfile(dir, name string, wc config.WorkspaceConfig) error {
 	if name == "" {
 		return fmt.Errorf("a profile name is required")
 	}
-	if wc.ConfigDir == "" && wc.Bin == "" {
-		return fmt.Errorf("a profile must set at least --config-dir or --bin, or it does nothing")
+	if wc.ConfigDir == "" && wc.Bin == "" && !wc.DangerouslySkipPermissions {
+		return fmt.Errorf("a profile must set at least --config-dir, --bin, or --dangerously-skip-permissions, or it does nothing")
 	}
 	if _, err := supervisor.SanitizeBin(wc.Bin); err != nil {
 		return err
@@ -189,6 +194,8 @@ func init() {
 	agentProfileAddCmd.Flags().String("config-dir", "", "Claude config directory for this profile (e.g. ~/.claude-work) — the account it runs under")
 	agentProfileAddCmd.Flags().String("bin", "", "Command to run instead of the default `claude` (a real program on PATH, not a shell alias)")
 	agentProfileAddCmd.Flags().String("permission-mode", "", "Permission mode passed to remote control (default|acceptEdits|plan|auto|dontask)")
+	agentProfileAddCmd.Flags().Bool("dangerously-skip-permissions", false,
+		"Run this profile's sessions with permission prompts OFF (--permission-mode bypassPermissions). Removes the gate you answer from your phone — trusted local config only, off by default.")
 	agentProfileCmd.AddCommand(agentProfileAddCmd, agentProfileListCmd, agentProfileRemoveCmd)
 	agentCmd.AddCommand(agentProfileCmd)
 }

--- a/cmd/agent_profile.go
+++ b/cmd/agent_profile.go
@@ -125,6 +125,9 @@ func addProfile(dir, name string, wc config.WorkspaceConfig) error {
 		return fmt.Errorf("unknown or disallowed permissionMode %q (want one of: %s)",
 			wc.PermissionMode, supervisor.PermissionModeHint())
 	}
+	if wc.DangerouslySkipPermissions && wc.PermissionMode != "" {
+		return fmt.Errorf("set either --permission-mode or --dangerously-skip-permissions, not both")
+	}
 	path := agentUserConfigPath(dir)
 	user, err := config.LoadUser(path)
 	if err != nil {

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -52,6 +52,7 @@ func runAgentInit(cmd *cobra.Command, _ []string) {
 	aliases, _ := cmd.Flags().GetStringSlice("alias")
 	configDir, _ := cmd.Flags().GetString("config-dir")
 	sensitive, _ := cmd.Flags().GetBool("sensitive")
+	skipPerms, _ := cmd.Flags().GetBool("dangerously-skip-permissions")
 
 	if err := writeRepoAgentConfig(cwd, id, aliases, sensitive); err != nil {
 		exitWithError("agent_write_repo_config", err, 1)
@@ -75,12 +76,15 @@ func runAgentInit(cmd *cobra.Command, _ []string) {
 
 	// init is the deliberate opt-in, so it is what turns supervision on.
 	// `corgi agent scan` registers without arming anything.
-	if err := enableWorkspace(id, configDir); err != nil {
+	if err := enableWorkspace(id, configDir, skipPerms); err != nil {
 		exitWithError("agent_write_user_config", err, 1)
 	}
 
 	utils.Infof("registered %s (%s) and enabled it\n", id, cwd)
 	utils.Info("wrote .corgi/agent.yml — safe to commit, it holds identity only")
+	if skipPerms {
+		utils.Info("⚠ permissions: SKIPPED for this workspace — its remote sessions run without the prompts you answer from your phone. Undo with `corgi agent workspaces` or by editing the user config.")
+	}
 	if configDir == "" {
 		utils.Info("no config dir set: this workspace uses your default Claude account.")
 		utils.Info("If you keep work and personal logins separate, set one:")
@@ -168,7 +172,7 @@ func writeRepoAgentConfig(dir, id string, aliases []string, sensitive bool) erro
 
 // enableWorkspace turns on supervision for a workspace, and records its Claude
 // config directory, in the trusted user-level file.
-func enableWorkspace(id, configDir string) error {
+func enableWorkspace(id, configDir string, skipPerms bool) error {
 	dir, err := agentDir()
 	if err != nil {
 		return err
@@ -183,6 +187,12 @@ func enableWorkspace(id, configDir string) error {
 	entry.Autostart = &on
 	if configDir != "" {
 		entry.ConfigDir = configDir
+	}
+	// Never silently clears an already-set opt-in: a re-init without the flag
+	// leaves a previously-granted bypass alone, matching how the config overlay
+	// OR-s capability booleans rather than overwriting them.
+	if skipPerms {
+		entry.DangerouslySkipPermissions = true
 	}
 	user.Workspaces[id] = entry
 
@@ -478,6 +488,8 @@ func init() {
 	agentInitCmd.Flags().StringSlice("alias", nil, "Extra names this workspace answers to, e.g. --alias 'recipe app'")
 	agentInitCmd.Flags().String("config-dir", "", "CLAUDE_CONFIG_DIR for this workspace, so it runs under a specific Claude account")
 	agentInitCmd.Flags().Bool("sensitive", false, "Never open a public tunnel for this workspace")
+	agentInitCmd.Flags().Bool("dangerously-skip-permissions", false,
+		"Run this workspace's sessions with permission prompts OFF (--permission-mode bypassPermissions). Removes the gate you answer from your phone — off by default.")
 
 	agentScanCmd.Flags().Bool("dry-run", false, "Show what would be registered without changing anything")
 

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -83,7 +83,8 @@ func runAgentInit(cmd *cobra.Command, _ []string) {
 	utils.Infof("registered %s (%s) and enabled it\n", id, cwd)
 	utils.Info("wrote .corgi/agent.yml — safe to commit, it holds identity only")
 	if skipPerms {
-		utils.Info("⚠ permissions: SKIPPED for this workspace — its remote sessions run without the prompts you answer from your phone. Undo with `corgi agent workspaces` or by editing the user config.")
+		utils.Info("⚠ permissions: SKIPPED for this workspace — its remote sessions run without the prompts you answer from your phone.")
+		utils.Infof("  to undo: remove `dangerouslySkipPermissions: true` for %s from %s\n", id, agentUserConfigPath(mustAgentDir()))
 	}
 	if configDir == "" {
 		utils.Info("no config dir set: this workspace uses your default Claude account.")

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -62,6 +62,7 @@ type agentUpResult struct {
 func runAgentUp(cmd *cobra.Command, _ []string) {
 	addr, _ := cmd.Flags().GetString("http")
 	provider, _ := cmd.Flags().GetString("provider")
+	tunnelName, _ := cmd.Flags().GetString("tunnel-name")
 
 	dir, err := agentDir()
 	if err != nil {
@@ -103,7 +104,7 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	if err := spawnDetachedMCP(dir, addr, provider); err != nil {
+	if err := spawnDetachedMCP(dir, addr, provider, tunnelName); err != nil {
 		exitWithError("agent_up_mcp", err, 1)
 	}
 	res.MCPStarted = true
@@ -177,10 +178,15 @@ func ensureDaemon(dir string) (*daemon.Info, error) {
 	return nil, fmt.Errorf("daemon did not come up — see %s", filepath.Join(dir, "serve.log"))
 }
 
-func spawnDetachedMCP(dir, addr, provider string) error {
+func spawnDetachedMCP(dir, addr, provider, tunnelName string) error {
 	args := []string{"mcp", "--http", addr, "--tunnel", "--pair"}
 	if provider != "" {
 		args = append(args, "--tunnel-provider", provider)
+	}
+	// A named tunnel gives a stable public URL, so the launcher can be
+	// bookmarked / saved to a home screen and survive a restart of `agent up`.
+	if tunnelName != "" {
+		args = append(args, "--tunnel-name", tunnelName)
 	}
 	// Truncate the old log first: awaitMCPLog must not read a previous run's
 	// URL or pairing code as this one's.
@@ -392,5 +398,6 @@ func orDefault(s, def string) string {
 func init() {
 	agentUpCmd.Flags().String("http", defaultMCPAddr, "Local MCP address")
 	agentUpCmd.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
+	agentUpCmd.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — gives a stable public URL you can bookmark (needs a one-time `cloudflared tunnel create`; see docs/tunnel.md)")
 	agentCmd.AddCommand(agentUpCmd)
 }

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -27,6 +27,10 @@ const defaultMCPAddr = "127.0.0.1:8765"
 // mcpLogName is the detached MCP server's log file, under the agent data dir.
 const mcpLogName = "mcp.log"
 
+// mcpPidName records the detached MCP server's pid so `corgi agent down` can
+// stop the tunnel + pairing server that `agent up` started, not just the daemon.
+const mcpPidName = "mcp.pid"
+
 var agentUpCmd = &cobra.Command{
 	Use:   "up",
 	Short: "One command from a stack directory to phone-startable: register, daemon, tunnel, pairing",
@@ -160,7 +164,7 @@ func ensureDaemon(dir string) (*daemon.Info, error) {
 	if info, err := daemon.ReadInfo(dir); err == nil && info != nil {
 		return info, nil
 	}
-	if err := spawnDetached(dir, "serve.log", "agent", "serve"); err != nil {
+	if _, err := spawnDetached(dir, "serve.log", "agent", "serve"); err != nil {
 		return nil, err
 	}
 	deadline := time.Now().Add(10 * time.Second)
@@ -181,19 +185,27 @@ func spawnDetachedMCP(dir, addr, provider string) error {
 	// Truncate the old log first: awaitMCPLog must not read a previous run's
 	// URL or pairing code as this one's.
 	_ = os.Remove(filepath.Join(dir, mcpLogName))
-	return spawnDetached(dir, mcpLogName, args...)
-}
-
-// spawnDetached starts corgi itself with args, output to <dir>/<logName>, in
-// its own process group so it outlives this command and later Ctrl+Cs.
-func spawnDetached(dir, logName string, args ...string) error {
-	exe, err := os.Executable()
+	pid, err := spawnDetached(dir, mcpLogName, args...)
 	if err != nil {
 		return err
 	}
+	// Best-effort: a missing pid file only means `agent down` cannot stop this
+	// MCP for you, not that anything is wrong with the running server.
+	_ = os.WriteFile(filepath.Join(dir, mcpPidName), []byte(strconv.Itoa(pid)+"\n"), 0o600)
+	return nil
+}
+
+// spawnDetached starts corgi itself with args, output to <dir>/<logName>, in
+// its own process group so it outlives this command and later Ctrl+Cs. Returns
+// the child pid so the caller can record it for a later stop.
+func spawnDetached(dir, logName string, args ...string) (int, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, err
+	}
 	logFile, err := os.OpenFile(filepath.Join(dir, logName), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer logFile.Close()
 	c := exec.Command(exe, args...)
@@ -201,7 +213,10 @@ func spawnDetached(dir, logName string, args ...string) error {
 	c.Stderr = logFile
 	c.Stdin = nil
 	utils.SetProcessGroup(c)
-	return c.Start()
+	if err := c.Start(); err != nil {
+		return 0, err
+	}
+	return c.Process.Pid, nil
 }
 
 // acquireUpLock takes an exclusive, pid-stamped lock so only one `agent up`

--- a/cmd/agent_up_test.go
+++ b/cmd/agent_up_test.go
@@ -230,3 +230,26 @@ func TestMustAgentDirReturnsTheAgentDir(t *testing.T) {
 		t.Errorf("mustAgentDir() = %q, want %q", got, want)
 	}
 }
+
+func TestReadAgentPidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, mcpPidName)
+
+	if _, ok := readAgentPidFile(path); ok {
+		t.Error("a missing pid file must report not-ok, so `agent down` has nothing to stop")
+	}
+	if err := os.WriteFile(path, []byte("4321\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if pid, ok := readAgentPidFile(path); !ok || pid != 4321 {
+		t.Errorf("readAgentPidFile = %d, %v; want 4321, true", pid, ok)
+	}
+	for _, bad := range []string{"garbage\n", "-1\n", ""} {
+		if err := os.WriteFile(path, []byte(bad), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := readAgentPidFile(path); ok {
+			t.Errorf("a malformed pid %q must report not-ok", bad)
+		}
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,10 +18,11 @@ import (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Create db service",
-	Long: `
-This is used to create db service from template.	
-	`,
+	Short: "Set up a stack from corgi-compose.yml (clone repos, create db services + env)",
+	Long: `Prepares everything corgi-compose.yml describes, without starting it: clones each
+service repo (--depth for a shallow clone, --feature to check out a branch where a
+repo has it), creates the database service files and .env files, runs the required:
+installs, and adds corgi's generated paths to .gitignore. Then 'corgi run' starts it.`,
 	Run:     runInit,
 	Aliases: []string{"initialize", "clone"},
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -330,6 +330,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		mux.HandleFunc("/app", launcherPageHandler)
 		mux.Handle("/launch/workspaces", bearerAuth(token, http.HandlerFunc(launchWorkspacesHandler), deviceStore))
 		mux.Handle("/launch/start", bearerAuth(token, http.HandlerFunc(launchStartHandler), deviceStore))
+		mux.Handle("/launch/sessions", bearerAuth(token, http.HandlerFunc(launchSessionsHandler), deviceStore))
 	}
 
 	// /pair is deliberately NOT behind the bearer check: its whole purpose is

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -166,14 +166,38 @@ const launcherPageHTML = `<!doctype html>
   button{border:0;border-radius:.55rem;padding:.5rem .9rem;font-size:.85rem;font-weight:600;cursor:pointer;
       background:#e8e8e8;color:#0f1115}
   button:disabled{opacity:.5}
-  a.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;
-      padding:.5rem .9rem;border-radius:.55rem;font-weight:600;font-size:.85rem}
+  a.open,button.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;border:0;
+      padding:.5rem .9rem;border-radius:.55rem;font-weight:600;font-size:.85rem;cursor:pointer}
+  .right{display:flex;flex-direction:column;align-items:flex-end;gap:.35rem}
+  .modes{display:flex;gap:.3rem;font-size:.68rem;color:#8a90a6;align-items:center}
+  .modes span{margin-right:.1rem}
+  .modes .m{background:#12151b;border:1px solid #2a2e37;color:#9aa0a6;border-radius:.4rem;
+      padding:.12rem .4rem;font-size:.68rem;font-weight:600}
+  .modes .m.sel{background:#2a2e37;color:#e8e8e8;border-color:#3a3f4b}
   .msg{color:#9aa0a6;font-size:.9rem;margin:1rem 0}
   .err{color:#ff7b72}
   code{background:#1a1d23;padding:.1rem .3rem;border-radius:.3rem}
+  details.settings{margin:1.6rem 0 0;border-top:1px solid #2a2e37;padding-top:1rem}
+  details.settings summary{color:#9aa0a6;font-size:.85rem;cursor:pointer}
+  details.settings p{color:#8a90a6;font-size:.78rem;line-height:1.5}
+  pre{background:#1a1d23;border:1px solid #2a2e37;border-radius:.5rem;padding:.7rem;
+      overflow-x:auto;font-size:.72rem;line-height:1.4;white-space:pre;color:#c8cdd6}
 </style>
 <header>🐕 corgi<small id="host">your machine</small></header>
-<main><div id="list" class="msg">Loading…</div></main>
+<main>
+  <div id="list" class="msg">Loading…</div>
+  <details class="settings" id="settings" hidden>
+    <summary>⚙ Settings</summary>
+    <p><b>Claude app connector.</b> Prefer the Claude app? Add corgi as a custom connector on claude.ai (Settings → Connectors → Add custom), so the app can control this machine too. Tap to copy:</p>
+    <pre id="cfg"></pre>
+    <button id="copycfg">Copy connector config</button>
+    <p id="copymsg" class="msg"></p>
+    <p>Each workspace above has an <b>open in</b> switch — <b>app</b> deep-links into the Claude app; <b>browser</b> keeps the session here in this browser (use it for a workspace on a different Claude account than the app is signed into). Remembered per workspace, on this browser only.</p>
+  </details>
+  <p class="msg" style="text-align:center;margin-top:1.4rem">
+    <a id="allsessions" target="_blank" rel="noopener" style="color:#7ee787;text-decoration:none">See all your sessions on claude.ai ↗</a>
+  </p>
+</main>
 <script>
   const esc = s => String(s).replace(/[&<>"']/g, c =>
     ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -186,13 +210,34 @@ const launcherPageHTML = `<!doctype html>
   const token = (() => { try { return localStorage.getItem('corgi_token') || ''; } catch { return ''; } })();
   const list = document.getElementById('list');
   const auth = { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' };
+  // Set in JS (not a static href) so the page source carries no external link;
+  // this is a user navigation to the Claude session list, not a loaded asset.
+  try { document.getElementById('allsessions').href = 'https://claude.ai/code'; } catch {}
+
+  let lastWorkspaces = [];
+  const openMode = id => { try { return localStorage.getItem('corgi_open_' + id) || 'app'; } catch { return 'app'; } };
+  const setOpenMode = (id, m) => { try { localStorage.setItem('corgi_open_' + id, m); } catch {} };
 
   if (!token) {
     list.className = 'msg';
     list.innerHTML = 'Not paired on this browser yet. On your laptop run ' +
       '<code>corgi agent up</code> and scan the QR to pair, then come back here.';
   } else {
+    initSettings();
     load();
+  }
+
+  function initSettings() {
+    const s = document.getElementById('settings');
+    const connector = JSON.stringify({ mcpServers: { corgi: {
+      url: location.origin + '/mcp', headers: { Authorization: 'Bearer ' + token } } } }, null, 2);
+    document.getElementById('cfg').textContent = connector;
+    s.hidden = false;
+    document.getElementById('copycfg').onclick = async (e) => {
+      const msg = document.getElementById('copymsg');
+      try { await navigator.clipboard.writeText(connector); msg.textContent = '✓ Copied'; }
+      catch { msg.textContent = 'Long-press the box above to copy.'; }
+    };
   }
 
   async function load() {
@@ -207,6 +252,7 @@ const launcherPageHTML = `<!doctype html>
   }
 
   function render(workspaces) {
+    lastWorkspaces = workspaces;
     if (!workspaces.length) {
       list.className = 'msg';
       list.innerHTML = 'No workspaces registered. On the laptop: <code>corgi agent scan ~/dev</code>.';
@@ -224,11 +270,10 @@ const launcherPageHTML = `<!doctype html>
       left.innerHTML = '<div class="name"><span class="dot' + (ws.running ? ' on' : '') + '"></span> ' +
         esc(ws.id) + '</div><div class="path">' + esc(ws.path) + '</div>' + note;
       const right = document.createElement('div');
+      right.className = 'right';
       if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
-        const a = document.createElement('a');
-        a.className = 'open'; a.href = ws.sessionUrl; a.textContent = 'Open session';
-        a.target = '_blank'; a.rel = 'noopener noreferrer';
-        right.appendChild(a);
+        right.appendChild(openControl(ws));
+        right.appendChild(modeSwitch(ws.id));
       } else {
         const b = document.createElement('button');
         b.textContent = ws.running ? 'Starting…' : (ws.note ? 'Retry' : 'Start');
@@ -239,6 +284,37 @@ const launcherPageHTML = `<!doctype html>
       row.appendChild(left); row.appendChild(right);
       list.appendChild(row);
     }
+  }
+
+  // app mode uses a real anchor tap so iOS deep-links into the Claude app;
+  // browser mode opens via JS, which keeps the session in this browser (right
+  // for a workspace signed into a different Claude account than the app).
+  function openControl(ws) {
+    if (openMode(ws.id) === 'browser') {
+      const b = document.createElement('button');
+      b.className = 'open'; b.textContent = 'Open session';
+      b.onclick = () => window.open(ws.sessionUrl, '_blank', 'noopener');
+      return b;
+    }
+    const a = document.createElement('a');
+    a.className = 'open'; a.href = ws.sessionUrl; a.textContent = 'Open session';
+    a.target = '_blank'; a.rel = 'noopener noreferrer';
+    return a;
+  }
+
+  function modeSwitch(id) {
+    const cur = openMode(id);
+    const wrap = document.createElement('div');
+    wrap.className = 'modes';
+    wrap.appendChild(document.createTextNode('open in:'));
+    for (const m of ['app', 'browser']) {
+      const b = document.createElement('button');
+      b.className = 'm' + (cur === m ? ' sel' : '');
+      b.textContent = m;
+      b.onclick = () => { setOpenMode(id, m); render(lastWorkspaces); };
+      wrap.appendChild(b);
+    }
+    return wrap;
   }
 
   async function startSession(id, btn) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -408,12 +408,21 @@ const launcherPageHTML = `<!doctype html>
       const s = j.sessions || [];
       if (!s.length) { box.innerHTML = '<div class="none">No active sessions. corgi lists these from the claude CLI — none are running for this workspace.</div>'; return; }
       box.innerHTML = '';
-      // These are the local Claude sessions the claude CLI reports for this
-      // workspace (kind + age). They carry no claude.ai web URL, so they are shown
-      // as status, not links — the openable one is the green "Open session" above.
+      // Sessions the claude CLI reports for this workspace. Each links via the
+      // documented claude.ai/code/<session-id> scheme; a session that was never
+      // connected to claude.ai (pure local terminal) may 404 there, so the link
+      // is best-effort — remote-control sessions, the common case here, open.
       for (const sess of s) {
-        const el = document.createElement('div');
+        const url = sess.sessionId ? 'https://claude.ai/code/' + encodeURIComponent(sess.sessionId) : '';
+        const clickable = url && safeClaudeUrl(url);
+        const el = document.createElement(clickable ? 'a' : 'div');
         el.className = 's';
+        if (clickable) {
+          el.href = url; el.target = '_blank'; el.rel = 'noopener noreferrer';
+          el.title = 'Open on claude.ai (works for connected sessions)';
+          // Honor the workspace's open-in choice: browser mode stays in the browser.
+          if (openMode(id) === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
+        }
         el.innerHTML = '<span>' + esc(sess.name || sess.sessionId || 'session') + '</span>' +
           '<span class="when">' + esc(sess.kind || '') + ' · ' + esc(fmtWhen(sess.startedAt)) + '</span>';
         box.appendChild(el);

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -1,12 +1,18 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
+	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
@@ -122,6 +128,99 @@ func launchStartHandler(w http.ResponseWriter, r *http.Request) {
 	writeLaunchJSON(w, result)
 }
 
+// claudeSession is one entry from `claude agents --json`.
+type claudeSession struct {
+	Name      string `json:"name"`
+	SessionID string `json:"sessionId"`
+	CWD       string `json:"cwd"`
+	Kind      string `json:"kind"`
+	StartedAt int64  `json:"startedAt"`
+	PID       int    `json:"pid"`
+}
+
+// launchSessionsHandler lists the Claude sessions for one workspace. corgi holds
+// no Claude credentials of its own: it shells out to `claude agents --json`,
+// which reads the local session state the CLI already keeps, scoped to the
+// workspace directory and run under that workspace's own account.
+func launchSessionsHandler(w http.ResponseWriter, r *http.Request) {
+	setLaunchHeaders(w)
+	if r.Method != http.MethodGet {
+		writeLaunchError(w, http.StatusMethodNotAllowed, "GET only")
+		return
+	}
+	id := strings.TrimSpace(r.URL.Query().Get("workspace"))
+	if id == "" {
+		writeLaunchError(w, http.StatusBadRequest, "a workspace is required")
+		return
+	}
+	absPath, configDir, ok := workspaceSessionTarget(id)
+	if !ok {
+		writeLaunchError(w, http.StatusNotFound, "unknown workspace")
+		return
+	}
+	writeLaunchJSON(w, map[string]any{"sessions": listClaudeSessions(absPath, configDir)})
+}
+
+// workspaceSessionTarget resolves a workspace id to its directory and the Claude
+// config dir (account) its sessions live under. The id is the trusted registry
+// key, and the directory comes from the registry — never from the caller — so a
+// device token cannot point the shell-out at an arbitrary path.
+func workspaceSessionTarget(id string) (absPath, configDir string, ok bool) {
+	registry, _, err := agentRegistry()
+	if err != nil {
+		return "", "", false
+	}
+	ws, found := registry.Find(id)
+	if !found || ws.AbsPath == "" {
+		return "", "", false
+	}
+	dir, err := agentDir()
+	if err != nil {
+		return ws.AbsPath, "", true
+	}
+	user, err := config.LoadUser(agentUserConfigPath(dir))
+	if err != nil {
+		return ws.AbsPath, "", true
+	}
+	repo, _ := config.LoadRepo(ws.AbsPath)
+	return ws.AbsPath, config.Resolve(id, repo, user).ConfigDir, true
+}
+
+// listClaudeSessions returns the Claude sessions under absPath. Best-effort: a
+// missing claude binary, a timeout, or no sessions all resolve to an empty list,
+// so the launcher shows "no sessions" rather than a 500.
+func listClaudeSessions(absPath, configDir string) []claudeSession {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	// Fixed argv (no shell); absPath is the trusted registry path.
+	cmd := exec.CommandContext(ctx, "claude", "agents", "--json", "--cwd", absPath)
+	cmd.Env = os.Environ()
+	if d := expandTilde(configDir); d != "" {
+		cmd.Env = append(cmd.Env, "CLAUDE_CONFIG_DIR="+d)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return []claudeSession{}
+	}
+	var sessions []claudeSession
+	if json.Unmarshal(out, &sessions) != nil {
+		return []claudeSession{}
+	}
+	return sessions
+}
+
+func expandTilde(p string) string {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			if p == "~" {
+				return home
+			}
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
 func launcherPageHandler(w http.ResponseWriter, r *http.Request) {
 	setLaunchHeaders(w)
 	w.Header().Set(headerContentType, "text/html; charset=utf-8")
@@ -157,8 +256,14 @@ const launcherPageHTML = `<!doctype html>
   header small{display:block;color:#9aa0a6;font-size:.8rem;font-weight:400;margin-top:.2rem}
   main{padding:0 1.2rem 2rem;max-width:34rem;margin:0 auto}
   .ws{background:#1a1d23;border:1px solid #2a2e37;border-radius:.7rem;padding:.9rem 1rem;margin:.6rem 0;
-      display:flex;align-items:center;justify-content:space-between;gap:.6rem}
+      display:flex;align-items:center;justify-content:space-between;gap:.6rem;flex-wrap:wrap}
   .ws .name{font-weight:600}
+  .sbtn{background:none;border:0;color:#8a90a6;font-size:.72rem;font-weight:600;cursor:pointer;
+      padding:.2rem 0;margin-top:.25rem}
+  .sessions{flex-basis:100%;margin-top:.5rem;border-top:1px solid #2a2e37;padding-top:.5rem}
+  .sessions .s{display:flex;justify-content:space-between;gap:.6rem;font-size:.76rem;color:#c8cdd6;padding:.22rem 0}
+  .sessions .s .when{color:#8a90a6;font-size:.7rem;flex:0 0 auto}
+  .sessions .none{color:#8a90a6;font-size:.74rem}
   .ws .path{color:#8a90a6;font-size:.72rem;word-break:break-all;margin-top:.15rem}
   .ws .wnote{color:#ff7b72;font-size:.72rem;margin-top:.3rem;line-height:1.4}
   .dot{width:.55rem;height:.55rem;border-radius:50%;background:#3a3f4b;flex:0 0 auto}
@@ -269,6 +374,12 @@ const launcherPageHTML = `<!doctype html>
       const note = (!ws.running && ws.note) ? '<div class="wnote">' + esc(ws.note) + '</div>' : '';
       left.innerHTML = '<div class="name"><span class="dot' + (ws.running ? ' on' : '') + '"></span> ' +
         esc(ws.id) + '</div><div class="path">' + esc(ws.path) + '</div>' + note;
+      const sbtn = document.createElement('button');
+      sbtn.className = 'sbtn'; sbtn.textContent = 'sessions ⌄';
+      const sessionsBox = document.createElement('div');
+      sessionsBox.className = 'sessions'; sessionsBox.style.display = 'none';
+      sbtn.onclick = () => toggleSessions(ws.id, sbtn, sessionsBox);
+      left.appendChild(sbtn);
       const right = document.createElement('div');
       right.className = 'right';
       if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
@@ -281,9 +392,40 @@ const launcherPageHTML = `<!doctype html>
         b.onclick = () => startSession(ws.id, b);
         right.appendChild(b);
       }
-      row.appendChild(left); row.appendChild(right);
+      row.appendChild(left); row.appendChild(right); row.appendChild(sessionsBox);
       list.appendChild(row);
     }
+  }
+
+  async function toggleSessions(id, btn, box) {
+    if (box.style.display !== 'none') { box.style.display = 'none'; btn.textContent = 'sessions ⌄'; return; }
+    box.style.display = ''; btn.textContent = 'sessions ⌃';
+    box.innerHTML = '<div class="none">Loading…</div>';
+    try {
+      const r = await fetch('/launch/sessions?workspace=' + encodeURIComponent(id), { headers: auth });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || r.status);
+      const s = j.sessions || [];
+      if (!s.length) { box.innerHTML = '<div class="none">No active sessions. corgi lists these from the claude CLI — none are running for this workspace.</div>'; return; }
+      box.innerHTML = '';
+      for (const sess of s) {
+        const el = document.createElement('div');
+        el.className = 's';
+        el.innerHTML = '<span>' + esc(sess.name || sess.sessionId || 'session') +
+          ' <span class="when">· ' + esc(sess.kind || '') + '</span></span>' +
+          '<span class="when">' + esc(fmtWhen(sess.startedAt)) + '</span>';
+        box.appendChild(el);
+      }
+    } catch (e) { box.innerHTML = '<div class="none">✗ ' + esc(e.message) + '</div>'; }
+  }
+
+  function fmtWhen(ms) {
+    if (!ms) return '';
+    const diff = (Date.now() - ms) / 1000;
+    if (diff < 60) return 'just now';
+    if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+    if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+    return new Date(ms).toLocaleDateString();
   }
 
   // app mode uses a real anchor tap so iOS deep-links into the Claude app;

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -408,12 +408,14 @@ const launcherPageHTML = `<!doctype html>
       const s = j.sessions || [];
       if (!s.length) { box.innerHTML = '<div class="none">No active sessions. corgi lists these from the claude CLI — none are running for this workspace.</div>'; return; }
       box.innerHTML = '';
+      // These are the local Claude sessions the claude CLI reports for this
+      // workspace (kind + age). They carry no claude.ai web URL, so they are shown
+      // as status, not links — the openable one is the green "Open session" above.
       for (const sess of s) {
         const el = document.createElement('div');
         el.className = 's';
-        el.innerHTML = '<span>' + esc(sess.name || sess.sessionId || 'session') +
-          ' <span class="when">· ' + esc(sess.kind || '') + '</span></span>' +
-          '<span class="when">' + esc(fmtWhen(sess.startedAt)) + '</span>';
+        el.innerHTML = '<span>' + esc(sess.name || sess.sessionId || 'session') + '</span>' +
+          '<span class="when">' + esc(sess.kind || '') + ' · ' + esc(fmtWhen(sess.startedAt)) + '</span>';
         box.appendChild(el);
       }
     } catch (e) { box.innerHTML = '<div class="none">✗ ' + esc(e.message) + '</div>'; }

--- a/cmd/mcp_launcher_test.go
+++ b/cmd/mcp_launcher_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -143,5 +145,34 @@ func TestBuildLaunchWorkspacesNilStatus(t *testing.T) {
 	out := buildLaunchWorkspaces(reg, nil)
 	if len(out) != 1 || out[0].Running || out[0].Note != "" {
 		t.Errorf("with no daemon, a workspace is just listed idle, got %+v", out[0])
+	}
+}
+
+func TestLaunchSessionsHandlerRequiresAWorkspace(t *testing.T) {
+	rec := httptest.NewRecorder()
+	launchSessionsHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/sessions", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("a sessions request with no workspace must be 400, got %d", rec.Code)
+	}
+}
+
+func TestLaunchSessionsHandlerRejectsNonGET(t *testing.T) {
+	rec := httptest.NewRecorder()
+	launchSessionsHandler(rec, httptest.NewRequest(http.MethodPost, "/launch/sessions?workspace=x", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST to sessions must be 405, got %d", rec.Code)
+	}
+}
+
+func TestExpandTilde(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if got := expandTilde("~/.claude-x"); got != filepath.Join(home, ".claude-x") {
+		t.Errorf("expandTilde(~/.claude-x) = %q", got)
+	}
+	if got := expandTilde("/abs/path"); got != "/abs/path" {
+		t.Errorf("an absolute path must pass through, got %q", got)
+	}
+	if got := expandTilde(""); got != "" {
+		t.Errorf("empty must stay empty, got %q", got)
 	}
 }

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -40,6 +40,20 @@ again would be worse.
 
 ## Quick start
 
+One command does the whole phone-startable setup — register this stack, start
+the daemon + MCP + tunnel + pairing, and print a QR (and the pairing code):
+
+```bash
+cd ~/dev/your-stack
+corgi agent up                   # register + daemon + tunnel + pairing, prints a QR
+```
+
+Everything `agent up` starts is **detached**, so it survives crashes and the
+Remote Control network timeout — but not a reboot. Add `corgi agent install`
+once to start the daemon at login so it comes back after a restart.
+
+Or do it step by step:
+
 ```bash
 cd ~/dev/your-stack
 corgi agent init                 # register AND enable this stack
@@ -65,6 +79,7 @@ corgi agent serve --foreground   # run it in this terminal and watch
 
 | command | what it does |
 |---|---|
+| `corgi agent up` | one shot: register + daemon + tunnel + pairing, prints a QR |
 | `corgi agent init` | register this stack, write `.corgi/agent.yml` |
 | `corgi agent scan <dir>` | find stacks under a directory and register them (does not enable) |
 | `corgi agent serve` | supervise Remote Control for every enabled workspace |
@@ -183,10 +198,12 @@ rather than merely convenient:
 - **`args` is trusted config only.** An argv is a choice of what code runs, so
   there is deliberately no field in the committed `.corgi/agent.yml` that
   reaches it. A cloned repository cannot choose the command.
-- **Nothing may disarm the permission prompts.** `--dangerously-*` and `--yolo`
-  in `args` are rejected, the same rule that already rejects
-  `permissionMode: bypassPermissions`. Those prompts are what you answer from
-  your phone.
+- **Untrusted config may never disarm the permission prompts.** `--dangerously-*`
+  and `--yolo` smuggled through `args`, and a `permissionMode: bypassPermissions`
+  string, are rejected. The one way to skip prompts is the explicit
+  `dangerouslySkipPermissions` boolean in your trusted user config (see [Running
+  more than one Claude account](#running-more-than-one-claude-account)) — never
+  a committed repo file.
 - **A setting that cannot take effect is an error.** `spawn` and
   `permissionMode` on a `custom` kind are rejected rather than dropped, and so
   is a `configDir` with no `configDirEnv` to put it in — silently ignoring the
@@ -270,10 +287,32 @@ can mark itself `sensitive`, which only removes capability. It cannot choose
 which binary runs, which account is used, or which permission mode applies —
 otherwise cloning a repository would be a way to run code on your machine.
 
-`permissionMode: bypassPermissions` is rejected outright, and corgi never
-passes `--dangerously-skip-permissions` whatever your aliases do. Those prompts
-are what you answer from your phone, and they are the main defence against a
-session acting on injected instructions from a file it read.
+Those prompts are what you answer from your phone, and they are the main defence
+against a session acting on injected instructions from a file it read. So corgi
+does not skip them **unless you deliberately ask it to, per workspace, in your
+trusted config**:
+
+```bash
+corgi agent init --dangerously-skip-permissions          # this workspace
+corgi agent profile add skp --config-dir ~/.claude-x \
+  --dangerously-skip-permissions                         # or a reusable profile
+```
+
+That sets `dangerouslySkipPermissions: true`, and corgi then passes
+`--permission-mode bypassPermissions` for that workspace. Two guarantees hold
+even so:
+
+- **A committed repo file can never turn it on.** The field lives only in the
+  trusted user config; `.corgi/agent.yml` has no such field, so cloning a
+  repository cannot make your machine skip prompts. A stray
+  `permissionMode: bypassPermissions` string, or a `--dangerously` flag smuggled
+  through `args:`, is still rejected — the boolean above is the one sanctioned
+  route.
+- **It is never silent.** `corgi agent up`/`serve` print
+  `⚠ permissions: SKIPPED` for any workspace running this way, and
+  `corgi agent profile list` marks the profile.
+
+Leave it off (the default) for anything you would not let run unattended.
 
 ## The MCP tools
 
@@ -489,7 +528,9 @@ export CORGI_DATA_DIR="$(brew --prefix)/var/corgi"
 
 - Config split by trust; a cloned repo cannot grant itself capability.
 - `bin` must be a command name on PATH, never a path.
-- `bypassPermissions` rejected; `--dangerously-skip-permissions` never passed.
+- Permission prompts are only skipped when your trusted config explicitly sets
+  `dangerouslySkipPermissions` — never from a committed repo file, a
+  `permissionMode` string, or a smuggled `--dangerously` arg; and never silently.
 - Ambient credentials stripped from supervised processes and reported.
 - The user config must be `0600` or corgi refuses to read it; briefs are written
   `0600` for the same reason — they name repository paths and branches.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -312,6 +312,12 @@ even so:
   `⚠ permissions: SKIPPED` for any workspace running this way, and
   `corgi agent profile list` marks the profile.
 
+One caveat on the profile form: profiles are global, so a bypass **profile** can
+be applied to any non-sensitive workspace from the phone, not only the one you
+built it for. Prefer `agent init --dangerously-skip-permissions` to pin the bypass
+to a single workspace; reach for a bypass profile only when you deliberately want
+it reusable across several.
+
 Leave it off (the default) for anything you would not let run unattended.
 
 ## The MCP tools

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -61,6 +61,33 @@ corgi agent install              # start at login (launchd / systemd)
 corgi agent status               # what is running, and under which account
 ```
 
+### A launcher URL that never changes
+
+The default is a Cloudflare **quick tunnel**: free, no signup — and a **new random
+URL every restart**, so the phone bookmark goes stale whenever `agent up` reruns.
+For a permanent URL, use a **named tunnel**:
+
+```bash
+# one-time (free Cloudflare account + a domain on it):
+cloudflared tunnel login
+cloudflared tunnel create corgi-agent
+cloudflared tunnel route dns corgi-agent corgi.yourdomain.com
+
+# then always:
+corgi agent up --tunnel-name corgi-agent
+```
+
+The launcher now lives at the same hostname forever — save it to the phone's home
+screen once. Provider notes (ngrok's free static `*.ngrok-free.dev` domain,
+localtunnel's best-effort `--subdomain`) and per-service stable tunnels:
+[docs/tunnel.md](tunnel.md#stable-urls-named-mode).
+
+One more knob worth knowing: a workspace's Claude **default model** is not corgi's
+to pick — `claude remote-control` takes no model flag; you choose it per message in
+the Claude app. But the `model` setting in that workspace's config dir
+(`<configDir>/settings.json`) sets the default a new session starts with, and it
+rides along with `--config-dir` / profiles automatically.
+
 `corgi agent scan <dir>` registers stacks it finds but **does not enable them**.
 Supervision is opt-in per workspace: scanning a projects folder should not
 quietly spawn a Claude session for every stack in it. Run `corgi agent init` in

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -1,0 +1,62 @@
+# Databases & infra drivers
+
+In `services` you can run anything you like. In `db_services`, corgi ships **managed drivers** that handle the container, seeding, a native shell, and env vars for you — so a database is one short block, not a page of Compose.
+
+A couple are whole stacks rather than single containers: `localstack` stands up a fleet of AWS services, and `supabase` brings up auth, storage, and studio — all from the same file.
+
+## Once a database is up
+
+- **Seed it** with real data from a file (`seedFromFilePath:`) or another database (`seedFromDb:`). `corgi run --seed` loads it; the dump format is chosen per driver automatically.
+- **Open a shell** with `corgi db shell [name]` — the right tool (`psql`, `mongosh`, `redis-cli`, …) with credentials already filled in. Add `-e '<query>'` to run one query and exit.
+- **Manage them** from the `corgi db` menu — bring containers up or down, seed, or dump.
+- **Just the databases.** Running a service from your IDE or debugger? `corgi db -u` brings the databases up on their own and leaves the rest to you.
+
+## What gets wired
+
+corgi writes each service's `.env` and sources it before your commands run.
+
+- A `depends_on_db` edge writes the database's connection vars — for Postgres that's `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`; other drivers use their own prefix (`REDIS_`, `MYSQL_`, `MONGO_`, …), and `envAlias:` renames it (`envAlias: DATABASE` → `DATABASE_HOST`, …).
+- A `depends_on_services` edge writes `<SERVICE>_URL` (e.g. `API_URL=http://localhost:7012`).
+
+Run `corgi env <service>` to see the exact, fully-resolved set a service will get, and where each value came from.
+
+## The 38 managed drivers
+
+- [postgres](https://www.postgresql.org), [example](https://github.com/Andriiklymiuk/corgi_examples/tree/main/postgres)
+- [mongodb](https://www.mongodb.com), [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/mongodb/mongodb-go.corgi-compose.yml)
+- [rabbitmq](https://www.rabbitmq.com), [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/rabbitmq/rabbitmq-go-nestjs.corgi-compose.yml)
+- [sqs](https://docs.localstack.cloud/user-guide/aws/sqs/) — local AWS SQS, [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/aws_sqs/aws_sqs_postgres_go_deno.corgi-compose.yml)
+- [s3](https://docs.localstack.cloud/user-guide/aws/s3/) — local AWS S3 buckets
+- [redis](https://redis.io), [example](https://github.com/Andriiklymiuk/corgi_examples/blob/main/redis/redis-bun-expo.corgi-compose.yml)
+- [redis-server](https://redis.io)
+- [mysql](https://www.mysql.com)
+- [mariadb](https://mariadb.org)
+- [dynamodb](https://aws.amazon.com/dynamodb/)
+- [kafka](https://kafka.apache.org)
+- [mssql](https://www.microsoft.com/en-us/sql-server/sql-server-downloads)
+- [cassandra](https://cassandra.apache.org/_/index.html)
+- [cockroach](https://www.cockroachlabs.com)
+- [clickhouse](https://clickhouse.com)
+- [scylla](https://www.scylladb.com)
+- [keydb](https://docs.keydb.dev)
+- [influxdb](https://www.influxdata.com)
+- [surrealdb](https://surrealdb.com)
+- [neo4j](https://neo4j.com)
+- [arangodb](https://arangodb.com)
+- [elasticsearch](https://www.elastic.co/elasticsearch#)
+- [timescaledb](https://www.timescale.com)
+- [couchdb](https://couchdb.apache.org)
+- [dgraph](https://dgraph.io)
+- [meilisearch](https://www.meilisearch.com)
+- [mailpit](https://mailpit.axllent.org) — mail-mock SMTP + web UI (the local mail server Supabase uses); web UI port via `port2`
+- [faunadb](https://fauna.com)
+- [yugabytedb](https://www.yugabyte.com)
+- [skytable](https://skytable.io)
+- [dragonfly](https://www.dragonflydb.io)
+- [redict](https://redict.io)
+- [valkey](https://github.com/valkey-io/valkey)
+- [postgis](https://postgis.net)
+- [pgvector](https://github.com/pgvector/pgvector) — postgres + `pgvector` extension. Uses prefix `DB_`, same as plain `postgres`
+- [localstack](https://docs.localstack.cloud/) — single container for multiple AWS services (sqs, s3, sns, secretsmanager, ssm, kinesis), with `queues` / `buckets` / `topics` / `secrets` auto-created from config. Full docs: [drivers/localstack.md](drivers/localstack.md)
+- [supabase](https://supabase.com/docs/guides/local-development) — wraps `supabase init`/`start`. Emits `SUPABASE_*` + S3 vars, ports from config.toml. Seeds `buckets:` and `authUsers:` on `up`; `jwtSecret:` re-signs keys; `configTomlPath:` makes corgi own config.toml under `corgi_services/`; `port:`/`dbPort:`/`studioPort:`/`inbucketPort:` patch the matching `[section].port`. Full docs: [drivers/supabase.md](drivers/supabase.md)
+- `image` — generic docker-image driver for any public image (gotenberg, mailhog, jaeger, meilisearch, …). Set `image:` + `port:` + optional `containerPort:`/`environment:`/`volumes:`/`command:`. Full docs: [drivers/image.md](drivers/image.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,67 @@
+# Getting it running on a real project
+
+The examples use public repos. Real workspaces have private repos, prerequisites, and first-run hiccups — here's the honest version.
+
+**What you need:** `git`, and Docker (only if you declare `db_services`). Everything else lives in your project's `required:` block. Homebrew is just one way to install corgi itself, not a requirement. corgi runs on macOS, Linux, and Windows (PowerShell or WSL), so a mixed-OS team shares the same `corgi-compose.yml`.
+
+## The `required:` block — a runnable record of what the project needs
+
+That block is more than a checklist — it's a committed, runnable record of everything the workspace needs. Each entry has:
+
+- `why:` — so teammates know what it's for
+- `checkCmd:` — how to verify it (check a specific version here if you want)
+- `install:` — the commands to get it
+
+`install:` runs whatever it takes: a `brew install`, a `pyenv`/`rbenv` install to pin Python 3.12 or Ruby 3.4, a native lib, a cert via `mkcert -install`. `corgi doctor` runs every `checkCmd`; `corgi doctor --fix` runs the `install:` steps for you — so "what do I need installed?" is answered in the file, not a wiki.
+
+## Private repos just work
+
+corgi clones with plain `git`, so your existing SSH keys or credential helper are used as-is — private GitHub/GitLab services clone fine if your `git` is already set up. There's no corgi-specific auth to configure.
+
+## Joining a team that already uses corgi
+
+`git pull`, then `corgi run`. No `corgi-compose.yml` yet? You don't have to hand-write it — `corgi create` (or `/corgi-new` with Claude) inspects the repos and scaffolds one. Adding corgi is a single committed file, and teammates who don't use it aren't affected, since everything corgi generates is gitignored.
+
+## When the first run trips up
+
+- **Port already in use** — `corgi doctor` names the process holding it; `corgi run --kill-port` frees it.
+- **Missing tool, or Docker not running** — `corgi doctor --fix`.
+- **A clone failed** — you don't have git access to that repo yet; fix your SSH/token and re-run.
+- **Seeding failed** — check the `seedFromFilePath` path and that the dump matches the driver.
+- **Want a clean slate?** `corgi stop` tears down a detached run; `corgi clean -i db,corgi_services` drops the databases and generated files (add `services` to also remove the cloned repos).
+
+## Secrets & env files
+
+corgi writes each service's `.env` for you — DB host/port/credentials, sibling-service URLs — and sources it before your commands run. On first init it also adds `.env*` and `corgi_services/*` to your project's `.gitignore`, so **generated env files and any secrets in them never get committed**.
+
+Your own secrets (API keys, tokens) go in a service's env or a tier file like `env/staging/web.env` — also gitignored, also staying on your machine. The `corgi-compose.yml` itself holds config, not secrets, so it's safe to commit and share.
+
+Run `corgi env <service>` to see the exact, fully-resolved set a service will get, and where each value came from.
+
+## Low lock-in
+
+Your services stay ordinary git repos, your databases are standard Docker images (corgi even writes a plain `docker-compose.yml` per database under `corgi_services/db_services/`), and the wiring is just `.env` files. Stop using corgi and you keep all of it.
+
+## Env tiers — local, staging, or a mix
+
+Define an env tier once — a folder of per-service env files, plus whether to skip the local databases:
+
+```yml
+envTiers:
+  staging:
+    dir: env/staging   # you create env/staging/<service>.env with the staging URLs/keys
+    dbServices: none   # skip local databases — the staging env already points at staging's
+```
+
+Then pick it with a flag — run everything locally, or just the frontend against staging:
+
+```bash
+corgi run                                  # everything local
+corgi run --tier staging --services web    # only the web app, talking to staging
+```
+
+A tier can also set `confirm: true` to prompt before you run against a sensitive one.
+
+## A phone or another device on your LAN
+
+`corgi run --host auto` puts your machine's LAN IP into the service-URL env vars instead of `localhost`, so a real device or simulator can reach your dev API (pass an explicit IP instead of `auto` if you prefer). Databases stay on `localhost`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,118 @@
+# Installing corgi
+
+Once installed, `corgi` works from any folder. corgi is a single binary on a steady semver release train (1.x).
+
+## macOS / Linux — [Homebrew](https://brew.sh)
+
+```bash
+brew install andriiklymiuk/homebrew-tools/corgi
+```
+
+## macOS / Linux — install script
+
+No Homebrew? This one-liner grabs the right binary for your OS/arch from GitHub releases:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Andriiklymiuk/corgi/main/install.sh | sh
+```
+
+It verifies the release's sha256 checksum before installing, to `/usr/local/bin` if it can, otherwise `~/.local/bin` (and adds it to your PATH for zsh/bash/fish).
+
+Optional overrides:
+
+- `CORGI_VERSION=1.10.0` — pin a version
+- `CORGI_INSTALL_DIR=$HOME/bin` — force a directory
+- `CORGI_NO_MODIFY_PATH=1` — don't touch shell rc files
+
+## Windows — PowerShell
+
+```powershell
+irm https://raw.githubusercontent.com/Andriiklymiuk/corgi/main/install.ps1 | iex
+```
+
+Installs to `%LOCALAPPDATA%\corgi\bin` and adds it to your user PATH.
+
+## Windows — [Scoop](https://scoop.sh)
+
+```powershell
+scoop bucket add corgi https://github.com/Andriiklymiuk/scoop-bucket
+scoop install corgi
+```
+
+## [mise](https://mise.jdx.dev) (tool/version manager)
+
+```bash
+mise use -g github:Andriiklymiuk/corgi
+```
+
+Reads corgi's GitHub releases directly — no registry config needed.
+
+## [pkgx](https://pkgx.sh)
+
+```bash
+pkgx corgi run        # one-off, no install
+pkgx install corgi    # to PATH
+```
+
+## Verify & update
+
+```bash
+corgi -h
+```
+
+`corgi upgrade` (alias `corgi update`) notices how you installed corgi and upgrades the same way. Pin the whole team to one version with `CORGI_VERSION` (install script) or mise, so everyone runs the same corgi.
+
+Want to try it cold? Run the expo + hono example straight from a URL:
+
+```bash
+corgi run -t https://github.com/Andriiklymiuk/corgi_examples/blob/main/honoExpoTodo/hono-bun-expo.corgi-compose.yml
+```
+
+## VSCode extension
+
+Install the [corgi extension](https://marketplace.visualstudio.com/items?itemName=corgi.corgi) for syntax highlighting, autocompletion, and one-click commands.
+
+## Shell tab-completion
+
+Brew installs `_corgi` (zsh), `corgi.bash`, `corgi.fish` automatically. After that:
+
+- `corgi run --services <TAB>` → service names from `corgi-compose.yml`
+- `corgi run --dbServices <TAB>` → db_services
+- `corgi script -n <TAB>` → script names per service (filters by `--services` if set)
+- `corgi tunnel <TAB>` → tunnelable services
+- `corgi clean -i <TAB>` → clean targets — and completions are wired for `corgi tunnel --provider`, `corgi run --omit`, and the global `--dockerContext` / `--fromTemplateName` too
+
+### Completion showing filenames instead of names? (zsh fpath / Linux setup)
+
+**zsh users — if `<TAB>` shows files instead of names**, your shell isn't loading brew's site-functions dir. One-time fix in `~/.zshrc` (works for every brew CLI, not just corgi):
+
+```sh
+# macOS Apple Silicon
+FPATH="/opt/homebrew/share/zsh/site-functions:$FPATH"
+# macOS Intel
+FPATH="/usr/local/share/zsh/site-functions:$FPATH"
+# Linux (linuxbrew)
+FPATH="/home/linuxbrew/.linuxbrew/share/zsh/site-functions:$FPATH"
+
+autoload -Uz compinit && compinit
+```
+
+Add it BEFORE any existing `compinit` call. Then `rm -f ~/.zcompdump* && exec zsh`.
+
+Why: brew drops completions in `<brew-prefix>/share/zsh/site-functions/`, but plain zsh doesn't include that path in `$fpath` by default — so the file is installed but never loaded. Same gap affects `gh`, `kubectl`, `helm`, etc.
+
+**Linux native package managers** (apt/dnf/pacman) — corgi isn't packaged there yet. Use the install script, then generate the completion script manually:
+
+```sh
+# zsh
+mkdir -p ~/.zsh/completions
+corgi completion zsh > ~/.zsh/completions/_corgi
+# add once to ~/.zshrc:
+fpath=(~/.zsh/completions $fpath); autoload -Uz compinit && compinit
+
+# bash (needs bash-completion package)
+corgi completion bash | sudo tee /etc/bash_completion.d/corgi >/dev/null
+
+# fish
+corgi completion fish > ~/.config/fish/completions/corgi.fish
+```

--- a/plugins/corgi/skills/ci/SKILL.md
+++ b/plugins/corgi/skills/ci/SKILL.md
@@ -90,8 +90,8 @@ manifest instead.
 
 ## The failures that actually happen
 
-Every one of these was found the expensive way — a 20-30 minute cycle each, some
-several. Check them before writing a line, not after a red run.
+Each of these costs a full 20-30 minute CI cycle to hit. Check them before
+writing a line, not after a red run.
 
 **A health check that is polled must never do work.** This is the big one. An
 Expo dev server builds a bundle per request and Vite pre-bundles dependencies on
@@ -106,8 +106,7 @@ is ready, so retrying only queues more work.
 checks it stays silent about locally: the job running inside a container, and
 any `copyEnvFromFilePath` the runner does not have — the latter otherwise boots
 the service against a committed `.env-example` whose placeholder values fail at
-the first request, thousands of lines from the cause. Both cost twenty minutes
-each time they are found the hard way.
+the first request, thousands of lines from the cause.
 
 **A failed `beforeStart` fails the run — do not grep the logs for it.** corgi
 still lets the rest of the stack come up, but `corgi run --wait` returns the

--- a/plugins/corgi/skills/corgi/SKILL.md
+++ b/plugins/corgi/skills/corgi/SKILL.md
@@ -7,7 +7,7 @@ description: Author and explain corgi-compose.yml files and the corgi CLI. Use w
 
 Corgi (https://github.com/Andriiklymiuk/corgi) runs multi-service projects from a single `corgi-compose.yml`. It handles: cloning service repos, starting databases in Docker, seeding from dumps, generating `.env` files with cross-service URLs, and running all services concurrently.
 
-When this skill activates, you are the expert on corgi. Do not fall back to generic docker-compose / npm advice if a `corgi-compose.yml` is present — corgi is the authoritative entry point for that project.
+Don't fall back to generic docker-compose / npm advice if a `corgi-compose.yml` is present — corgi is the authoritative entry point for that project.
 
 ## Critical: `corgi run` is long-running
 
@@ -89,12 +89,12 @@ corgi config               # show current user settings (~/.corgi/config.yml)
 corgi notifications on|off|test            # toggle/test desktop crash notifications
 corgi status               # health check (one-shot)
 corgi status --ready       # block until all healthy / timeout (CI-friendly)
-corgi status --watch       # live monitor, transitions only
+corgi status --watch       # BLOCKS until Ctrl+C — interactive only; agents use --ready --timeout
 corgi tunnel               # public HTTPS tunnels (long-running) — default cloudflared
 corgi db shell [name]                       # interactive DB shell inside running container (psql/redis-cli/mongosh/…)
 corgi db shell [name] -e "SELECT 1"         # one-shot query, exit; CI-friendly
 corgi db snapshot [name] [svc]              # fast physical Postgres snapshot (built indexes+matviews); postgres family only
-corgi db restore  [name] [svc]              # restore pgdata from a snapshot → up on built data, zero recompute
+corgi db restore  [name|path] [svc]         # restore pgdata from a snapshot → up on built data, zero recompute
 corgi init                 # scaffold db_services/ + cloned repos
 corgi create               # interactive yml editor
 corgi clean -i db          # stop+remove db containers (also: services, corgi_services, all)

--- a/plugins/corgi/skills/debug/SKILL.md
+++ b/plugins/corgi/skills/debug/SKILL.md
@@ -94,8 +94,9 @@ Absent → skip.
   trace = real failure.
 - **Slow first boot vs hung** — a first run that clones repos / seeds a DB / pulls
   images legitimately takes minutes. Tell apart ONLY by whether the log keeps
-  advancing: `corgi status --watch` (or a 2nd `corgi status --json` after ~30s,
-  compare the healthy count). Cross-ref `../corgi/references/debugging.md`.
+  advancing: a 2nd `corgi status --json` after ~30s, compare the healthy count
+  (never `corgi status --watch` — it blocks until Ctrl+C and hangs an agent).
+  Cross-ref `../corgi/references/debugging.md`.
 
 ## Step 1 — `corgi doctor` when something won't start
 

--- a/plugins/corgi/skills/design-parity/SKILL.md
+++ b/plugins/corgi/skills/design-parity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-parity
-description: Use when a change has a design behind it and someone must prove the build matches — "compare it with the design", "does this match Figma", "check it against the mockup", "download the designs", "side-by-side with the design", "design review of this screen", "did we build what was designed", "pixel check", "the designer says it's off". Covers pulling design frames to disk, making an unreleased feature reachable so it can be shot at all, capturing app screens, composing labelled side-by-sides, and reporting deviations (fixed vs deliberate). NOT the device-driving loop itself (the `mobile` skill) or store marketing screenshots (`mobile-screenshots`).
+description: Use when a change has a design behind it and someone must prove the build matches — "compare it with the design", "does this match Figma", "check it against the mockup", "download the designs", "side-by-side with the design", "design review of this screen", "did we build what was designed", "pixel check", "the designer says it's off". NOT the device-driving loop itself (the `mobile` skill) or store marketing screenshots (`mobile-screenshots`).
 ---
 
 # Prove the build matches the design

--- a/plugins/corgi/skills/memory/SKILL.md
+++ b/plugins/corgi/skills/memory/SKILL.md
@@ -7,8 +7,6 @@ description: The workspace memory convention for a corgi stack — a committed, 
 
 A corgi workspace remembers things not in git or code: **why** a driver/port/template was chosen, how a past **incident** was fixed, **domain** facts, recurring **fixes**. Store is `.corgi/memory/` — committed, shared by the team via the repo, keyed to the `corgi-compose.yml` stack. This skill is the convention; `suggest`/`debug`/`stories`/`review` reference it.
 
-Workspace-scoped analog of the host harness's per-project memory — that one is private/single-machine; this one is committed/shared/stack-scoped.
-
 ## Guardrails (non-negotiable)
 
 - **Opt-in.** No `.corgi/memory/` → reads skip silently (no memory is not an error); writes **offer** to create the store, never force it.

--- a/plugins/corgi/skills/mobile-screenshots/SKILL.md
+++ b/plugins/corgi/skills/mobile-screenshots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mobile-screenshots
-description: Use when generating store screenshots for an Expo / React Native app — "make App Store screenshots", "Play Market screenshots", "store screenshots for all languages", "framed marketing screenshots", "screenshots in the right store sizes", "feature graphic", "upload screenshots to the stores", "send screenshots to App Store / Play automatically", "device-frame the screenshots with headlines". Covers the capture matrix (iPhone / iPad / Android phone+tablet × locales), framing via the external app-store-screenshots editor skill, exporting at exact store sizes, and uploading with fastlane deliver/supply. NOT a single-screen verify (that's the `mobile` skill) or authoring corgi-compose (the `corgi` skill).
+description: Use when generating store screenshots for an Expo / React Native app — "make App Store screenshots", "Play Market screenshots", "store screenshots for all languages", "framed marketing screenshots", "screenshots in the right store sizes", "feature graphic", "upload screenshots to the stores", "send screenshots to App Store / Play automatically", "device-frame the screenshots with headlines". NOT a single-screen verify (that's the `mobile` skill) or authoring corgi-compose (the `corgi` skill).
 ---
 
 # Store screenshots, end to end

--- a/plugins/corgi/skills/mobile/SKILL.md
+++ b/plugins/corgi/skills/mobile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mobile
-description: Use when verifying a mobile (Expo / React Native) change on a real device — "test on the emulator", "run it on the simulator", "screenshot the app", "drive it with Maestro", "does this screen render", "check it on Android/iOS", "tap through the app", "is the animation right" — or when a local iOS/Android build + TestFlight/Play ship needs driving. Covers the device-driving loop (deep links, Maestro flows, screenshots, sips crops) AND the gotchas that actually bite — Maestro ASCII-only input, non-login-shell pod builds, Metro `--clear` redbox desync, native-needs-rebuild, SceneKit magenta-at-runtime, square particles, apple-targets widget/App-Clip extension creds + App Group capability, stale Android autolinking package, low-disk local-build ENOSPC, native dep/ABI skew → dyld symbol-missing launch crash, Maestro `launchApp` resuming the last screen. NOT for writing the app code (normal edits) or authoring corgi-compose (corgi skill).
+description: Use when verifying a mobile (Expo / React Native) change on a real device — "test on the emulator", "run it on the simulator", "screenshot the app", "drive it with Maestro", "does this screen render", "check it on Android/iOS", "tap through the app", "is the animation right" — or when a local iOS/Android build + TestFlight/Play ship needs driving. NOT for writing the app code (normal edits) or authoring corgi-compose (corgi skill).
 ---
 
 # Verify mobile change on device

--- a/plugins/corgi/skills/purchases/SKILL.md
+++ b/plugins/corgi/skills/purchases/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: purchases
-description: Use when managing In-App Purchases / store metadata / RevenueCat for an Expo / React Native app — "set up the IAPs", "push the IAP review notes", "update store metadata for purchases", "the App Review notes for each pack", "configure RevenueCat products", "add a premium pack / deck / unlock", "manage non-consumables", "sync product ids across stores". Covers the product-id source-of-truth, a version-controlled local source for per-IAP App Review notes (примечание) generated from the catalog with a drift-guard test, and pushing IAP `reviewNote` via the App Store Connect API — because fastlane `deliver` does NOT manage IAP metadata. NOT for the binary submit (ship skill) or device verification (mobile skill).
+description: Use when managing In-App Purchases / store metadata / RevenueCat for an Expo / React Native app — "set up the IAPs", "push the IAP review notes", "update store metadata for purchases", "the App Review notes for each pack", "configure RevenueCat products", "add a premium pack / deck / unlock", "manage non-consumables", "sync product ids across stores". NOT for the binary submit (ship skill) or device verification (mobile skill).
 ---
 
 # Manage IAPs + store purchase metadata

--- a/plugins/corgi/skills/review/SKILL.md
+++ b/plugins/corgi/skills/review/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user wants a code review of one or more EXISTING pull/
 
 # Corgi review
 
-Review one or more existing remote PR/MR(s) on GitHub or GitLab against each repo's own standards (CLAUDE.md/AGENTS.md, lint and format config) plus the intent from any linked Linear or Jira tracker ticket, then post a human-readable summary comment and inline line-level suggestions back onto each PR/MR — all behind a preview gate before anything goes public. It is the direct counterpart to the `stories` skill: stories **creates** draft PRs/MRs from issues or feature text; review **consumes** existing ones. It reuses stories' workspace model (services, dirs, and forges resolved from `corgi-compose.yml`) and stories' token-efficiency model (cluster by service+area, investigate once, orchestrator-as-cache, reuse ledger).
+Review one or more existing remote PR/MR(s) on GitHub or GitLab against each repo's own standards (CLAUDE.md/AGENTS.md, lint and format config) plus the intent from any linked Linear or Jira tracker ticket, then post a human-readable summary comment and inline line-level suggestions back onto each PR/MR — all behind a preview gate before anything goes public. Services, dirs, and forges resolve from `corgi-compose.yml`.
 
 ## Two modes — route from the verb
 

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -12,8 +12,8 @@ hard-code.
 
 ## Speed model
 
-Lighter than a full multi-agent pipeline. **One blocking gate** on the
-adjustment/bug fast path; complex stories add superpowers checkpoints.
+**One blocking gate** on the adjustment/bug fast path; complex stories add
+superpowers checkpoints.
 
 - **Gate (blocking): spec sign-off** (Phase 2). Confirm intent before any branch.
   Cheap, guards the whole batch. Never skip — a clear up-front directive collapses

--- a/plugins/corgi/skills/suggest-proactive/SKILL.md
+++ b/plugins/corgi/skills/suggest-proactive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: suggest-proactive
-description: Use when the user wants corgi to PROACTIVELY surface improvements on a schedule instead of on demand — "suggest things automatically", "run suggest every week", "open a ticket for the best idea on a cadence", "be a proactive engineer / push me work", or when a scheduled job invokes /corgi-suggest-proactive. Runs the suggest ranking, dedupes the top idea against open tickets + recently-dismissed ones, and either proposes it (default) or, only if auto-file-drafts is opted in, files exactly ONE draft tracker ticket — rate-limited, never spammy, draft-only, never assigned or built. NOT for on-demand idea generation (use the suggest skill) or implementing anything (use the stories skill).
+description: Use when the user wants corgi to PROACTIVELY surface improvements on a schedule instead of on demand — "suggest things automatically", "run suggest every week", "open a ticket for the best idea on a cadence", "be a proactive engineer / push me work", or when a scheduled job invokes /corgi-suggest-proactive. NOT for on-demand idea generation (use the suggest skill) or implementing anything (use the stories skill).
 ---
 
 # Corgi proactive suggest

--- a/plugins/corgi/skills/suggest/SKILL.md
+++ b/plugins/corgi/skills/suggest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: suggest
-description: Use when the user wants feature or improvement ideas for a corgi workspace — "suggest features", "what should we build next", "ideas to improve X", "how do we make this faster/safer/cheaper", "what's missing", "any new business cases". Scans the stack + its business domain + existing features and proposes RANKED, evidence-backed suggestions across two lenses — product/business (new features, new business cases, UX) and engineering (performance, reliability, security, cost, tech-debt, even a language rewrite when the ROI is high) — each tied to a measurable outcome. Specs the chosen one and offers to create a tracker story (asks where). NOT for implementing it (use the stories skill) or authoring corgi-compose.yml (use the corgi skill).
+description: Use when the user wants feature or improvement ideas for a corgi workspace — "suggest features", "what should we build next", "ideas to improve X", "how do we make this faster/safer/cheaper", "what's missing", "any new business cases". NOT for implementing it (use the stories skill) or authoring corgi-compose.yml (use the corgi skill).
 ---
 
 # Corgi suggest

--- a/plugins/corgi/skills/tracker/SKILL.md
+++ b/plugins/corgi/skills/tracker/SKILL.md
@@ -43,7 +43,7 @@ tool name.**
   (`atlassian.net`/project key) → `mcp__atlassian__*`. Both + bare key → ask. Neither
   connected → name what to connect, offer a git-only digest.
 
-## Phase 1 — Correlate ticket ↔ code (the superpower)
+## Phase 1 — Correlate ticket ↔ code
 
 Per in-scope ticket (skip only if no compose): find its PRs — prefer the tracker's
 own git links (Linear attachments / Jira dev-panel), else list PRs whose head branch

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -82,6 +82,14 @@ type WorkspaceConfig struct {
 	// subscription.
 	InheritAPIKey     bool `yaml:"inheritApiKey"`
 	InheritOAuthToken bool `yaml:"inheritOauthToken"`
+	// DangerouslySkipPermissions runs this workspace's session with permission
+	// prompts turned off (emitted as --permission-mode bypassPermissions). It
+	// removes the gate a person answers from their phone — the main defence
+	// against a session acting on instructions injected into a file it read.
+	// Trusted config only, and by construction: RepoConfig has no such field, so
+	// a cloned repository can never turn it on. Off unless the machine's owner
+	// sets it, per-workspace or in a profile.
+	DangerouslySkipPermissions bool `yaml:"dangerouslySkipPermissions"`
 }
 
 // LoadRepo reads `.corgi/agent.yml` from a workspace directory. A missing file
@@ -223,6 +231,7 @@ func overlay(base, over WorkspaceConfig) WorkspaceConfig {
 	// per-workspace entry cannot silently turn off a default the user set.
 	base.InheritAPIKey = base.InheritAPIKey || over.InheritAPIKey
 	base.InheritOAuthToken = base.InheritOAuthToken || over.InheritOAuthToken
+	base.DangerouslySkipPermissions = base.DangerouslySkipPermissions || over.DangerouslySkipPermissions
 	return base
 }
 

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -140,6 +140,15 @@ func LoadUser(path string) (*UserConfig, error) {
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
+	// Bypass must be a deliberate per-workspace (or per-profile) choice. Under
+	// defaults: it would skip prompts for every workspace — including ones a
+	// later `agent scan` adds — and the OR overlay means no workspace could turn
+	// it back off. Too dangerous to allow as a blanket default.
+	if c.Defaults.DangerouslySkipPermissions {
+		return nil, fmt.Errorf(
+			"%s: dangerouslySkipPermissions cannot be set under defaults: — set it per-workspace or per-profile, so each bypass is a deliberate opt-in with an opt-out",
+			path)
+	}
 	if c.Workspaces == nil {
 		c.Workspaces = map[string]WorkspaceConfig{}
 	}

--- a/utils/agent/config/config_test.go
+++ b/utils/agent/config/config_test.go
@@ -204,6 +204,20 @@ func TestDangerouslySkipPermissionsIsATrustedCapabilityFlag(t *testing.T) {
 	}
 }
 
+func TestLoadUserRejectsBlanketDefaultBypass(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yml")
+	body := "version: 1\ndefaults:\n  dangerouslySkipPermissions: true\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A default-level bypass would skip prompts for every workspace with no
+	// per-workspace opt-out, so it must fail to load rather than apply silently.
+	if _, err := LoadUser(path); err == nil {
+		t.Error("dangerouslySkipPermissions under defaults: must be rejected")
+	}
+}
+
 // The id is the lookup key into trusted per-workspace settings, so a cloned
 // repository must not be able to choose it. Declaring someone else's workspace
 // id would otherwise inherit their configDir, bin, and permission mode.

--- a/utils/agent/config/config_test.go
+++ b/utils/agent/config/config_test.go
@@ -183,6 +183,27 @@ func TestResolveCannotSilentlyDisableACredentialDefault(t *testing.T) {
 	}
 }
 
+func TestDangerouslySkipPermissionsIsATrustedCapabilityFlag(t *testing.T) {
+	// OR-ed like the other capability booleans: an omitted per-workspace value
+	// must not silently disable a default.
+	user := &UserConfig{
+		Defaults:   WorkspaceConfig{DangerouslySkipPermissions: true},
+		Workspaces: map[string]WorkspaceConfig{"acme": {}},
+	}
+	if got := Resolve("acme", nil, user); !got.DangerouslySkipPermissions {
+		t.Error("an omitted bool must not override an explicit default")
+	}
+
+	// The security invariant: a committed repo file can never turn it on.
+	// RepoConfig has no such field, so even a repo that declares it resolves to
+	// off without a trusted entry — cloning a repo cannot skip your prompts.
+	dir := writeRepoConfig(t, "version: 1\nworkspace:\n  id: acme\ndangerouslySkipPermissions: true\n")
+	repo, _ := LoadRepo(dir)
+	if got := Resolve("acme", repo, &UserConfig{}); got.DangerouslySkipPermissions {
+		t.Error("a cloned repository must not be able to skip permission prompts")
+	}
+}
+
 // The id is the lookup key into trusted per-workspace settings, so a cloned
 // repository must not be able to choose it. Declaring someone else's workspace
 // id would otherwise inherit their configDir, bin, and permission mode.

--- a/utils/agent/supervisor/kind.go
+++ b/utils/agent/supervisor/kind.go
@@ -136,8 +136,14 @@ func claudeArgs(c SpawnConfig) ([]string, error) {
 	if c.Capacity > 0 {
 		args = append(args, "--capacity", strconv.Itoa(c.Capacity))
 	}
-	if mode := strings.TrimSpace(c.PermissionMode); mode != "" && !forbiddenPermissionModes[normalize(mode)] {
-		args = append(args, "--permission-mode", mode)
+	switch {
+	case c.SkipPermissions:
+		// The one sanctioned bypass: emitted only for a workspace whose trusted
+		// config set dangerouslySkipPermissions. bypassPermissions is a real
+		// remote-control mode that corgi otherwise refuses.
+		args = append(args, "--permission-mode", "bypassPermissions")
+	case strings.TrimSpace(c.PermissionMode) != "" && !forbiddenPermissionModes[normalize(c.PermissionMode)]:
+		args = append(args, "--permission-mode", strings.TrimSpace(c.PermissionMode))
 	}
 	if name := strings.TrimSpace(c.Name); name != "" {
 		args = append(args, "--name", name)

--- a/utils/agent/supervisor/spawn.go
+++ b/utils/agent/supervisor/spawn.go
@@ -40,6 +40,13 @@ type SpawnConfig struct {
 	InheritAPIKey bool
 	// InheritOAuthToken does the same for CLAUDE_CODE_OAUTH_TOKEN.
 	InheritOAuthToken bool
+	// SkipPermissions runs the session with permission prompts disarmed,
+	// emitted as --permission-mode bypassPermissions. This is the one sanctioned
+	// route around the bypass block, so ValidateSpawnConfig allows it — unlike a
+	// forbidden permissionMode string or a smuggled --dangerously arg. It comes
+	// only from trusted config, and the supervisor warns when it is on, because
+	// it removes the gate a person answers from their phone.
+	SkipPermissions bool
 	// Name is the remote-control session name shown in claude.ai/code.
 	Name string
 	// WakeLock controls whether the machine is kept awake while this
@@ -170,6 +177,21 @@ func ValidPermissionMode(mode string) bool {
 func PermissionModeHint() string { return sortedKeys(validPermissionModes) }
 
 func validatePermissionMode(c SpawnConfig, kind Kind) error {
+	if c.SkipPermissions {
+		// The sanctioned bypass. Still has to be a kind that understands a
+		// permission mode, and must not also carry a different one.
+		if !kind.SupportsPermissionMode {
+			return fmt.Errorf(
+				"workspace %s: kind %q takes no permission mode, so dangerouslySkipPermissions has nothing to disarm — put the flag in args: instead",
+				c.WorkspaceID, kind.Name)
+		}
+		if m := normalize(c.PermissionMode); m != "" && m != "bypasspermissions" {
+			return fmt.Errorf(
+				"workspace %s: set either permissionMode or dangerouslySkipPermissions, not both",
+				c.WorkspaceID)
+		}
+		return nil
+	}
 	mode := normalize(c.PermissionMode)
 	if mode == "" {
 		return nil

--- a/utils/agent/supervisor/spawn_test.go
+++ b/utils/agent/supervisor/spawn_test.go
@@ -83,6 +83,34 @@ func TestBuildArgsNeverSkipsPermissions(t *testing.T) {
 	}
 }
 
+func TestSkipPermissionsIsTheSanctionedBypass(t *testing.T) {
+	c := baseConfig()
+	c.SkipPermissions = true
+
+	if err := ValidateSpawnConfig(c); err != nil {
+		t.Fatalf("dangerouslySkipPermissions is the one allowed bypass and must validate: %v", err)
+	}
+	args, err := BuildArgs(c)
+	if err != nil {
+		t.Fatalf("BuildArgs() error = %v", err)
+	}
+	// It rides on --permission-mode bypassPermissions, the mode remote control
+	// understands — not the plain-claude --dangerously-skip-permissions flag.
+	i := slices.Index(args, "--permission-mode")
+	if i < 0 || i+1 >= len(args) || args[i+1] != "bypassPermissions" {
+		t.Fatalf("SkipPermissions must emit --permission-mode bypassPermissions, got %v", args)
+	}
+}
+
+func TestSkipPermissionsRejectsAConflictingMode(t *testing.T) {
+	c := baseConfig()
+	c.SkipPermissions = true
+	c.PermissionMode = "acceptEdits"
+	if err := ValidateSpawnConfig(c); err == nil {
+		t.Fatal("both dangerouslySkipPermissions and a different permissionMode is ambiguous and must be rejected")
+	}
+}
+
 func TestBuildArgs(t *testing.T) {
 	c := baseConfig()
 	c.Spawn = "worktree"


### PR DESCRIPTION
Follow-up polish on the merged remote-session-start feature, plus a README/docs restructure and skill cleanup.

## Docs
- **README slimmed** 662 → ~230 lines: agent-first, unslopped (dropped unprovable claims + fake time numbers), run-your-stack value kept. Deep reference moved to `docs/databases.md`, `docs/getting-started.md`, `docs/install.md`.
- Documented `corgi agent up` in `docs/agent.md` (was missing).

## Skills
- Frontmatter `description` trimmed to **triggers-only** (house rule) across 6 aux skills.
- **Two real agent hang-risks fixed**: `corgi status --watch` (blocks until Ctrl+C) was recommended in the `corgi` and `debug` skills.
- Slop/residue cut (role-play lines, war-story editorializing, a non-English token).

## Agent — permission bypass (opt-in, trusted-config only)
Reverses the blanket "never skip permissions" **only** behind an explicit opt-in:
- `dangerouslySkipPermissions` on a workspace/profile → emits `--permission-mode bypassPermissions`.
- **A committed `.corgi/agent.yml` can never enable it** (field is trusted-config only); a smuggled `--dangerously` arg or `bypassPermissions` string is still rejected.
- **Never silent**: `agent up`/`serve` print `⚠ permissions: SKIPPED`; `agent profile list` marks it.
- New flags: `corgi agent init --dangerously-skip-permissions`, `corgi agent profile add --dangerously-skip-permissions`.

## Agent — `corgi agent down`
Mirror of `agent up`: stops the daemon **and** the detached MCP + tunnel (records the MCP pid at up time). `agent stop` still stops only the daemon.

## Launcher
- **Settings** section with the copy-paste Claude connector config (was lost).
- Per-workspace **open in: app | browser** switch (remembered on-device) — browser mode keeps a workspace on a different Claude account in the browser instead of deep-linking the app under the wrong account.
- Link to the full session list on claude.ai.

## Fix
- `corgi init` help said *"Create db service"*; it actually materializes the whole stack.

## Tests
Sanctioned-bypass validation + argv, the repo-can't-enable security invariant, and the agent-down pid helper. `gofmt`/`vet` clean; native + Windows build; full `cmd` (819) + agent suites pass with `-race`.