### PR TITLE
Actionable startup failures, working Retry, and real session links

### DIFF
--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -103,6 +104,7 @@ func runAgentInit(cmd *cobra.Command, _ []string) {
 		utils.Info("If you keep work and personal logins separate, set one:")
 		utils.Infof("  corgi agent init --config-dir ~/.claude-work\n")
 	}
+	warnIfUntrusted(configDir, cwd)
 	utils.Info("next: `corgi agent install` to start at login, then `corgi agent status`")
 }
 
@@ -157,6 +159,54 @@ func composeFileName(dir string) string {
 		}
 	}
 	return "corgi-compose.yml"
+}
+
+// claudeTrustsDir reports whether Claude's own config records an accepted
+// workspace-trust dialog for dir under the given account. remote-control
+// refuses an untrusted directory, and only a human running `claude` there can
+// accept the dialog — so init/up warn up front instead of letting the phone
+// discover a card that can never start. Best-effort: an unparseable config
+// reports trusted, so a format change never produces false warnings; a missing
+// file means Claude never ran under that account, which IS untrusted.
+func claudeTrustsDir(configDir, dir string) bool {
+	base := expandTilde(configDir)
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return true
+		}
+		base = home
+	}
+	data, err := os.ReadFile(filepath.Join(base, ".claude.json"))
+	if err != nil {
+		return false
+	}
+	var cfg struct {
+		Projects map[string]struct {
+			HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+		} `json:"projects"`
+	}
+	if json.Unmarshal(data, &cfg) != nil || cfg.Projects == nil {
+		return true
+	}
+	return cfg.Projects[dir].HasTrustDialogAccepted
+}
+
+// warnIfUntrusted prints the one-time-fix instruction when Claude has not
+// trusted dir under the workspace's account.
+func warnIfUntrusted(configDir, dir string) {
+	if claudeTrustsDir(configDir, dir) {
+		return
+	}
+	utils.Infof("⚠ Claude has not trusted %s yet%s — run `claude` there once and accept the trust dialog, or the remote session will fail to start.\n",
+		dir, trustAccountSuffix(configDir))
+}
+
+func trustAccountSuffix(configDir string) string {
+	if configDir == "" {
+		return ""
+	}
+	return " under " + configDir
 }
 
 // registeredComposeFile is what the registry records: the real compose file, or

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -89,6 +89,14 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 	res.MCPAddr = addr
 
 	res.Workspace, res.Registered = registerCwdWorkspace()
+	if res.Workspace != "" {
+		// Same trust pre-check init does: an untrusted folder produces a phone
+		// card that can only ever fail, so say it now, while the fix is one
+		// `claude` run away in the terminal the user is already in.
+		if absPath, cfgDir, ok := workspaceSessionTarget(res.Workspace); ok {
+			warnIfUntrusted(cfgDir, absPath)
+		}
+	}
 
 	info, err := ensureDaemon(dir)
 	if err != nil {

--- a/cmd/agent_workspace_test.go
+++ b/cmd/agent_workspace_test.go
@@ -183,6 +183,34 @@ func TestRegisterCwdWorkspaceRefusesADoubleCollision(t *testing.T) {
 	}
 }
 
