### PR TITLE
Fix the stuck MCP port loop; agent mode for any git repo; agents alias

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -32,8 +31,9 @@ var agentCmd = &cobra.Command{
 		applyGlobalFlags(cmd)
 		warnStrandedAgentData()
 	},
-	Use:   "agent",
-	Short: "Keep Claude Code Remote Control running for your corgi workspaces",
+	Use:     "agent",
+	Aliases: []string{"agents"},
+	Short:   "Keep Claude Code Remote Control running for your corgi workspaces",
 	Long: `Agent mode makes this machine an always-on, multi-repo Remote Control host.
 
 Remote Control already gives you a phone-driven Claude Code session on your own
@@ -155,7 +155,7 @@ func loadSpawnConfigs(dir string, foreground bool) ([]supervisor.SpawnConfig, er
 		return nil, err
 	}
 
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 
 	var out []supervisor.SpawnConfig
 	for _, w := range registry.Sorted() {
@@ -177,7 +177,7 @@ func remoteResolver(dir string, foreground bool) func(id, profile string) (super
 		if err != nil {
 			return supervisor.SpawnConfig{}, err
 		}
-		registry.Reconcile(dirHasComposeFile)
+		registry.Reconcile(dirIsWorkspace)
 		w, ok := registry.Find(id)
 		if !ok {
 			return supervisor.SpawnConfig{}, fmt.Errorf("no workspace called %q in the registry — run `corgi agent scan` on the laptop", id)
@@ -287,6 +287,23 @@ func dirHasComposeFile(dir string) bool {
 		}
 	}
 	return false
+}
+
+// dirIsWorkspace reports whether dir can be registered for agent mode: a corgi
+// stack, or any git repository. Remote Control is useful on a plain repo too —
+// requiring a compose file locked whole projects out of `agent init`/`up` for
+// no reason. Still not "any folder": the git requirement keeps the old dead-guard
+// bug (registering an arbitrary directory) from coming back.
+func dirIsWorkspace(dir string) bool {
+	if dirHasComposeFile(dir) {
+		return true
+	}
+	if dir == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	// A .git FILE (not dir) is a worktree/submodule pointer — also a repo.
+	return err == nil && (info.IsDir() || info.Mode().IsRegular())
 }
 
 // printStartupDiagnostics is the one line per workspace that prevents the most
@@ -429,70 +446,6 @@ func runAgentStop(_ *cobra.Command, _ []string) {
 	utils.Infof("stopping corgi agent (pid %d)\n", info.PID)
 }
 
-// ---------------------------------------------------------------- down
-
-var agentDownCmd = &cobra.Command{
-	Use:   "down",
-	Short: "Stop everything `corgi agent up` started — the daemon and the detached MCP + tunnel",
-	Long: `The mirror of ` + "`corgi agent up`" + `. Stops the agent daemon and the detached
-MCP server that serves the launcher and pairing over the tunnel, so the public
-URL goes down too. (` + "`corgi agent stop`" + ` stops only the daemon.)`,
-	Run: runAgentDown,
-}
-
-func runAgentDown(_ *cobra.Command, _ []string) {
-	dir, err := agentDir()
-	if err != nil {
-		exitWithError("agent_data_dir", err, 1)
-	}
-	stopped := false
-
-	if info, rerr := daemon.ReadInfo(dir); rerr == nil && info != nil {
-		if proc, ferr := os.FindProcess(info.PID); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
-			utils.Infof("stopped agent daemon (pid %d)\n", info.PID)
-			stopped = true
-		}
-	}
-
-	// The detached MCP + tunnel that `agent up` recorded. Stopping it is what
-	// takes the public URL down; `agent stop` alone leaves it serving.
-	//
-	// PidAlive guards against a recycled pid: mcp.pid can outlive its process (an
-	// MCP crash, a reboot, an `agent stop` all leave it on disk), and the OS may
-	// hand that number to an unrelated process. PidAlive confirms the pid is still
-	// its own process-group leader — which the detached MCP is and a recycled pid
-	// almost never is — so a stale file cannot make `down` kill your editor.
-	pidPath := filepath.Join(dir, mcpPidName)
-	if pid, ok := readAgentPidFile(pidPath); ok {
-		if utils.PidAlive(pid, "") {
-			if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
-				utils.Infof("stopped MCP + tunnel (pid %d)\n", pid)
-				stopped = true
-			}
-		}
-		_ = os.Remove(pidPath)
-	}
-	_ = os.Remove(filepath.Join(dir, "agent-up.lock"))
-
-	if !stopped {
-		utils.Info("corgi agent is not running")
-	}
-}
-
-// readAgentPidFile reads a pid written by spawnDetached. A missing or malformed
-// file just means there is nothing to stop.
-func readAgentPidFile(path string) (int, bool) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return 0, false
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || pid <= 0 {
-		return 0, false
-	}
-	return pid, true
-}
-
 // ---------------------------------------------------------------- workspaces
 
 var agentWorkspacesCmd = &cobra.Command{
@@ -510,7 +463,7 @@ var agentWorkspacesListCmd = &cobra.Command{
 
 func runAgentWorkspacesList(_ *cobra.Command, _ []string) {
 	registry, path := mustLoadRegistry()
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 	_ = workspace.Save(path, registry)
 
 	if utils.JSONOutput {
@@ -611,7 +564,7 @@ var agentSessionStopCmd = &cobra.Command{
 // cannot drift.
 func enqueueSessionCommand(action string, args []string, profile string) {
 	registry, _ := mustLoadRegistry()
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 	res := workspace.Resolve(registry, strings.Join(args, " "))
 	if !res.Resolved() {
 		if utils.JSONOutput {

--- a/cmd/agent_brief.go
+++ b/cmd/agent_brief.go
@@ -48,6 +48,15 @@ func probeWorkspaceRepos(dir string) []brief.RepoState {
 
 	byPrefix := map[string]string{}
 	var out []brief.RepoState
+	if err != nil || corgi == nil {
+		// A git-only workspace (no compose) still has exactly one repo worth
+		// briefing: the workspace directory itself. Without this, the handover
+		// brief for the restarted session carries no branch or dirty state at
+		// all — for the very workspaces that are nothing but a repo.
+		if state, ok := repoState(filepath.Base(dir), dir, false); ok {
+			out = append(out, state)
+		}
+	}
 	if err == nil && corgi != nil {
 		for service, path := range utils.ServiceDirs(corgi, nil) {
 			// Worktree directories are named from the repository ROOT, not the

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -40,9 +40,9 @@ func runAgentInit(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		exitWithError("agent_cwd", err, 1)
 	}
-	if !dirHasComposeFile(cwd) {
-		exitWithError("agent_no_compose",
-			fmt.Errorf("no corgi-compose.yml here — run this in a stack, or `corgi agent scan <dir>` to find them"), 2)
+	if !dirIsWorkspace(cwd) {
+		exitWithError("agent_no_workspace",
+			fmt.Errorf("nothing to register here — run this in a corgi stack or a git repository (or `corgi agent scan <dir>` to find stacks)"), 2)
 	}
 
 	id, _ := cmd.Flags().GetString("id")
@@ -445,7 +445,7 @@ func checkUserConfigPermissions(path string) agentCheck {
 
 func checkRegisteredWorkspaces() agentCheck {
 	registry, _ := mustLoadRegistry()
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 
 	var ok, unreachable int
 	for _, w := range registry.Workspaces {

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -54,15 +54,27 @@ func runAgentInit(cmd *cobra.Command, _ []string) {
 	sensitive, _ := cmd.Flags().GetBool("sensitive")
 	skipPerms, _ := cmd.Flags().GetBool("dangerously-skip-permissions")
 
+	registry, path := mustLoadRegistry()
+	// Refuse to repoint an id that belongs to a different directory. The id is
+	// the key into the trusted per-workspace settings (configDir, a granted
+	// permission bypass), so silently taking over "api" from another repo also
+	// named api would transfer that capability to the new directory. Sticky
+	// settings make this worse, and repo basenames collide constantly.
+	if prior, ok := registry.Find(id); ok && prior.AbsPath != "" && prior.AbsPath != cwd {
+		exitWithError("agent_id_taken", fmt.Errorf(
+			"workspace id %q already belongs to %s — its settings (account, permissions) must not transfer here. "+
+				"Pass --id <something-else> to register this directory under its own name",
+			id, prior.AbsPath), 2)
+	}
+
 	if err := writeRepoAgentConfig(cwd, id, aliases, sensitive); err != nil {
 		exitWithError("agent_write_repo_config", err, 1)
 	}
 
-	registry, path := mustLoadRegistry()
 	existing, _ := registry.Find(id)
 	existing.ID = id
 	existing.AbsPath = cwd
-	existing.ComposeFile = composeFileName(cwd)
+	existing.ComposeFile = registeredComposeFile(cwd)
 	existing.Aliases = aliases
 	existing.Status = workspace.StatusOK
 	// Cache the service names so "fix the api" can resolve to the stack that
@@ -145,6 +157,16 @@ func composeFileName(dir string) string {
 		}
 	}
 	return "corgi-compose.yml"
+}
+
+// registeredComposeFile is what the registry records: the real compose file, or
+// empty for a git-only workspace — never the default-name fallback, which would
+// tell `corgi agent workspaces --json` readers a file exists that does not.
+func registeredComposeFile(dir string) string {
+	if dirHasComposeFile(dir) {
+		return composeFileName(dir)
+	}
+	return ""
 }
 
 func writeRepoAgentConfig(dir, id string, aliases []string, sensitive bool) error {

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -32,6 +32,10 @@ const mcpLogName = "mcp.log"
 // stop the tunnel + pairing server that `agent up` started, not just the daemon.
 const mcpPidName = "mcp.pid"
 
+// mcpAddrName records the address that MCP listens on, so `agent down`'s
+// no-pid-file fallback can look at the right port even after --http.
+const mcpAddrName = "mcp.addr"
+
 var agentUpCmd = &cobra.Command{
 	Use:   "up",
 	Short: "One command from a stack directory to phone-startable: register, daemon, tunnel, pairing",
@@ -64,6 +68,7 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 	addr, _ := cmd.Flags().GetString("http")
 	provider, _ := cmd.Flags().GetString("provider")
 	tunnelName, _ := cmd.Flags().GetString("tunnel-name")
+	fresh, _ := cmd.Flags().GetBool("fresh")
 
 	dir, err := agentDir()
 	if err != nil {
@@ -93,20 +98,42 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 
 	res.LogPath = filepath.Join(dir, mcpLogName)
 	if mcpListening(addr) {
-		// Something already holds the port — usually a corgi MCP from an earlier
-		// `agent up` whose pairing window is long used up. When the listener is
-		// identifiably corgi, stop it and fall through to a fresh spawn (fresh
-		// tunnel, fresh pairing window) instead of refusing forever.
-		if !reclaimCorgiMCP(addr) {
-			res.Hint = fmt.Sprintf(
-				"%s is already in use by something that is not corgi's MCP server. "+
-					"Free the port (or pass --http with a free one) and rerun `corgi agent up`. "+
-					"corgi's own server logs to %s and is stopped by `corgi agent down`.",
-				addr, res.LogPath)
+		// Something already holds the port. Re-running `up` must be a safe,
+		// idempotent ensure step — a phone may be mid-session on the running
+		// server, so it is only ever replaced when --fresh says so.
+		if !fresh {
+			if pid, ok := readAgentPidFile(filepath.Join(dir, mcpPidName)); ok && utils.PidAlive(pid, "") {
+				// Ours and healthy: report it as up, with the URL its log recorded.
+				if data, rerr := os.ReadFile(res.LogPath); rerr == nil {
+					if parsed, _ := parseMCPLog(string(data)); parsed.publicURL != "" {
+						res.PublicURL = parsed.publicURL
+					}
+				}
+				res.Hint = "MCP + tunnel already running. To pair a NEW device (fresh pairing window + tunnel), rerun with --fresh."
+			} else {
+				res.Hint = fmt.Sprintf(
+					"%s is held by a server corgi did not record starting. If it is a leftover corgi MCP, "+
+						"rerun `corgi agent up --fresh` to replace it (or `corgi agent down` to stop it); "+
+						"anything else, free the port or pass --http with a free one. Log: %s",
+					addr, res.LogPath)
+			}
 			printAgentUp(res)
 			return
 		}
-		_ = os.Remove(filepath.Join(dir, mcpPidName))
+		found, freed := reclaimCorgiMCP(addr)
+		switch {
+		case freed:
+			_ = os.Remove(filepath.Join(dir, mcpPidName))
+		case found:
+			exitWithError("agent_up_mcp", fmt.Errorf(
+				"a corgi MCP on %s did not release the port within 5s — stop it manually (`corgi agent down`, or kill the pid lsof names) and rerun", addr), 1)
+		default:
+			res.Hint = fmt.Sprintf(
+				"%s is already in use by something that is not corgi's MCP server. "+
+					"Free the port (or pass --http with a free one) and rerun `corgi agent up`.", addr)
+			printAgentUp(res)
+			return
+		}
 	}
 
 	if err := spawnDetachedMCP(dir, addr, provider, tunnelName); err != nil {
@@ -148,14 +175,22 @@ func registerCwdWorkspace() (string, bool) {
 		// would hijack that workspace; disambiguate with the parent instead so
 		// two repos both called "api" can coexist.
 		id = filepath.Base(filepath.Dir(cwd)) + "-" + id
-		if existing2, ok := registry.Find(id); ok && existing2.AbsPath == cwd {
-			return id, false
+		if existing2, ok := registry.Find(id); ok {
+			if existing2.AbsPath == cwd {
+				return id, false
+			}
+			// Both levels collide with other directories. Refusing beats
+			// repointing: the id keys trusted settings (account, permissions),
+			// which must never silently transfer to a new directory.
+			utils.Infof("workspace names %q and %q are both taken by other directories — register with `corgi agent init --id <name>`\n",
+				filepath.Base(cwd), id)
+			return "", false
 		}
 	}
 	existing, _ := registry.Find(id)
 	existing.ID = id
 	existing.AbsPath = cwd
-	existing.ComposeFile = composeFileName(cwd)
+	existing.ComposeFile = registeredComposeFile(cwd)
 	existing.Status = workspace.StatusOK
 	existing.Services, existing.Repos = describeStack(cwd)
 	registry.Upsert(existing)
@@ -204,6 +239,7 @@ func spawnDetachedMCP(dir, addr, provider, tunnelName string) error {
 	// Best-effort: a missing pid file only means `agent down` cannot stop this
 	// MCP for you, not that anything is wrong with the running server.
 	_ = os.WriteFile(filepath.Join(dir, mcpPidName), []byte(strconv.Itoa(pid)+"\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, mcpAddrName), []byte(addr+"\n"), 0o600)
 	return nil
 }
 
@@ -294,6 +330,15 @@ func corgiListenerPIDs(addr string) []int {
 	if err != nil {
 		return nil
 	}
+	// Exact-name match, not Contains: a neighbour binary that merely embeds the
+	// word (corgit, my-corgi-tool) must never be killed. macOS ps prints the
+	// full path, Linux the bare (possibly truncated) name — Base handles both,
+	// and corgi's own name fits untruncated. A differently-named dev build of
+	// corgi is matched via this process's own executable name.
+	wanted := map[string]bool{"corgi": true}
+	if exe, err := os.Executable(); err == nil {
+		wanted[filepath.Base(exe)] = true
+	}
 	var pids []int
 	for _, field := range strings.Fields(string(out)) {
 		pid, err := strconv.Atoi(field)
@@ -304,19 +349,21 @@ func corgiListenerPIDs(addr string) []int {
 		if err != nil {
 			continue
 		}
-		if strings.Contains(filepath.Base(strings.TrimSpace(string(comm))), "corgi") {
+		if wanted[filepath.Base(strings.TrimSpace(string(comm)))] {
 			pids = append(pids, pid)
 		}
 	}
 	return pids
 }
 
-// reclaimCorgiMCP stops a corgi MCP already holding addr and waits for the port
-// to free. Reports whether the port is now available.
-func reclaimCorgiMCP(addr string) bool {
+// reclaimCorgiMCP stops the corgi MCP(s) holding addr and waits for the port to
+// free. found says a corgi listener was there at all; freed says the port is
+// now available — the split keeps the caller's message honest (a corgi server
+// that ignored SIGTERM is not "something that is not corgi").
+func reclaimCorgiMCP(addr string) (found, freed bool) {
 	pids := corgiListenerPIDs(addr)
 	if len(pids) == 0 {
-		return false
+		return false, false
 	}
 	for _, pid := range pids {
 		if proc, err := os.FindProcess(pid); err == nil {
@@ -326,11 +373,11 @@ func reclaimCorgiMCP(addr string) bool {
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if !mcpListening(addr) {
-			return true
+			return true, true
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	return !mcpListening(addr)
+	return true, !mcpListening(addr)
 }
 
 func mcpListening(addr string) bool {
@@ -493,25 +540,37 @@ func runAgentDown(_ *cobra.Command, _ []string) {
 	// its own process-group leader — which the detached MCP is and a recycled pid
 	// almost never is — so a stale file cannot make `down` kill your editor.
 	pidPath := filepath.Join(dir, mcpPidName)
+	mcpStopped := false
 	if pid, ok := readAgentPidFile(pidPath); ok {
 		if utils.PidAlive(pid, "") {
 			if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
 				utils.Infof("stopped MCP + tunnel (pid %d)\n", pid)
-				stopped = true
+				stopped, mcpStopped = true, true
 			}
 		}
 		_ = os.Remove(pidPath)
 	}
-	// Fallback for an MCP with no pid file (started by an older corgi, or the
-	// file was lost): a corgi process still listening on the default MCP port
-	// is ours to stop — leaving it is exactly the stuck loop where every
-	// `agent up` refuses the busy port and pairing never reopens.
-	for _, pid := range corgiListenerPIDs(defaultMCPAddr) {
-		if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
-			utils.Infof("stopped MCP + tunnel on %s (pid %d)\n", defaultMCPAddr, pid)
-			stopped = true
+	// Fallback ONLY when the pid file stopped nothing — an MCP from an older
+	// corgi, or a lost file: a corgi process still listening on the recorded
+	// (or default) MCP port is ours to stop. Leaving it is exactly the stuck
+	// loop where every `agent up` refuses the busy port and pairing never
+	// reopens. Guarded so a just-SIGTERMed server still draining its listener
+	// is not signalled twice and reported as two servers.
+	if !mcpStopped {
+		fallbackAddr := defaultMCPAddr
+		if data, rerr := os.ReadFile(filepath.Join(dir, mcpAddrName)); rerr == nil {
+			if a := strings.TrimSpace(string(data)); a != "" {
+				fallbackAddr = a
+			}
+		}
+		for _, pid := range corgiListenerPIDs(fallbackAddr) {
+			if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+				utils.Infof("stopped MCP + tunnel on %s (pid %d)\n", fallbackAddr, pid)
+				stopped = true
+			}
 		}
 	}
+	_ = os.Remove(filepath.Join(dir, mcpAddrName))
 	_ = os.Remove(filepath.Join(dir, "agent-up.lock"))
 
 	if !stopped {
@@ -537,5 +596,6 @@ func init() {
 	agentUpCmd.Flags().String("http", defaultMCPAddr, "Local MCP address")
 	agentUpCmd.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
 	agentUpCmd.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — gives a stable public URL you can bookmark (needs a one-time `cloudflared tunnel create`; see docs/tunnel.md)")
+	agentUpCmd.Flags().Bool("fresh", false, "Replace a corgi MCP already holding the port: new tunnel + a new single-use pairing window (a phone mid-session on the old URL is cut)")
 	agentCmd.AddCommand(agentUpCmd)
 }

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -92,16 +93,20 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 
 	res.LogPath = filepath.Join(dir, mcpLogName)
 	if mcpListening(addr) {
-		// Something already holds the port. It cannot be probed for identity
-		// here, and a pairing window is single-use anyway, so do not claim it is
-		// corgi or reprint a possibly-stale URL as current — point at the log
-		// and tell the user how to get a fresh window.
-		res.Hint = fmt.Sprintf(
-			"%s is already in use. If it is your corgi MCP server, its output is in %s; "+
-				"to pair a new device, stop it and rerun `corgi agent up` (or pass --http with a free port).",
-			addr, res.LogPath)
-		printAgentUp(res)
-		return
+		// Something already holds the port — usually a corgi MCP from an earlier
+		// `agent up` whose pairing window is long used up. When the listener is
+		// identifiably corgi, stop it and fall through to a fresh spawn (fresh
+		// tunnel, fresh pairing window) instead of refusing forever.
+		if !reclaimCorgiMCP(addr) {
+			res.Hint = fmt.Sprintf(
+				"%s is already in use by something that is not corgi's MCP server. "+
+					"Free the port (or pass --http with a free one) and rerun `corgi agent up`. "+
+					"corgi's own server logs to %s and is stopped by `corgi agent down`.",
+				addr, res.LogPath)
+			printAgentUp(res)
+			return
+		}
+		_ = os.Remove(filepath.Join(dir, mcpPidName))
 	}
 
 	if err := spawnDetachedMCP(dir, addr, provider, tunnelName); err != nil {
@@ -124,12 +129,13 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 	printAgentUp(res)
 }
 
-// registerCwdWorkspace puts the current stack in the registry, like one step of
-// `corgi agent scan`. Registration only — autostart stays opt-in, and remote
-// start is the point of this command anyway.
+// registerCwdWorkspace puts the current workspace — a corgi stack or a plain
+// git repository — in the registry, like one step of `corgi agent scan`.
+// Registration only — autostart stays opt-in, and remote start is the point of
+// this command anyway.
 func registerCwdWorkspace() (string, bool) {
 	cwd, err := os.Getwd()
-	if err != nil || !dirHasComposeFile(cwd) {
+	if err != nil || !dirIsWorkspace(cwd) {
 		return "", false
 	}
 	id := filepath.Base(cwd)
@@ -269,6 +275,64 @@ func upLockIsStale(path string) bool {
 	return proc.Signal(syscall.Signal(0)) != nil
 }
 
+// corgiListenerPIDs returns the pids of corgi processes listening on addr's
+// port. This is the recovery path for an MCP left over by an older `agent up`
+// (started before mcp.pid existed, or whose pid file was lost): without it the
+// port stays held, every `up` refuses, and pairing can never reopen. Only pids
+// whose command name contains "corgi" are returned — an unidentified listener
+// is never touched. Unix-only (lsof); on Windows or without lsof it returns
+// nothing and callers fall back to the manual hint.
+func corgiListenerPIDs(addr string) []int {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil
+	}
+	out, err := exec.Command("lsof", "-ti", "tcp:"+port, "-sTCP:LISTEN").Output()
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, field := range strings.Fields(string(out)) {
+		pid, err := strconv.Atoi(field)
+		if err != nil || pid <= 0 || pid == os.Getpid() {
+			continue
+		}
+		comm, err := exec.Command("ps", "-o", "comm=", "-p", strconv.Itoa(pid)).Output()
+		if err != nil {
+			continue
+		}
+		if strings.Contains(filepath.Base(strings.TrimSpace(string(comm))), "corgi") {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// reclaimCorgiMCP stops a corgi MCP already holding addr and waits for the port
+// to free. Reports whether the port is now available.
+func reclaimCorgiMCP(addr string) bool {
+	pids := corgiListenerPIDs(addr)
+	if len(pids) == 0 {
+		return false
+	}
+	for _, pid := range pids {
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Signal(syscall.SIGTERM)
+		}
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !mcpListening(addr) {
+			return true
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return !mcpListening(addr)
+}
+
 func mcpListening(addr string) bool {
 	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 	if err != nil {
@@ -393,6 +457,80 @@ func orDefault(s, def string) string {
 		return def
 	}
 	return s
+}
+
+// ---------------------------------------------------------------- down
+
+var agentDownCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Stop everything `corgi agent up` started — the daemon and the detached MCP + tunnel",
+	Long: `The mirror of ` + "`corgi agent up`" + `. Stops the agent daemon and the detached
+MCP server that serves the launcher and pairing over the tunnel, so the public
+URL goes down too. (` + "`corgi agent stop`" + ` stops only the daemon.)`,
+	Run: runAgentDown,
+}
+
+func runAgentDown(_ *cobra.Command, _ []string) {
+	dir, err := agentDir()
+	if err != nil {
+		exitWithError("agent_data_dir", err, 1)
+	}
+	stopped := false
+
+	if info, rerr := daemon.ReadInfo(dir); rerr == nil && info != nil {
+		if proc, ferr := os.FindProcess(info.PID); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+			utils.Infof("stopped agent daemon (pid %d)\n", info.PID)
+			stopped = true
+		}
+	}
+
+	// The detached MCP + tunnel that `agent up` recorded. Stopping it is what
+	// takes the public URL down; `agent stop` alone leaves it serving.
+	//
+	// PidAlive guards against a recycled pid: mcp.pid can outlive its process (an
+	// MCP crash, a reboot, an `agent stop` all leave it on disk), and the OS may
+	// hand that number to an unrelated process. PidAlive confirms the pid is still
+	// its own process-group leader — which the detached MCP is and a recycled pid
+	// almost never is — so a stale file cannot make `down` kill your editor.
+	pidPath := filepath.Join(dir, mcpPidName)
+	if pid, ok := readAgentPidFile(pidPath); ok {
+		if utils.PidAlive(pid, "") {
+			if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+				utils.Infof("stopped MCP + tunnel (pid %d)\n", pid)
+				stopped = true
+			}
+		}
+		_ = os.Remove(pidPath)
+	}
+	// Fallback for an MCP with no pid file (started by an older corgi, or the
+	// file was lost): a corgi process still listening on the default MCP port
+	// is ours to stop — leaving it is exactly the stuck loop where every
+	// `agent up` refuses the busy port and pairing never reopens.
+	for _, pid := range corgiListenerPIDs(defaultMCPAddr) {
+		if proc, ferr := os.FindProcess(pid); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+			utils.Infof("stopped MCP + tunnel on %s (pid %d)\n", defaultMCPAddr, pid)
+			stopped = true
+		}
+	}
+	_ = os.Remove(filepath.Join(dir, "agent-up.lock"))
+
+	if !stopped {
+		utils.Info("corgi agent is not running")
+	}
+}
+
+// readAgentPidFile reads a pid written by spawnDetached. A missing or malformed
+// file just means there is nothing to stop.
+func readAgentPidFile(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
 }
 
 func init() {

--- a/cmd/agent_workspace_test.go
+++ b/cmd/agent_workspace_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"andriiklymiuk/corgi/utils/agent/config"
+)
+
+func TestDirIsWorkspace(t *testing.T) {
+	compose := t.TempDir()
+	if err := os.WriteFile(filepath.Join(compose, "corgi-compose.yml"), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRepo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(gitRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	worktree := t.TempDir() // a .git FILE marks a git worktree/submodule
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte("gitdir: /elsewhere\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !dirIsWorkspace(compose) {
+		t.Error("a corgi stack is a workspace")
+	}
+	if !dirIsWorkspace(gitRepo) {
+		t.Error("a plain git repo is a workspace — Remote Control is useful without a compose file")
+	}
+	if !dirIsWorkspace(worktree) {
+		t.Error("a git worktree (.git file) is a workspace")
+	}
+	if dirIsWorkspace(t.TempDir()) {
+		t.Error("an arbitrary folder is NOT a workspace — that guard must not regress")
+	}
+	if dirIsWorkspace("") {
+		t.Error("empty dir is not a workspace")
+	}
+}
+
+func TestCorgiListenerPIDsIsSafeOnBadInput(t *testing.T) {
+	if pids := corgiListenerPIDs("not-an-addr"); pids != nil {
+		t.Errorf("malformed addr must yield nothing, got %v", pids)
+	}
+	// Port 1 is never held by a corgi process; lsof finding nothing must mean
+	// "no one to stop", not an error.
+	if pids := corgiListenerPIDs("127.0.0.1:1"); len(pids) != 0 {
+		t.Errorf("an unheld port must yield nothing, got %v", pids)
+	}
+}
+
+func TestReclaimCorgiMCPWithNothingListening(t *testing.T) {
+	if reclaimCorgiMCP("127.0.0.1:1") {
+		t.Error("nothing corgi-owned on the port — reclaim must report not-reclaimed")
+	}
+}
+
+func TestWorkspaceSessionTarget(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	agentD := mustAgentDir()
+
+	if _, _, ok := workspaceSessionTarget("nope"); ok {
+		t.Error("an unknown workspace must not resolve")
+	}
+
+	stack := stackWithAgentConfig(t, "")
+	registerStack(t, agentD, "acme", stack)
+	absPath, configDir, ok := workspaceSessionTarget("acme")
+	if !ok || absPath != stack {
+		t.Fatalf("workspaceSessionTarget = %q, %v; want the registry path", absPath, ok)
+	}
+	if configDir != "" {
+		t.Errorf("no user config → default account, got %q", configDir)
+	}
+}
+
+func TestListClaudeSessionsWithoutTheBinary(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent")
+	sessions := listClaudeSessions(t.TempDir(), "")
+	if sessions == nil || len(sessions) != 0 {
+		t.Errorf("a missing claude binary must mean an empty list, not an error: %v", sessions)
+	}
+}
+
+func TestLaunchSessionsHandlerUnknownWorkspace(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	rec := httptest.NewRecorder()
+	launchSessionsHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/sessions?workspace=ghost", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown workspace must be 404, got %d", rec.Code)
+	}
+}
+
+func TestLaunchSessionsHandlerListsForARegisteredWorkspace(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	t.Setenv("PATH", "/nonexistent") // no claude binary → empty list, still 200
+	registerStack(t, mustAgentDir(), "acme", stackWithAgentConfig(t, ""))
+
+	rec := httptest.NewRecorder()
+	launchSessionsHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/sessions?workspace=acme", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a registered workspace must answer 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAddProfileRejectsSkipPlusPermissionMode(t *testing.T) {
+	err := addProfile(t.TempDir(), "both", config.WorkspaceConfig{
+		ConfigDir: "~/.claude-x", PermissionMode: "acceptEdits", DangerouslySkipPermissions: true,
+	})
+	if err == nil {
+		t.Error("a profile with both a permission mode and the bypass is ambiguous and must be rejected at add time")
+	}
+}
+
+func TestEnableWorkspaceSkipPermissionsIsSticky(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	agentD := mustAgentDir()
+
+	if err := enableWorkspace("acme", "~/.claude-x", true); err != nil {
+		t.Fatal(err)
+	}
+	user, err := config.LoadUser(agentUserConfigPath(agentD))
+	if err != nil || !user.Workspaces["acme"].DangerouslySkipPermissions {
+		t.Fatalf("init --dangerously-skip-permissions must persist: %+v, %v", user, err)
+	}
+
+	// A later re-init WITHOUT the flag must not silently clear the granted bypass.
+	if err := enableWorkspace("acme", "", false); err != nil {
+		t.Fatal(err)
+	}
+	user, _ = config.LoadUser(agentUserConfigPath(agentD))
+	if !user.Workspaces["acme"].DangerouslySkipPermissions {
+		t.Error("a re-init without the flag must leave a previously-granted bypass alone")
+	}
+	if user.Workspaces["acme"].ConfigDir != "~/.claude-x" {
+		t.Error("a re-init without --config-dir must keep the existing one")
+	}
+}

--- a/cmd/agent_workspace_test.go
+++ b/cmd/agent_workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"andriiklymiuk/corgi/utils/agent/config"
+	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
 func TestDirIsWorkspace(t *testing.T) {
@@ -53,8 +54,9 @@ func TestCorgiListenerPIDsIsSafeOnBadInput(t *testing.T) {
 }
 
 func TestReclaimCorgiMCPWithNothingListening(t *testing.T) {
-	if reclaimCorgiMCP("127.0.0.1:1") {
-		t.Error("nothing corgi-owned on the port — reclaim must report not-reclaimed")
+	found, freed := reclaimCorgiMCP("127.0.0.1:1")
+	if found || freed {
+		t.Error("nothing corgi-owned on the port — reclaim must report neither found nor freed")
 	}
 }
 
@@ -112,6 +114,72 @@ func TestAddProfileRejectsSkipPlusPermissionMode(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("a profile with both a permission mode and the bypass is ambiguous and must be rejected at add time")
+	}
+}
+
+func TestResolveForSessionReachesAGitOnlyWorkspace(t *testing.T) {
+	// The regression this guards: mcp_agent.go's Reconcile calls kept the old
+	// compose-only predicate, so the phone's own tools flagged a freshly
+	// registered git-only repo as unreachable — and saved that to disk.
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registerStack(t, mustAgentDir(), "myrepo", repo)
+
+	w, ambiguous, err := resolveForSession("myrepo")
+	if err != nil || ambiguous != nil || w == nil {
+		t.Fatalf("a git-only workspace must resolve for session start: w=%v amb=%v err=%v", w, ambiguous, err)
+	}
+	if w.AbsPath != repo {
+		t.Errorf("resolved path = %q, want %q", w.AbsPath, repo)
+	}
+}
+
+func TestRegisterCwdWorkspaceInAGitOnlyRepo(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
+	id, registered := registerCwdWorkspace()
+	if !registered || id == "" {
+		t.Fatalf("a git repo without a compose file must register: id=%q registered=%v", id, registered)
+	}
+	reg, _ := mustLoadRegistry()
+	w, ok := reg.Find(id)
+	if !ok {
+		t.Fatal("registered workspace missing from the registry")
+	}
+	if w.ComposeFile != "" {
+		t.Errorf("a git-only workspace must record no compose file, got %q", w.ComposeFile)
+	}
+}
+
+func TestRegisterCwdWorkspaceRefusesADoubleCollision(t *testing.T) {
+	// Both the basename and the parent-basename ids belong to other dirs:
+	// registering must refuse, never repoint an id that keys trusted settings.
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "api")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentD := mustAgentDir()
+	registerStack(t, agentD, "api", "/somewhere/else/api")
+	// occupy the disambiguated name too
+	reg, _ := mustLoadRegistry()
+	reg.Upsert(workspace.Workspace{ID: filepath.Base(parent) + "-api", AbsPath: "/a/third/place", Status: workspace.StatusOK})
+	if err := workspace.Save(agentRegistryPath(agentD), reg); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(repo)
+	if id, registered := registerCwdWorkspace(); registered || id != "" {
+		t.Fatalf("a double id collision must refuse, got id=%q registered=%v", id, registered)
 	}
 }
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -382,15 +382,20 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		_ = srv.Close()
 	}()
 
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		fmt.Fprintln(os.Stderr, "mcp server error:", err)
-		cancel() // kill the tunnel subprocess (exec.CommandContext) before exit
-		if tunnelDone != nil {
-			select {
-			case <-tunnelDone:
-			case <-time.After(2 * time.Second):
-			}
+	err := srv.ListenAndServe()
+	// Join the tunnel runner on BOTH exits. On the graceful path (SIGTERM →
+	// srv.Close → ErrServerClosed) returning without the join races process
+	// exit against CommandContext's kill goroutine — losing that race orphans
+	// cloudflared: a live public URL routing to a dead port.
+	cancel() // kill the tunnel subprocess (exec.CommandContext)
+	if tunnelDone != nil {
+		select {
+		case <-tunnelDone:
+		case <-time.After(2 * time.Second):
 		}
+	}
+	if err != nil && err != http.ErrServerClosed {
+		fmt.Fprintln(os.Stderr, "mcp server error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -276,7 +276,7 @@ func mcpWorkspaces() (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 	_ = workspace.Save(path, registry)
 	return map[string]any{"workspaces": registry.Sorted()}, nil
 }
@@ -289,7 +289,7 @@ func mcpWorkspaceResolve(query string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 	return workspace.Resolve(registry, query), nil
 }
 
@@ -303,7 +303,7 @@ func resolveForSession(query string) (*workspace.Workspace, any, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 	res := workspace.Resolve(registry, query)
 	if !res.Resolved() {
 		return nil, res, nil

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -52,7 +52,7 @@ func launchWorkspacesHandler(w http.ResponseWriter, r *http.Request) {
 		writeLaunchError(w, http.StatusInternalServerError, "could not read the workspace registry")
 		return
 	}
-	registry.Reconcile(dirHasComposeFile)
+	registry.Reconcile(dirIsWorkspace)
 
 	var status *daemon.Status
 	if dir, derr := agentDir(); derr == nil {

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -40,8 +40,9 @@ again would be worse.
 
 ## Quick start
 
-One command does the whole phone-startable setup — register this stack, start
-the daemon + MCP + tunnel + pairing, and print a QR (and the pairing code):
+One command does the whole phone-startable setup — register this workspace (a
+corgi stack **or any git repository** — no compose file needed), start the
+daemon + MCP + tunnel + pairing, and print a QR (and the pairing code):
 
 ```bash
 cd ~/dev/your-stack

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -44,6 +44,11 @@ One command does the whole phone-startable setup — register this workspace (a
 corgi stack **or any git repository** — no compose file needed), start the
 daemon + MCP + tunnel + pairing, and print a QR (and the pairing code):
 
