### PR TITLE
agent stop/down: wait for the daemon to exit (stop && up race)

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/brief"
@@ -444,6 +445,30 @@ func runAgentStop(_ *cobra.Command, _ []string) {
 		exitWithError("agent_stop", fmt.Errorf("could not stop pid %d: %w", info.PID, err), 1)
 	}
 	utils.Infof("stopping corgi agent (pid %d)\n", info.PID)
+
+	// Block until the daemon is actually gone. Returning on signal-sent made
+	// `corgi agent stop && corgi agent up` a race: up's ensureDaemon read the
+	// dying daemon as "running (same pid)", skipped starting a fresh one, and
+	// the machine ended up with no daemon at all.
+	if waitForDaemonExit(dir, 10*time.Second) {
+		utils.Info("stopped")
+	} else {
+		utils.Infof("still shutting down after 10s — check `corgi agent status` (pid %d)\n", info.PID)
+	}
+}
+
+// waitForDaemonExit polls until the daemon's record is gone (ReadInfo validates
+// liveness and clears a stale file itself) or the timeout passes.
+func waitForDaemonExit(dir string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if info, err := daemon.ReadInfo(dir); err != nil || info == nil {
+			return true
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	info, err := daemon.ReadInfo(dir)
+	return err != nil || info == nil
 }
 
 // ---------------------------------------------------------------- workspaces

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -534,6 +534,9 @@ func runAgentDown(_ *cobra.Command, _ []string) {
 
 	if info, rerr := daemon.ReadInfo(dir); rerr == nil && info != nil {
 		if proc, ferr := os.FindProcess(info.PID); ferr == nil && proc.Signal(syscall.SIGTERM) == nil {
+			// Wait for the exit, or `down && up` races: up reads the dying
+			// daemon as running and starts nothing.
+			_ = waitForDaemonExit(dir, 10*time.Second)
 			utils.Infof("stopped agent daemon (pid %d)\n", info.PID)
 			stopped = true
 		}


### PR DESCRIPTION
Field bug, visible in one screenful: `corgi agent stop && corgi agent up --fresh` printed *stopping (pid 16521)* then *✓ daemon running (pid 16521)* — the same pid. `stop` returned on signal-sent, `up` read the dying daemon as alive, started nothing, and the machine ended up with **no daemon**: every phone card showed "the corgi agent daemon is not running".

`stop` and `down` now block (up to 10s) until the daemon record is gone — `ReadInfo` already validates liveness and clears a stale file, so the wait is exactly "the daemon is truly finished". `stop` prints `stopped` when done, or says it's still shutting down after 10s.