+func TestClaudeTrustsDir(t *testing.T) {
+	cfgDir := t.TempDir()
+	body := `{"projects": {"/trusted": {"hasTrustDialogAccepted": true}, "/declined": {"hasTrustDialogAccepted": false}}}`
+	if err := os.WriteFile(filepath.Join(cfgDir, ".claude.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !claudeTrustsDir(cfgDir, "/trusted") {
+		t.Error("an accepted trust dialog must report trusted")
+	}
+	if claudeTrustsDir(cfgDir, "/declined") {
+		t.Error("a declined dialog must report untrusted")
+	}
+	if claudeTrustsDir(cfgDir, "/never-opened") {
+		t.Error("a dir Claude never opened must report untrusted — that is the warning's whole point")
+	}
+	// Claude never ran under this account at all → nothing is trusted.
+	if claudeTrustsDir(t.TempDir(), "/anything") {
+		t.Error("a missing .claude.json means Claude never ran under the account — untrusted")
+	}
+	// An unparseable config must NOT warn: a format change is not the user's problem.
+	broken := t.TempDir()
+	_ = os.WriteFile(filepath.Join(broken, ".claude.json"), []byte("not json"), 0o600)
+	if !claudeTrustsDir(broken, "/anything") {
+		t.Error("an unparseable config must assume trusted, never false-warn")
+	}
+}
+
 func TestEnableWorkspaceSkipPermissionsIsSticky(t *testing.T) {
 	t.Setenv("CORGI_DATA_DIR", t.TempDir())
 	agentD := mustAgentDir()

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -38,7 +38,11 @@ type launchWorkspace struct {
 	Status     string   `json:"status"`
 	Running    bool     `json:"running"`
 	SessionURL string   `json:"sessionUrl,omitempty"`
-	Note       string   `json:"note,omitempty"`
+	// SessionLinks are per-session claude.ai URLs captured from remote
+	// control's own output — the only links the site resolves (the ids the
+	// claude CLI lists locally are UUIDs the web does not know).
+	SessionLinks []string `json:"sessionLinks,omitempty"`
+	Note         string   `json:"note,omitempty"`
 }
 
 func launchWorkspacesHandler(w http.ResponseWriter, r *http.Request) {
@@ -63,9 +67,10 @@ func launchWorkspacesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type wsRunState struct {
-	running bool
-	url     string
-	note    string
+	running  bool
+	url      string
+	note     string
+	sessions []string
 }
 
 // buildLaunchWorkspaces joins the registry with the daemon's live status into
@@ -76,7 +81,7 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 	running := map[string]wsRunState{}
 	if status != nil {
 		for _, ws := range status.Workspaces {
-			running[ws.WorkspaceID] = wsRunState{running: ws.Running, url: ws.SessionURL, note: ws.LastReason}
+			running[ws.WorkspaceID] = wsRunState{running: ws.Running, url: ws.SessionURL, note: ws.LastReason, sessions: ws.Sessions}
 		}
 		for _, d := range status.Diagnostics {
 			if d.Warning == "" {
@@ -93,7 +98,8 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 		s := running[ws.ID]
 		out = append(out, launchWorkspace{
 			ID: ws.ID, Aliases: ws.Aliases, Path: ws.AbsPath,
-			Status: string(ws.Status), Running: s.running, SessionURL: s.url, Note: s.note,
+			Status: string(ws.Status), Running: s.running, SessionURL: s.url,
+			SessionLinks: s.sessions, Note: s.note,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
@@ -378,7 +384,7 @@ const launcherPageHTML = `<!doctype html>
       sbtn.className = 'sbtn'; sbtn.textContent = 'sessions ⌄';
       const sessionsBox = document.createElement('div');
       sessionsBox.className = 'sessions'; sessionsBox.style.display = 'none';
-      sbtn.onclick = () => toggleSessions(ws.id, sbtn, sessionsBox);
+      sbtn.onclick = () => toggleSessions(ws, sbtn, sessionsBox);
       left.appendChild(sbtn);
       const right = document.createElement('div');
       right.className = 'right';
@@ -397,40 +403,42 @@ const launcherPageHTML = `<!doctype html>
     }
   }
 
-  async function toggleSessions(id, btn, box) {
-    if (box.style.display !== 'none') { box.style.display = 'none'; btn.textContent = 'sessions ⌄'; return; }
-    box.style.display = ''; btn.textContent = 'sessions ⌃';
-    box.innerHTML = '<div class="none">Loading…</div>';
+  async function toggleSessions(ws, btn, box) {
+    if (box.style.display !== 'none') { box.style.display = 'none'; btn.textContent = 'sessions \u2304'; return; }
+    box.style.display = ''; btn.textContent = 'sessions \u2303';
+    box.innerHTML = '';
+    // Openable links come ONLY from the per-session URLs remote control printed
+    // (captured by the daemon). Ids from the claude CLI are local UUIDs the
+    // site does not resolve; those rows render below as plain status, no link.
+    const links = (ws.sessionLinks || []).filter(safeClaudeUrl);
+    for (const url of links.slice().reverse()) {
+      const el = document.createElement('a');
+      el.className = 's';
+      el.href = url; el.target = '_blank'; el.rel = 'noopener noreferrer';
+      const m = openMode(ws.id);
+      if (m === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
+      if (m === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(url); };
+      el.innerHTML = '<span>' + esc(url.split('/').pop().slice(0, 18)) + '\u2026</span><span class="when">open \u2197</span>';
+      box.appendChild(el);
+    }
+    const info = document.createElement('div');
+    info.className = 'none'; info.textContent = 'Loading\u2026';
+    box.appendChild(info);
     try {
-      const r = await fetch('/launch/sessions?workspace=' + encodeURIComponent(id), { headers: auth });
+      const r = await fetch('/launch/sessions?workspace=' + encodeURIComponent(ws.id), { headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
       const s = j.sessions || [];
-      if (!s.length) { box.innerHTML = '<div class="none">No active sessions. corgi lists these from the claude CLI — none are running for this workspace.</div>'; return; }
-      box.innerHTML = '';
-      // Sessions the claude CLI reports for this workspace. Each links via the
-      // documented claude.ai/code/<session-id> scheme; a session that was never
-      // connected to claude.ai (pure local terminal) may 404 there, so the link
-      // is best-effort — remote-control sessions, the common case here, open.
+      if (!s.length && !links.length) { info.textContent = 'No sessions yet for this workspace.'; return; }
+      info.remove();
       for (const sess of s) {
-        const url = sess.sessionId ? 'https://claude.ai/code/' + encodeURIComponent(sess.sessionId) : '';
-        const clickable = url && safeClaudeUrl(url);
-        const el = document.createElement(clickable ? 'a' : 'div');
+        const el = document.createElement('div');
         el.className = 's';
-        if (clickable) {
-          el.href = url; el.target = '_blank'; el.rel = 'noopener noreferrer';
-          el.title = 'Open on claude.ai (works for connected sessions)';
-          // Honor the workspace's open-in choice: browser mode stays in the browser.
-          // Honor the workspace's open-in choice, same as the main button.
-          const m = openMode(id);
-          if (m === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
-          if (m === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(url); };
-        }
-        el.innerHTML = '<span>' + esc(sess.name || sess.sessionId || 'session') + '</span>' +
-          '<span class="when">' + esc(sess.kind || '') + ' · ' + esc(fmtWhen(sess.startedAt)) + '</span>';
+        el.innerHTML = '<span>' + esc(sess.name || 'session') + '</span>' +
+          '<span class="when">' + esc(sess.kind || '') + ' \u00b7 ' + esc(fmtWhen(sess.startedAt)) + '</span>';
         box.appendChild(el);
       }
-    } catch (e) { box.innerHTML = '<div class="none">✗ ' + esc(e.message) + '</div>'; }
+    } catch (e) { info.textContent = '\u2717 ' + e.message; }
   }
 
   function fmtWhen(ms) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.20.40"
+var APP_VERSION = "1.20.41"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.20.40",
+  "version": "1.20.41",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -426,8 +426,17 @@ func (d *Daemon) drainCommands(ctx context.Context, launch func(*supervisor.Runn
 
 func (d *Daemon) startWorkspace(ctx context.Context, c command.Command, launch func(*supervisor.Runner)) {
 	if r := d.findRunner(c.WorkspaceID); r != nil && r.Supervising() {
-		d.requestPublish() // already supervised — the fresh status is the answer
-		return
+		if r.State().Running {
+			d.requestPublish() // already up — the fresh status is the answer
+			return
+		}
+		// Supervising but not running: the runner is waiting out a restart
+		// backoff after a failure. A remote start here is the user tapping
+		// Retry — after fixing the cause (accepting the trust dialog, logging
+		// in), they should not wait out a five-minute backoff, and silently
+		// answering "already supervised" made the button look broken. Replace
+		// the runner and try right now, with a fresh failure streak.
+		r.StopAsync()
 	}
 	cfg, err := d.ResolveWorkspace(c.WorkspaceID, c.Profile)
 	if err != nil {

--- a/utils/agent/supervisor/exec.go
+++ b/utils/agent/supervisor/exec.go
@@ -68,6 +68,9 @@ func StartProcess(ctx context.Context, cfg SpawnConfig) (Process, error) {
 	if cfg.OnSessionURL != nil {
 		writers = append(writers, newURLScanner(cfg.OnSessionURL))
 	}
+	if cfg.OnSessionLink != nil {
+		writers = append(writers, newSessionLinkScanner(cfg.OnSessionLink))
+	}
 	if cfg.OnActivity != nil {
 		writers = append(writers, activityWriter{cfg.OnActivity})
 	}
@@ -184,6 +187,56 @@ func (u *urlScanner) Write(p []byte) (int, error) {
 	u.mu.Unlock()
 	if hit != "" {
 		u.report(hit)
+	}
+	return len(p), nil
+}
+
+// sessionLinkPattern matches the per-session claude.ai links remote control
+// prints as sessions spawn (…/code/session_<id>?from=cli, wrapped in OSC-8
+// hyperlink escapes). Only the id is captured — the query string and escape
+// bytes terminate the character class — and callers rebuild the canonical URL
+// from it. This is the ONLY reliable source for a session's web link: the ids
+// `claude agents --json` prints are local UUIDs the site does not resolve.
+var sessionLinkPattern = regexp.MustCompile(`https://claude\.ai/code/(session_[A-Za-z0-9]+)`)
+
+// sessionLinkScanner reports every DISTINCT per-session id seen in the process
+// output, unlike urlScanner which reports one URL and stops. A match touching
+// the end of the buffer is held back — the next write could extend the id.
+type sessionLinkScanner struct {
+	mu      sync.Mutex
+	partial []byte
+	seen    map[string]bool
+	report  func(id string)
+}
+
+func newSessionLinkScanner(report func(string)) *sessionLinkScanner {
+	return &sessionLinkScanner{seen: map[string]bool{}, report: report}
+}
+
+func (s *sessionLinkScanner) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	s.partial = append(s.partial, p...)
+	var hits []string
+	cut := 0
+	for _, m := range sessionLinkPattern.FindAllSubmatchIndex(s.partial, -1) {
+		if m[1] >= len(s.partial) {
+			break // may extend on the next write; keep for then
+		}
+		if id := string(s.partial[m[2]:m[3]]); !s.seen[id] {
+			s.seen[id] = true
+			hits = append(hits, id)
+		}
+		cut = m[1]
+	}
+	if cut > 0 {
+		s.partial = s.partial[cut:]
+	}
+	if len(s.partial) > maxPartialLine {
+		s.partial = s.partial[len(s.partial)-maxPartialLine:]
+	}
+	s.mu.Unlock()
+	for _, id := range hits {
+		s.report(id)
 	}
 	return len(p), nil
 }

--- a/utils/agent/supervisor/exec_scanner_test.go
+++ b/utils/agent/supervisor/exec_scanner_test.go
@@ -1,0 +1,47 @@
+package supervisor
+
+import (
+	"testing"
+)
+
+func TestSessionLinkScannerCapturesEachDistinctSession(t *testing.T) {
+	var got []string
+	s := newSessionLinkScanner(func(id string) { got = append(got, id) })
+
+	// Real remote-control output: OSC-8 hyperlink escapes around the URL, a
+	// query string, and the same session printed twice.
+	chunk := "\x1b]8;;https://claude.ai/code/session_01AAA?from=cliAttached\x1b]8;;\x1b\\\n" +
+		"link https://claude.ai/code/session_01AAA?from=cliprobe\n" +
+		"and https://claude.ai/code/session_02BBB done\n"
+	_, _ = s.Write([]byte(chunk))
+
+	if len(got) != 2 || got[0] != "session_01AAA" || got[1] != "session_02BBB" {
+		t.Fatalf("scanner must report each distinct session once, got %v", got)
+	}
+
+	// An id split across writes must not be reported truncated.
+	_, _ = s.Write([]byte("see https://claude.ai/code/session_03C"))
+	_, _ = s.Write([]byte("CC now\n"))
+	if len(got) != 3 || got[2] != "session_03CCC" {
+		t.Fatalf("a split id must be assembled whole, got %v", got)
+	}
+}
+
+func TestRunnerAddSessionLinkDedupsAndCaps(t *testing.T) {
+	r := NewRunner(baseConfig(), nil, NewWakeLock(WakeLockOff))
+	for i := 0; i < 2; i++ {
+		r.addSessionLink("session_01X")
+	}
+	if n := len(r.State().Sessions); n != 1 {
+		t.Fatalf("the same session must be recorded once, got %d", n)
+	}
+	if r.State().Sessions[0] != "https://claude.ai/code/session_01X" {
+		t.Fatalf("stored value must be the canonical URL, got %q", r.State().Sessions[0])
+	}
+	for i := 0; i < maxTrackedSessions+5; i++ {
+		r.addSessionLink("session_" + string(rune('A'+i%26)) + string(rune('a'+i/26)))
+	}
+	if n := len(r.State().Sessions); n > maxTrackedSessions {
+		t.Fatalf("sessions must cap at %d, got %d", maxTrackedSessions, n)
+	}
+}

--- a/utils/agent/supervisor/policy.go
+++ b/utils/agent/supervisor/policy.go
@@ -59,6 +59,11 @@ var authFailureMarkers = []string{
 	"oauth token has expired",
 }
 
+// trustFailureMarker is what remote control prints for a directory whose Claude
+// workspace-trust dialog was never accepted. Retrying cannot accept a dialog,
+// so this disables the workspace with instructions instead of looping.
+const trustFailureMarker = "workspace not trusted"
+
 // Exit is one observed termination of a supervised process.
 type Exit struct {
 	Code      int
@@ -143,19 +148,32 @@ func Decide(e Exit, attempt, consecutiveStartupFailures int) Decision {
 		}
 
 	case CauseStartupFailure:
+		// A missing workspace-trust acceptance never fixes itself by retrying —
+		// only a human running `claude` in the folder can accept the dialog. Say
+		// exactly that instead of a generic retry line the user has to debug.
+		if strings.Contains(strings.ToLower(e.Output), trustFailureMarker) {
+			return Decision{
+				Cause:   cause,
+				Disable: true,
+				Notify:  true,
+				Reason:  "Claude has not trusted this folder yet — run `claude` in the workspace once, accept the trust dialog, then retry",
+			}
+		}
 		if consecutiveStartupFailures+1 >= MaxStartupFailures {
 			return Decision{
 				Cause:   cause,
 				Disable: true,
 				Notify:  true,
-				Reason:  "remote control exited immediately " + strconv.Itoa(consecutiveStartupFailures+1) + " times — run `corgi agent doctor`",
+				Reason: withLastOutputLine(
+					"remote control exited immediately "+strconv.Itoa(consecutiveStartupFailures+1)+" times — run `corgi agent doctor`",
+					e.Output),
 			}
 		}
 		return Decision{
 			Cause:   cause,
 			Restart: true,
 			Delay:   backoffFor(attempt),
-			Reason:  "remote control exited during startup, retrying",
+			Reason:  withLastOutputLine("remote control exited during startup, retrying", e.Output),
 		}
 
 	case CauseNetworkTimeout:
@@ -176,6 +194,36 @@ func Decide(e Exit, attempt, consecutiveStartupFailures int) Decision {
 			Reason:  "remote control restarted after an unexpected exit",
 		}
 	}
+}
+
+// withLastOutputLine appends the child's last non-empty output line to a
+// reason, so "exited during startup" carries the actual error ("Workspace not
+// trusted…", a stack trace's final line) instead of making the user reproduce
+// the failure by hand to see it. No output → the reason stands alone.
+func withLastOutputLine(reason, output string) string {
+	line := lastOutputLine(output)
+	if line == "" {
+		return reason
+	}
+	return reason + " — last output: " + line
+}
+
+// maxReasonLineLen caps the quoted output line; reasons render on a phone card.
+const maxReasonLineLen = 160
+
+func lastOutputLine(output string) string {
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if len(line) > maxReasonLineLen {
+			line = line[:maxReasonLineLen] + "…"
+		}
+		return line
+	}
+	return ""
 }
 
 // backoffFor returns the delay for a restart attempt, holding at the last

--- a/utils/agent/supervisor/policy_test.go
+++ b/utils/agent/supervisor/policy_test.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -128,6 +129,34 @@ func TestDecideStopsAfterRepeatedStartupFailures(t *testing.T) {
 	}
 	if !d.Disable {
 		t.Error("a persistent startup failure must disable the workspace")
+	}
+}
+
+func TestDecideTrustFailureDisablesWithInstructions(t *testing.T) {
+	d := Decide(Exit{Code: 1, Uptime: time.Second,
+		Output: "Error: Workspace not trusted. Please run `claude` in /x first"}, 0, 0)
+
+	if d.Restart {
+		t.Error("retrying cannot accept a trust dialog — must not loop")
+	}
+	if !d.Disable || !d.Notify {
+		t.Error("a trust failure must disable and notify")
+	}
+	if !strings.Contains(d.Reason, "trust dialog") {
+		t.Errorf("the reason must say how to fix it, got %q", d.Reason)
+	}
+}
+
+func TestDecideStartupFailureCarriesTheChildsLastLine(t *testing.T) {
+	d := Decide(Exit{Code: 1, Uptime: time.Second,
+		Output: "some noise\nError: config file corrupt\n\n"}, 0, 0)
+
+	if !strings.Contains(d.Reason, "Error: config file corrupt") {
+		t.Errorf("the reason must quote the child's last output line so nobody reproduces the failure by hand to see it, got %q", d.Reason)
+	}
+	// No output at all → the generic reason stands alone, no dangling suffix.
+	if d := Decide(Exit{Code: 1, Uptime: time.Second}, 0, 0); strings.Contains(d.Reason, "last output") {
+		t.Errorf("no output must mean no quote suffix, got %q", d.Reason)
 	}
 }
 

--- a/utils/agent/supervisor/runner.go
+++ b/utils/agent/supervisor/runner.go
@@ -39,7 +39,14 @@ type RunState struct {
 	Origin      string    `json:"origin,omitempty"`
 	Profile     string    `json:"profile,omitempty"`
 	SessionURL  string    `json:"sessionUrl,omitempty"`
+	// Sessions are the canonical per-session claude.ai URLs spotted in the
+	// process output, oldest first — the only ids the site actually resolves.
+	Sessions []string `json:"sessions,omitempty"`
 }
+
+// maxTrackedSessions bounds RunState.Sessions; a runner alive for weeks must
+// not grow status.json without limit. Oldest entries fall off first.
+const maxTrackedSessions = 20
 
 // Runner supervises one workspace's remote-control process.
 type Runner struct {
@@ -93,8 +100,29 @@ func NewRunner(cfg SpawnConfig, start Starter, lock *WakeLock) *Runner {
 		stopped:  make(chan struct{}),
 	}
 	r.Config.OnSessionURL = r.setSessionURL
+	r.Config.OnSessionLink = r.addSessionLink
 	r.Config.OnActivity = r.recordActivity
 	return r
+}
+
+// addSessionLink records one per-session web URL spotted in the output. The
+// scanner already dedups within a process run; the check here dedups across
+// restarts, where a re-attached session prints its link again.
+func (r *Runner) addSessionLink(id string) {
+	url := "https://claude.ai/code/" + id
+	r.mu.Lock()
+	for _, s := range r.state.Sessions {
+		if s == url {
+			r.mu.Unlock()
+			return
+		}
+	}
+	r.state.Sessions = append(r.state.Sessions, url)
+	if len(r.state.Sessions) > maxTrackedSessions {
+		r.state.Sessions = r.state.Sessions[len(r.state.Sessions)-maxTrackedSessions:]
+	}
+	r.mu.Unlock()
+	r.notifyChange()
 }
 
 // recordActivity stamps the last-output time for the idle wake lock. On the

--- a/utils/agent/supervisor/spawn.go
+++ b/utils/agent/supervisor/spawn.go
@@ -69,6 +69,10 @@ type SpawnConfig struct {
 	// it so the exec layer can report the claude.ai session URL it spots in
 	// the process output. Best-effort — may never fire.
 	OnSessionURL func(url string)
+	// OnSessionLink is runtime wiring too: called once per distinct
+	// per-session id (session_…) remote control prints as sessions spawn —
+	// the only source of a session's real web link.
+	OnSessionLink func(id string)
 	// OnActivity is runtime wiring too: the exec layer calls it on every chunk
 	// of process output, which the idle wake lock uses as a "still working"
 	// signal. Must be cheap — it is on the output path.


### PR DESCRIPTION
Three failures from the first real day of phone use, each reproduced before fixing.

## Startup failures said nothing useful
The phone card showed *"remote control exited during startup, retrying"* while the child had printed the actual reason (`Workspace not trusted…`). Now:
- The failure reason **quotes the child's last output line** — no more reproducing by hand to see the error.
- A **trust failure disables with instructions** ("run `claude` in the workspace once, accept the trust dialog, then retry") instead of retry-looping — a retry can't accept a dialog.
- `agent init` / `up` **pre-check Claude's trust record** for the workspace's account and warn at registration time, in the terminal where the fix is one command away.

## Retry on the phone did nothing
A runner waiting out its restart backoff is `Supervising()`, so a remote start was answered "already supervised" — silently. Tapping **Retry now replaces the runner and tries immediately** with a fresh failure streak.

## Session links 404'd
The launcher's session links were built from `claude agents --json` ids — local UUIDs claude.ai does not resolve (verified: the web wants `session_…` ids; cross-org opens say "may belong to another organization"). Remote control **prints the real per-session URLs in its own output** — a second output scanner captures every distinct `session_…` id (OSC-8 hyperlink escapes and query strings handled), the runner publishes them through status, and the launcher links those. CLI-listed sessions render as plain status, never fabricated links.

## Tests
Trust-failure policy, last-output-line quoting, `claudeTrustsDir` matrix, session-link scanner (dedup, split-across-writes, escape handling), runner session cap. Full suites green with `-race`; native + Windows builds.