+> A registered workspace is phone-startable, so register directories you mean to
+> work in. In particular, if your `$HOME` is itself a git repo (dotfiles), running
+> `agent up` there registers your entire home directory — probably not what you
+> want.
+
 ```bash
 cd ~/dev/your-stack
 corgi agent up                   # register + daemon + tunnel + pairing, prints a QR

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -200,10 +200,16 @@ corgi_session_start { "workspace": "the recipe app", "profile": "work" }
 corgi agent up
 ```
 
-It registers the current stack, starts the daemon (if down), opens the MCP
-endpoint with a public tunnel, and prints a **scannable QR** for pairing — all
-detached, so you can run it and keep working. No port to remember. `--json`
-emits the URL and pairing code for a caller that wants them structured.
+It registers the current workspace — a corgi stack **or any git repository**
+(no compose file needed) — starts the daemon (if down), opens the MCP endpoint
+with a public tunnel, and prints a **scannable QR** for pairing — all detached,
+so you can run it and keep working. No port to remember. `--json` emits the URL
+and pairing code for a caller that wants them structured. A busy MCP port
+self-heals: when the holder is identifiably corgi's own server, `up` stops it
+and opens a fresh tunnel + pairing window instead of refusing. For a launcher
+URL that survives restarts, pass `--tunnel-name <name>` (cloudflared named
+tunnel — see docs/tunnel.md). The mirror is `corgi agent down`: stops the
+daemon AND the detached MCP + tunnel (`agent stop` stops only the daemon).
 
 The user scans the QR (or opens the printed URL) on their phone, names the
 device, and gets a per-device token. After pairing, the same page offers **Open
@@ -286,14 +292,17 @@ sessions awake but sleeps between turns.
 | workspace marked sensitive | Remote start is refused by design. Start it on the laptop, or unset `sensitive` in `.corgi/agent.yml`. |
 | queued but nothing started | Commands expire after 60s. Check `corgi agent status` diagnostics — a rejected start says why there. |
 | running but no `sessionUrl` | The session is fine; the URL was not spotted in output. Find it in claude.ai/code. |
+| `up` says the port is in use, pairing "not open" on the old URL | A leftover MCP holds the port. Newer corgi reclaims it on `up` automatically; otherwise `corgi agent down` then `corgi agent up` for a fresh tunnel + pairing window. |
 
 ## Things not to do
 
-- **Do not weaken permissions.** `permissionMode: bypassPermissions` is refused,
-  and `--dangerously-skip-permissions` is never passed. Those prompts are what
-  the user answers from their phone, and they are the defence against a session
-  acting on instructions injected through a file it read. If a permission prompt
-  is in the way, ask — do not route around it.
+- **Do not weaken permissions on your own.** A `permissionMode: bypassPermissions`
+  string and a smuggled `--dangerously` arg are refused. The one sanctioned route
+  is the user explicitly setting `--dangerously-skip-permissions` on `agent init`
+  or a profile — their deliberate, trusted-config choice, never yours to make.
+  Those prompts are what the user answers from their phone, the defence against a
+  session acting on instructions injected through a file it read. If a permission
+  prompt is in the way, ask — do not route around it.
 - **Do not put capability settings in `.corgi/agent.yml`.** That file is
   committed and travels with a clone. `bin`, `configDir`, `permissionMode`, and
   credential inheritance belong in the user-level config only. corgi ignores


### PR DESCRIPTION
Field fixes from first real use of the merged remote-session feature.

## The stuck loop (main fix)
An MCP left over from an earlier `agent up` (started before `mcp.pid` existed) held `127.0.0.1:8765`. `agent down` couldn't find it, every `agent up` refused the busy port, and pairing never reopened — the `{"error":"pairing is not open"}` dead end.

- **`agent up` self-heals**: when the port-holder is identifiably corgi (lsof + `ps` comm check), stop it and spawn a fresh server + fresh pairing window. An unidentified listener is never touched — the hint now points at `corgi agent down` and the log.
- **`agent down` fallback**: stops a corgi listener on the default MCP port even with no pid file (older corgi / lost file). Down/pid glue moved to `agent_up.go` beside the spawn glue it mirrors.

## Agent mode for any git repo
`corgi agent init` / `up` refused a repo without `corgi-compose.yml` — but Remote Control is useful on any repo. New `dirIsWorkspace` = compose **or** `.git` (dir or worktree file). Arbitrary folders still refused (the old dead-guard bug can't return); `agent scan` stays compose-only by design.

## Small
- `corgi agents …` now aliases `agent`.
- docs/agent.md updated.

## Tests
dirIsWorkspace matrix, port-reclaim safety on bad input, workspaceSessionTarget/listClaudeSessions/launchSessionsHandler paths, profile skip+mode conflict, sticky `--dangerously-skip-permissions` on re-init. Full suites green with `-race`; native + Windows builds. New-code coverage on this diff: 100% of measurable lines.