### PR TITLE
Agent: session timeline, phone Stop, webhook notifications, trust doctor

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -133,6 +133,14 @@ func runAgentServe(cmd *cobra.Command, _ []string) {
 	d := daemon.New(APP_VERSION, dir)
 	d.CaptureBrief = captureWorkspaceBrief
 	d.ResolveWorkspace = remoteResolver(dir, foreground)
+	if user, uerr := config.LoadUser(agentUserConfigPath(dir)); uerr == nil && user != nil && user.NotifyUrl != "" {
+		hook := webhookNotifier(user.NotifyUrl, nil)
+		if hook == nil {
+			utils.Infof("⚠ notifyUrl %q is not a usable http(s) URL — webhook notifications are off\n", user.NotifyUrl)
+		} else if n := combinedNotifier(d.Notify, hook); n != nil {
+			d.Notify = n
+		}
+	}
 	printStartupDiagnostics(configs)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/cmd/agent_features_test.go
+++ b/cmd/agent_features_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/events"
+)
+
+func TestWebhookNotifierPostsTitleAndBody(t *testing.T) {
+	got := make(chan [2]string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, 128)
+		n, _ := r.Body.Read(body)
+		got <- [2]string{r.Header.Get("Title"), string(body[:n])}
+	}))
+	defer srv.Close()
+
+	notify := webhookNotifier(srv.URL, srv.Client())
+	if notify == nil {
+		t.Fatal("a valid http URL must produce a notifier")
+	}
+	notify("corgi agent · acme", "session restarted")
+
+	select {
+	case pair := <-got:
+		if pair[0] != "corgi agent - acme" || pair[1] != "session restarted" {
+			t.Errorf("posted %q / %q", pair[0], pair[1])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("webhook never arrived")
+	}
+}
+
+func TestAsciiHeader(t *testing.T) {
+	if got := asciiHeader("corgi agent · idé"); got != "corgi agent - id" {
+		t.Errorf("asciiHeader = %q", got)
+	}
+}
+
+func TestWebhookNotifierRejectsBadURLs(t *testing.T) {
+	for _, u := range []string{"", "not a url", "ftp://x/y", "file:///etc/passwd", "https://"} {
+		if webhookNotifier(u, nil) != nil {
+			t.Errorf("url %q must not produce a notifier", u)
+		}
+	}
+}
+
+func TestCombinedNotifierSkipsNil(t *testing.T) {
+	if combinedNotifier(nil, nil) != nil {
+		t.Error("all-nil must collapse to nil")
+	}
+	calls := 0
+	n := combinedNotifier(nil, func(string, string) { calls++ })
+	n("t", "b")
+	if calls != 1 {
+		t.Errorf("calls = %d", calls)
+	}
+}
+
+func TestLaunchStopHandlerMethodAndValidation(t *testing.T) {
+	rec := httptest.NewRecorder()
+	launchStopHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/stop", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET must be 405, got %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	launchStopHandler(rec, httptest.NewRequest(http.MethodPost, "/launch/stop", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing workspace must be 400, got %d", rec.Code)
+	}
+}
+
+func TestSessionHistoryReadsTheTimeline(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+
+	log := events.NewLog(agentD)
+	log.Append("acme", events.Event{Kind: "started", PID: 1})
+	log.Append("acme", events.Event{Kind: "session", URL: "https://claude.ai/code/session_01A"})
+	log.Append("acme", events.Event{Kind: "session", URL: "https://claude.ai/code/session_01B"})
+	log.Append("acme", events.Event{Kind: "session", URL: "https://claude.ai/code/session_01A"})
+
+	got := sessionHistory("acme")
+	if len(got) != 2 {
+		t.Fatalf("history = %+v, want 2 deduped links", got)
+	}
+	if got[0].URL != "https://claude.ai/code/session_01A" || got[1].URL != "https://claude.ai/code/session_01B" {
+		t.Errorf("order = %q then %q, want newest first", got[0].URL, got[1].URL)
+	}
+	if got[0].At == 0 {
+		t.Error("history entries must carry a timestamp")
+	}
+}
+
+func TestSessionHistoryEmptyWithoutEvents(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	if got := sessionHistory("nope"); len(got) != 0 {
+		t.Errorf("no timeline means empty history, got %+v", got)
+	}
+}
+
+func TestCheckWorkspaceTrust(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	agentD, _ := agentDir()
+	stack := stackWithAgentConfig(t, "")
+	registerStack(t, agentD, "acme", stack)
+
+	checks := checkWorkspaceTrust()
+	if len(checks) != 1 {
+		t.Fatalf("checks = %+v, want one row for acme", checks)
+	}
+	if checks[0].OK {
+		t.Error("no .claude.json means untrusted, the row must fail with a fix")
+	}
+	if checks[0].Fix == "" {
+		t.Error("an untrusted workspace needs the fix instruction")
+	}
+
+	trust := map[string]any{"projects": map[string]any{stack: map[string]any{"hasTrustDialogAccepted": true}}}
+	data, _ := json.Marshal(trust)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checks = checkWorkspaceTrust()
+	if len(checks) != 1 || !checks[0].OK {
+		t.Errorf("a trusted workspace must pass, got %+v", checks)
+	}
+}
+
+func TestDescribeEvent(t *testing.T) {
+	cases := map[string]events.Event{
+		"started (pid 7)":                  {Kind: "started", PID: 7},
+		"session https://claude.ai/code/x": {Kind: "session", URL: "https://claude.ai/code/x"},
+		"disabled — auth broke":            {Kind: "disabled", Reason: "auth broke"},
+		"exited · crash — boom":            {Kind: "exited", Cause: "crash", Reason: "boom"},
+		"exited":                           {Kind: "exited"},
+	}
+	for want, e := range cases {
+		if got := describeEvent(e); got != want {
+			t.Errorf("describeEvent(%+v) = %q, want %q", e, got, want)
+		}
+	}
+}

--- a/cmd/agent_features_test.go
+++ b/cmd/agent_features_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/events"
 )
 
@@ -140,6 +142,117 @@ func TestCheckWorkspaceTrust(t *testing.T) {
 	}
 }
 
+func TestRunAgentLogsHumanAndJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	stack := stackWithAgentConfig(t, "")
+	registerStack(t, agentD, "acme", stack)
+
+	log := events.NewLog(agentD)
+	log.Append("acme", events.Event{Kind: "started", PID: 9})
+	log.Append("acme", events.Event{Kind: "exited", Cause: "crash", Reason: "boom"})
+
+	cmd := agentLogsCmd
+	orig := utils.JSONOutput
+	defer func() { utils.JSONOutput = orig }()
+
+	utils.JSONOutput = false
+	out := captureStdout(t, func() { runAgentLogs(cmd, []string{"acme"}) })
+	if !strings.Contains(out, "exited · crash — boom") || !strings.Contains(out, "started (pid 9)") {
+		t.Errorf("human timeline missing entries:\n%s", out)
+	}
+
+	utils.JSONOutput = true
+	out = captureStdout(t, func() { runAgentLogs(cmd, []string{"acme"}) })
+	if !strings.Contains(out, `"workspaceId"`) || !strings.Contains(out, `"crash"`) {
+		t.Errorf("json output missing fields:\n%s", out)
+	}
+	utils.JSONOutput = false
+
+	out = captureStdout(t, func() { runAgentLogs(cmd, []string{"acme"}) })
+	if out == "" {
+		t.Error("expected output for the human path")
+	}
+}
+
+func TestRunAgentLogsEmptyTimeline(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	registerStack(t, agentD, "acme", stackWithAgentConfig(t, ""))
+
+	orig := utils.JSONOutput
+	utils.JSONOutput = false
+	defer func() { utils.JSONOutput = orig }()
+	captureStdout(t, func() { runAgentLogs(agentLogsCmd, []string{"acme"}) })
+}
+
+func TestWebhookNotifierUnreachableTargetIsSilent(t *testing.T) {
+	notify := webhookNotifier("http://127.0.0.1:1/topic", nil)
+	if notify == nil {
+		t.Fatal("a well-formed URL must produce a notifier")
+	}
+	notify("title", "body")
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestLaunchStopHandlerBadBodyAndUnknownWorkspace(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+
+	rec := httptest.NewRecorder()
+	launchStopHandler(rec, httptest.NewRequest(http.MethodPost, "/launch/stop", strings.NewReader("{not json")))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad body must be 400, got %d", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	launchStopHandler(rec, httptest.NewRequest(http.MethodPost, "/launch/stop", strings.NewReader(`{"workspace":"ghost"}`)))
+	if rec.Code != http.StatusOK {
+		t.Errorf("an unresolved workspace answers 200 with candidates, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), `"state"`) {
+		t.Errorf("an unresolved workspace must not report a stop state: %s", rec.Body.String())
+	}
+}
+
+func TestMcpSessionEventsReturnsTimeline(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	registerStack(t, agentD, "acme", stackWithAgentConfig(t, ""))
+	events.NewLog(agentD).Append("acme", events.Event{Kind: "started", PID: 3})
+
+	got, err := mcpSessionEvents("acme", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok || m["workspaceId"] != "acme" {
+		t.Fatalf("result = %+v", got)
+	}
+	if evs, ok := m["events"].([]events.Event); !ok || len(evs) != 1 || evs[0].Kind != "started" {
+		t.Errorf("events = %+v", m["events"])
+	}
+
+	if amb, err := mcpSessionEvents("ghost", 10); err != nil || amb == nil {
+		t.Errorf("an unresolved name answers with candidates, not an error: %v %v", amb, err)
+	}
+}
+
+func TestSessionHistoryCapsAtTwenty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	log := events.NewLog(agentD)
+	for i := 0; i < 25; i++ {
+		log.Append("acme", events.Event{Kind: "session", URL: fmt.Sprintf("https://claude.ai/code/session_%02d", i)})
+	}
+	if got := sessionHistory("acme"); len(got) != 20 {
+		t.Errorf("history = %d entries, cap is 20", len(got))
+	}
+}
+
 func TestDescribeEvent(t *testing.T) {
 	cases := map[string]events.Event{
 		"started (pid 7)":                  {Kind: "started", PID: 7},
@@ -147,6 +260,7 @@ func TestDescribeEvent(t *testing.T) {
 		"disabled — auth broke":            {Kind: "disabled", Reason: "auth broke"},
 		"exited · crash — boom":            {Kind: "exited", Cause: "crash", Reason: "boom"},
 		"exited":                           {Kind: "exited"},
+		"weird":                            {Kind: "weird"},
 	}
 	for want, e := range cases {
 		if got := describeEvent(e); got != want {

--- a/cmd/agent_logs.go
+++ b/cmd/agent_logs.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/events"
+	"andriiklymiuk/corgi/utils/agent/workspace"
+
+	"github.com/spf13/cobra"
+)
+
+var agentLogsCmd = &cobra.Command{
+	Use:     "logs <workspace>",
+	Aliases: []string{"events", "timeline"},
+	Short:   "Show a workspace's session timeline (starts, exits, why)",
+	Args:    cobra.MinimumNArgs(1),
+	Run:     runAgentLogs,
+}
+
+func runAgentLogs(cmd *cobra.Command, args []string) {
+	registry, _ := mustLoadRegistry()
+	res := workspace.Resolve(registry, strings.Join(args, " "))
+	if !res.Resolved() {
+		if utils.JSONOutput {
+			utils.PrintJSON(res)
+		} else {
+			fmt.Println(res.Reason)
+			for _, c := range res.Candidates {
+				fmt.Printf("  %-20s %s\n", c.Workspace.ID, c.Workspace.AbsPath)
+			}
+		}
+		os.Exit(2)
+	}
+
+	dir, err := agentDir()
+	if err != nil {
+		exitWithError("agent_data_dir", err, 1)
+	}
+	limit, _ := cmd.Flags().GetInt("limit")
+	timeline := events.NewLog(dir).Read(res.Workspace.ID, limit)
+
+	if utils.JSONOutput {
+		utils.PrintJSON(map[string]any{"workspaceId": res.Workspace.ID, "events": timeline})
+		return
+	}
+	if len(timeline) == 0 {
+		utils.Infof("no events recorded for %s yet — the timeline fills as the daemon runs sessions\n", res.Workspace.ID)
+		return
+	}
+	for _, e := range timeline {
+		fmt.Printf("%s  %s\n", e.At.Local().Format("Jan 02 15:04:05"), describeEvent(e))
+	}
+}
+
+func describeEvent(e events.Event) string {
+	switch e.Kind {
+	case "started":
+		return fmt.Sprintf("started (pid %d)", e.PID)
+	case "session":
+		return "session " + e.URL
+	case "disabled":
+		return "disabled — " + e.Reason
+	case "exited":
+		s := "exited"
+		if e.Cause != "" {
+			s += " · " + e.Cause
+		}
+		if e.Reason != "" {
+			s += " — " + e.Reason
+		}
+		return s
+	}
+	return e.Kind
+}
+
+func init() {
+	agentLogsCmd.Flags().Int("limit", 30, "How many events to show, newest first (0 = all kept)")
+	agentCmd.AddCommand(agentLogsCmd)
+}

--- a/cmd/agent_notify.go
+++ b/cmd/agent_notify.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func webhookNotifier(rawURL string, client *http.Client) func(title, body string) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	target := u.String()
+	return func(title, body string) {
+		go func() {
+			req, err := http.NewRequest(http.MethodPost, target, strings.NewReader(body))
+			if err != nil {
+				return
+			}
+			// ntfy shows raw bytes for non-ASCII header values, so keep it ASCII.
+			req.Header.Set("Title", asciiHeader(title))
+			req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+			resp, err := client.Do(req)
+			if err != nil {
+				return
+			}
+			_ = resp.Body.Close()
+		}()
+	}
+}
+
+func asciiHeader(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '·':
+			b.WriteByte('-')
+		case r >= 32 && r < 127:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func combinedNotifier(notifiers ...func(title, body string)) func(title, body string) {
+	var active []func(title, body string)
+	for _, n := range notifiers {
+		if n != nil {
+			active = append(active, n)
+		}
+	}
+	if len(active) == 0 {
+		return nil
+	}
+	return func(title, body string) {
+		for _, n := range active {
+			n(title, body)
+		}
+	}
+}

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -436,6 +436,29 @@ func collectAgentChecks() []agentCheck {
 		return append(checks, agentCheck{Name: "data directory", Detail: err.Error()})
 	}
 	checks = append(checks, checkUserConfigPermissions(agentUserConfigPath(dir)), checkRegisteredWorkspaces(), checkDaemonRunning(dir))
+	checks = append(checks, checkWorkspaceTrust()...)
+	return checks
+}
+
+func checkWorkspaceTrust() []agentCheck {
+	registry, _, err := agentRegistry()
+	if err != nil {
+		return nil
+	}
+	var checks []agentCheck
+	for _, ws := range registry.Sorted() {
+		absPath, configDir, ok := workspaceSessionTarget(ws.ID)
+		if !ok || absPath == "" {
+			continue
+		}
+		c := agentCheck{Name: "trust · " + ws.ID, OK: true, Detail: "Claude trusts " + absPath + trustAccountSuffix(configDir)}
+		if !claudeTrustsDir(configDir, absPath) {
+			c.OK = false
+			c.Detail = "Claude has not trusted " + absPath + trustAccountSuffix(configDir) + " — remote sessions will refuse to start"
+			c.Fix = "run `claude` in that directory once and accept the trust prompt"
+		}
+		checks = append(checks, c)
+	}
 	return checks
 }
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -330,6 +330,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		mux.HandleFunc("/app", launcherPageHandler)
 		mux.Handle("/launch/workspaces", bearerAuth(token, http.HandlerFunc(launchWorkspacesHandler), deviceStore))
 		mux.Handle("/launch/start", bearerAuth(token, http.HandlerFunc(launchStartHandler), deviceStore))
+		mux.Handle("/launch/stop", bearerAuth(token, http.HandlerFunc(launchStopHandler), deviceStore))
 		mux.Handle("/launch/sessions", bearerAuth(token, http.HandlerFunc(launchSessionsHandler), deviceStore))
 	}
 

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -11,6 +11,7 @@ import (
 	"andriiklymiuk/corgi/utils/agent/command"
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
+	"andriiklymiuk/corgi/utils/agent/events"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -107,6 +108,17 @@ func registerAgentMCPTools(s *server.MCPServer) {
 		mcp.WithString("workspace", mcp.Required(), mcp.Description("Workspace id, alias, or human name")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
 		return mcpSessionStop(r.GetString("workspace", ""))
+	}))
+
+	s.AddTool(mcp.NewTool("corgi_session_events",
+		mcp.WithDescription(
+			"A workspace's session timeline, newest first: starts, exits with their classified cause and reason, "+
+				"disables, and captured claude.ai session links. Use it to answer why a session died or restarted. "+
+				"It never contains session output."),
+		mcp.WithString("workspace", mcp.Required(), mcp.Description("Workspace id, alias, or human name")),
+		mcp.WithNumber("limit", mcp.Description("Max events to return, newest first (default 30, 0 = all kept)")),
+	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
+		return mcpSessionEvents(r.GetString("workspace", ""), r.GetInt("limit", 30))
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_worktrees_materialize",
@@ -386,6 +398,24 @@ func mcpSessionStop(query string) (any, error) {
 	return map[string]any{
 		"workspaceId": w.ID, "state": "stopping", "commandId": c.ID,
 		"hint": "poll corgi_agent_status to confirm it stopped",
+	}, nil
+}
+
+func mcpSessionEvents(query string, limit int) (any, error) {
+	w, ambiguous, err := resolveForSession(query)
+	if err != nil {
+		return nil, err
+	}
+	if ambiguous != nil {
+		return ambiguous, nil
+	}
+	dir, err := agentDir()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"workspaceId": w.ID,
+		"events":      events.NewLog(dir).Read(w.ID, limit),
 	}, nil
 }
 

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -314,47 +314,76 @@ func writeLaunchError(w http.ResponseWriter, status int, msg string) {
 // /launch/* endpoints. Every dynamic value is escaped before it reaches the DOM.
 const launcherPageHTML = `<!doctype html>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="dark">
+<meta name="theme-color" content="#0b0d12">
 <title>corgi</title>
 <style>
-  body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e8e8e8;margin:0}
-  header{padding:1.4rem 1.2rem .6rem;font-size:1.3rem;font-weight:600}
-  header small{display:block;color:#9aa0a6;font-size:.8rem;font-weight:400;margin-top:.2rem}
-  main{padding:0 1.2rem 2rem;max-width:34rem;margin:0 auto}
-  .ws{background:#1a1d23;border:1px solid #2a2e37;border-radius:.7rem;padding:.9rem 1rem;margin:.6rem 0;
-      display:flex;align-items:center;justify-content:space-between;gap:.6rem;flex-wrap:wrap}
-  .ws .name{font-weight:600}
-  .sbtn{background:none;border:0;color:#8a90a6;font-size:.72rem;font-weight:600;cursor:pointer;
-      padding:.2rem 0;margin-top:.25rem}
-  .sessions{flex-basis:100%;margin-top:.5rem;border-top:1px solid #2a2e37;padding-top:.5rem}
-  .sessions .s{display:flex;justify-content:space-between;gap:.6rem;font-size:.76rem;color:#c8cdd6;padding:.22rem 0}
-  .sessions .s .when{color:#8a90a6;font-size:.7rem;flex:0 0 auto}
-  .sessions .none{color:#8a90a6;font-size:.74rem}
-  .ws .path{color:#8a90a6;font-size:.72rem;word-break:break-all;margin-top:.15rem}
-  .ws .wnote{color:#ff7b72;font-size:.72rem;margin-top:.3rem;line-height:1.4}
-  .dot{width:.55rem;height:.55rem;border-radius:50%;background:#3a3f4b;flex:0 0 auto}
-  .dot.on{background:#7ee787}
-  button{border:0;border-radius:.55rem;padding:.5rem .9rem;font-size:.85rem;font-weight:600;cursor:pointer;
-      background:#e8e8e8;color:#0f1115}
+  :root{--bg:#0b0d12;--card:#161a23;--card2:#11151d;--line:#262c3a;--text:#e9ecf1;
+      --dim:#8b93a7;--dim2:#6b7285;--green:#7ee787;--amber:#ffa657;--red:#ff7b72}
+  *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
+  body{font-family:-apple-system,system-ui,sans-serif;background:var(--bg);color:var(--text);margin:0;
+      padding-bottom:env(safe-area-inset-bottom);-webkit-font-smoothing:antialiased}
+  header{padding:calc(1.2rem + env(safe-area-inset-top)) 1.2rem .3rem;max-width:34rem;margin:0 auto}
+  .brand{display:flex;align-items:center;gap:.7rem}
+  .logo{width:2.6rem;height:2.6rem;border-radius:.9rem;background:linear-gradient(135deg,#1e2634,#131824);
+      border:1px solid var(--line);display:flex;align-items:center;justify-content:center;font-size:1.35rem;flex:0 0 auto}
+  h1{font-size:1.25rem;margin:0;letter-spacing:.01em}
+  header small{display:block;color:var(--dim);font-size:.78rem;font-weight:400;margin-top:.1rem}
+  main{padding:.4rem 1.2rem 2.2rem;max-width:34rem;margin:0 auto}
+  .ws{background:var(--card);border:1px solid var(--line);border-radius:1rem;padding:1rem 1.05rem;margin:.7rem 0;
+      display:flex;align-items:center;justify-content:space-between;gap:.7rem;flex-wrap:wrap;
+      box-shadow:0 1px 3px rgba(0,0,0,.3)}
+  .ws .name{font-weight:650;display:flex;align-items:center;gap:.5rem;font-size:.98rem}
+  .ws .path{color:var(--dim2);font-size:.7rem;word-break:break-all;margin-top:.2rem;
+      font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  .ws .wnote{color:var(--red);font-size:.72rem;margin-top:.35rem;line-height:1.45}
+  .dot{width:.55rem;height:.55rem;border-radius:50%;background:#3a4152;flex:0 0 auto}
+  .dot.on{background:var(--green);box-shadow:0 0 0 3px rgba(126,231,135,.14),0 0 8px rgba(126,231,135,.45)}
+  .sbtn{background:none;border:0;color:var(--dim);font-size:.72rem;font-weight:650;cursor:pointer;
+      padding:.25rem 0 0;margin-top:.3rem}
+  .sessions{flex-basis:100%;margin-top:.6rem;border-top:1px solid var(--line);padding-top:.55rem}
+  .sessions .s{display:flex;align-items:center;justify-content:space-between;gap:.6rem;font-size:.76rem;
+      color:#c9cfda;padding:.34rem .1rem;text-decoration:none}
+  a.s span:first-child{color:var(--green)}
+  .sessions .s .when{color:var(--dim2);font-size:.68rem;flex:0 0 auto}
+  .sessions .none,.sessions .hint{color:var(--dim2);font-size:.7rem;line-height:1.45;padding:.2rem 0}
+  .tag{font-size:.6rem;font-weight:700;color:var(--amber);border:1px solid rgba(255,166,87,.4);
+      border-radius:.35rem;padding:.05rem .3rem;margin-left:.45rem;vertical-align:1px}
+  button{border:0;border-radius:.65rem;padding:.55rem 1rem;font-size:.85rem;font-weight:650;cursor:pointer;
+      background:#232a39;color:var(--text);transition:transform .05s}
+  button:active{transform:scale(.97)}
   button:disabled{opacity:.5}
-  a.open,button.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;border:0;
-      padding:.5rem .9rem;border-radius:.55rem;font-weight:600;font-size:.85rem;cursor:pointer}
-  .right{display:flex;flex-direction:column;align-items:flex-end;gap:.35rem}
-  .modes{display:flex;gap:.3rem;font-size:.68rem;color:#8a90a6;align-items:center}
-  .modes span{margin-right:.1rem}
-  .modes .m{background:#12151b;border:1px solid #2a2e37;color:#9aa0a6;border-radius:.4rem;
-      padding:.12rem .4rem;font-size:.68rem;font-weight:600}
-  .modes .m.sel{background:#2a2e37;color:#e8e8e8;border-color:#3a3f4b}
-  .msg{color:#9aa0a6;font-size:.9rem;margin:1rem 0}
-  .err{color:#ff7b72}
-  code{background:#1a1d23;padding:.1rem .3rem;border-radius:.3rem}
-  details.settings{margin:1.6rem 0 0;border-top:1px solid #2a2e37;padding-top:1rem}
-  details.settings summary{color:#9aa0a6;font-size:.85rem;cursor:pointer}
-  details.settings p{color:#8a90a6;font-size:.78rem;line-height:1.5}
-  pre{background:#1a1d23;border:1px solid #2a2e37;border-radius:.5rem;padding:.7rem;
-      overflow-x:auto;font-size:.72rem;line-height:1.4;white-space:pre;color:#c8cdd6}
+  a.open,button.open{display:inline-block;background:var(--green);color:#08110a;text-decoration:none;border:0;
+      padding:.55rem 1rem;border-radius:.65rem;font-weight:700;font-size:.85rem;cursor:pointer}
+  .right{display:flex;flex-direction:column;align-items:flex-end;gap:.45rem}
+  .modes{display:flex;font-size:.68rem;color:var(--dim);align-items:center;background:var(--card2);
+      border:1px solid var(--line);border-radius:.55rem;padding:.14rem}
+  .modes span{padding:0 .3rem 0 .45rem;font-size:.64rem}
+  .modes .m{background:none;border:1px solid transparent;color:var(--dim);border-radius:.42rem;
+      padding:.2rem .5rem;font-size:.68rem;font-weight:650}
+  .modes .m.sel{background:#2b3345;color:var(--text)}
+  .msg{color:var(--dim);font-size:.9rem;margin:1rem 0;line-height:1.5}
+  .err{color:var(--red)}
+  code{background:var(--card);border:1px solid var(--line);padding:.1rem .35rem;border-radius:.35rem;font-size:.85em}
+  details.settings{margin:1.8rem 0 0;background:var(--card2);border:1px solid var(--line);
+      border-radius:1rem;padding:.4rem 1rem}
+  details.settings summary{color:var(--dim);font-size:.85rem;cursor:pointer;padding:.5rem 0;list-style:none}
+  details.settings summary::-webkit-details-marker{display:none}
+  details.settings p{color:var(--dim);font-size:.76rem;line-height:1.55}
+  label.toggle{display:flex;align-items:center;gap:.5rem;color:var(--dim);font-size:.78rem;
+      padding:.3rem 0 .7rem;cursor:pointer}
+  label.toggle input{accent-color:var(--green);width:1rem;height:1rem;margin:0}
+  pre{background:var(--bg);border:1px solid var(--line);border-radius:.6rem;padding:.7rem;
+      overflow-x:auto;font-size:.7rem;line-height:1.45;white-space:pre;color:#c9cfda}
+  .foot{text-align:center;margin-top:1.6rem;font-size:.85rem}
+  .foot a{color:var(--green);text-decoration:none}
 </style>
-<header>🐕 corgi<small id="host">your machine</small></header>
+<header>
+  <div class="brand"><span class="logo">🐕</span>
+    <div><h1>corgi</h1><small id="host">your machine</small></div>
+  </div>
+</header>
 <main>
   <div id="list" class="msg">Loading…</div>
   <details class="settings" id="settings" hidden>
@@ -364,9 +393,11 @@ const launcherPageHTML = `<!doctype html>
     <button id="copycfg">Copy connector config</button>
     <p id="copymsg" class="msg"></p>
     <p>Each workspace above has an <b>open in</b> switch — <b>app</b> deep-links into the Claude app; <b>browser</b> keeps the session here in this browser; <b>chrome</b> forces Chrome via its URL scheme (needs Chrome installed) — right for a workspace on a different Claude account than the app is signed into. Remembered per workspace, on this browser only.</p>
+    <label class="toggle"><input type="checkbox" id="showbridges"> Show hand-started (bridge) sessions</label>
+    <p>A <b>bridge</b> is a remote-control session someone started on the laptop itself. Its claude.ai page shows only what you send from it — until then it looks empty. The full transcript stays on the laptop.</p>
   </details>
-  <p class="msg" style="text-align:center;margin-top:1.4rem">
-    <a id="allsessions" target="_blank" rel="noopener" style="color:#7ee787;text-decoration:none">See all your sessions on claude.ai ↗</a>
+  <p class="foot">
+    <a id="allsessions" target="_blank" rel="noopener">See all your sessions on claude.ai ↗</a>
   </p>
 </main>
 <script>
@@ -388,6 +419,8 @@ const launcherPageHTML = `<!doctype html>
   let lastWorkspaces = [];
   const openMode = id => { try { return localStorage.getItem('corgi_open_' + id) || 'app'; } catch { return 'app'; } };
   const setOpenMode = (id, m) => { try { localStorage.setItem('corgi_open_' + id, m); } catch {} };
+  const showBridges = () => { try { return localStorage.getItem('corgi_show_bridges') !== '0'; } catch { return true; } };
+  const setShowBridges = on => { try { localStorage.setItem('corgi_show_bridges', on ? '1' : '0'); } catch {} };
 
   if (!token) {
     list.className = 'msg';
@@ -409,6 +442,9 @@ const launcherPageHTML = `<!doctype html>
       try { await navigator.clipboard.writeText(connector); msg.textContent = '✓ Copied'; }
       catch { msg.textContent = 'Long-press the box above to copy.'; }
     };
+    const bridges = document.getElementById('showbridges');
+    bridges.checked = showBridges();
+    bridges.onchange = () => setShowBridges(bridges.checked);
   }
 
   async function load() {
@@ -470,21 +506,27 @@ const launcherPageHTML = `<!doctype html>
     // Openable links come ONLY from the per-session URLs remote control printed
     // (captured by the daemon). Ids from the claude CLI are local UUIDs the
     // site does not resolve; those rows render below as plain status, no link.
-    const renderLink = (url) => {
+    const renderLink = (url, isBridge) => {
       const el = document.createElement('a');
       el.className = 's';
       el.href = url; el.target = '_blank'; el.rel = 'noopener noreferrer';
       const m = openMode(ws.id);
       if (m === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
       if (m === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(url); };
-      el.innerHTML = '<span>' + esc(url.split('/').pop().slice(0, 18)) + '\u2026</span><span class="when">open \u2197</span>';
+      const tag = isBridge ? '<span class="tag" title="Hand-started on the laptop \u2014 its web page may look empty">bridge</span>' : '';
+      el.innerHTML = '<span>' + esc(url.split('/').pop().slice(0, 18)) + '\u2026' + tag + '</span><span class="when">open \u2197</span>';
+      box.appendChild(el);
+    };
+    const note = (text) => {
+      const el = document.createElement('div');
+      el.className = 'hint'; el.textContent = text;
       box.appendChild(el);
     };
     // Captured from corgi-supervised output; the fetch below adds bridge
     // pointers from disk, which cover hand-started remote-control sessions.
     const shown = new Set();
     const links = (ws.sessionLinks || []).filter(safeClaudeUrl);
-    for (const url of links.slice().reverse()) { shown.add(url); renderLink(url); }
+    for (const url of links.slice().reverse()) { shown.add(url); renderLink(url, false); }
     const info = document.createElement('div');
     info.className = 'none'; info.textContent = 'Loading\u2026';
     box.appendChild(info);
@@ -492,11 +534,15 @@ const launcherPageHTML = `<!doctype html>
       const r = await fetch('/launch/sessions?workspace=' + encodeURIComponent(ws.id), { headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      for (const url of (j.links || []).filter(safeClaudeUrl)) {
-        if (!shown.has(url)) { shown.add(url); renderLink(url); }
+      const bridges = (j.links || []).filter(safeClaudeUrl).filter(u => !shown.has(u));
+      if (showBridges()) {
+        for (const url of bridges) { shown.add(url); renderLink(url, true); }
+        if (bridges.length) note('bridge = started by hand on the laptop; its page shows only what you send from it.');
+      } else if (bridges.length) {
+        note(bridges.length + ' bridge session' + (bridges.length > 1 ? 's' : '') + ' hidden \u2014 enable in Settings.');
       }
       const s = j.sessions || [];
-      if (!s.length && !shown.size) { info.textContent = 'No sessions yet for this workspace.'; return; }
+      if (!s.length && !shown.size && !bridges.length) { info.textContent = 'No sessions yet for this workspace.'; return; }
       info.remove();
       for (const sess of s) {
         const el = document.createElement('div');
@@ -548,7 +594,9 @@ const launcherPageHTML = `<!doctype html>
     const cur = openMode(id);
     const wrap = document.createElement('div');
     wrap.className = 'modes';
-    wrap.appendChild(document.createTextNode('open in:'));
+    const lbl = document.createElement('span');
+    lbl.textContent = 'open in';
+    wrap.appendChild(lbl);
     for (const m of ['app', 'browser', 'chrome']) {
       const b = document.createElement('button');
       b.className = 'm' + (cur === m ? ' sel' : '');

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -16,6 +16,7 @@ import (
 
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
+	"andriiklymiuk/corgi/utils/agent/events"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
@@ -136,6 +137,31 @@ func launchStartHandler(w http.ResponseWriter, r *http.Request) {
 	writeLaunchJSON(w, result)
 }
 
+func launchStopHandler(w http.ResponseWriter, r *http.Request) {
+	setLaunchHeaders(w)
+	if r.Method != http.MethodPost {
+		writeLaunchError(w, http.StatusMethodNotAllowed, "POST {workspace} to stop")
+		return
+	}
+	var req struct {
+		Workspace string `json:"workspace"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&req); err != nil {
+		writeLaunchError(w, http.StatusBadRequest, "could not read the stop request")
+		return
+	}
+	if strings.TrimSpace(req.Workspace) == "" {
+		writeLaunchError(w, http.StatusBadRequest, "a workspace is required")
+		return
+	}
+	result, err := mcpSessionStop(req.Workspace)
+	if err != nil {
+		writeLaunchError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeLaunchJSON(w, result)
+}
+
 // claudeSession is one entry from `claude agents --json`.
 type claudeSession struct {
 	Name      string `json:"name"`
@@ -169,7 +195,33 @@ func launchSessionsHandler(w http.ResponseWriter, r *http.Request) {
 	writeLaunchJSON(w, map[string]any{
 		"sessions": listClaudeSessions(absPath, configDir),
 		"links":    bridgeSessionLinks(absPath, configDir),
+		"history":  sessionHistory(id),
 	})
+}
+
+type launchHistoryEntry struct {
+	URL string `json:"url"`
+	At  int64  `json:"at"`
+}
+
+func sessionHistory(workspaceID string) []launchHistoryEntry {
+	dir, err := agentDir()
+	if err != nil {
+		return []launchHistoryEntry{}
+	}
+	seen := map[string]bool{}
+	out := []launchHistoryEntry{}
+	for _, e := range events.NewLog(dir).Read(workspaceID, 0) {
+		if e.Kind != "session" || e.URL == "" || seen[e.URL] {
+			continue
+		}
+		seen[e.URL] = true
+		out = append(out, launchHistoryEntry{URL: e.URL, At: e.At.UnixMilli()})
+		if len(out) >= 20 {
+			break
+		}
+	}
+	return out
 }
 
 // workspaceSessionTarget resolves a workspace id to its directory and the Claude
@@ -357,6 +409,8 @@ const launcherPageHTML = `<!doctype html>
   a.open,button.open{display:inline-block;background:var(--green);color:#08110a;text-decoration:none;border:0;
       padding:.55rem 1rem;border-radius:.65rem;font-weight:700;font-size:.85rem;cursor:pointer}
   .right{display:flex;flex-direction:column;align-items:flex-end;gap:.45rem}
+  button.stopb{background:none;border:1px solid rgba(255,123,114,.45);color:var(--red);
+      padding:.3rem .7rem;font-size:.72rem;border-radius:.5rem}
   .modes{display:flex;font-size:.68rem;color:var(--dim);align-items:center;background:var(--card2);
       border:1px solid var(--line);border-radius:.55rem;padding:.14rem}
   .modes span{padding:0 .3rem 0 .45rem;font-size:.64rem}
@@ -395,6 +449,7 @@ const launcherPageHTML = `<!doctype html>
     <p>Each workspace above has an <b>open in</b> switch — <b>app</b> deep-links into the Claude app; <b>browser</b> keeps the session here in this browser; <b>chrome</b> forces Chrome via its URL scheme (needs Chrome installed) — right for a workspace on a different Claude account than the app is signed into. Remembered per workspace, on this browser only.</p>
     <label class="toggle"><input type="checkbox" id="showbridges"> Show hand-started (bridge) sessions</label>
     <p>A <b>bridge</b> is a remote-control session someone started on the laptop itself. Its claude.ai page shows only what you send from it — until then it looks empty. The full transcript stays on the laptop.</p>
+    <p><b>Push notifications.</b> Set <code>notifyUrl</code> in the agent config on the laptop (for example an ntfy.sh topic you subscribe to in the ntfy app) and every session restart or failure reaches your phone. See <code>corgi agent doctor</code> and the agent docs.</p>
   </details>
   <p class="foot">
     <a id="allsessions" target="_blank" rel="noopener">See all your sessions on claude.ai ↗</a>
@@ -494,6 +549,7 @@ const launcherPageHTML = `<!doctype html>
         b.onclick = () => startSession(ws.id, b);
         right.appendChild(b);
       }
+      if (ws.running) right.appendChild(stopControl(ws.id));
       row.appendChild(left); row.appendChild(right); row.appendChild(sessionsBox);
       list.appendChild(row);
     }
@@ -506,7 +562,7 @@ const launcherPageHTML = `<!doctype html>
     // Openable links come ONLY from the per-session URLs remote control printed
     // (captured by the daemon). Ids from the claude CLI are local UUIDs the
     // site does not resolve; those rows render below as plain status, no link.
-    const renderLink = (url, isBridge) => {
+    const renderLink = (url, isBridge, when) => {
       const el = document.createElement('a');
       el.className = 's';
       el.href = url; el.target = '_blank'; el.rel = 'noopener noreferrer';
@@ -514,7 +570,8 @@ const launcherPageHTML = `<!doctype html>
       if (m === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
       if (m === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(url); };
       const tag = isBridge ? '<span class="tag" title="Hand-started on the laptop \u2014 its web page may look empty">bridge</span>' : '';
-      el.innerHTML = '<span>' + esc(url.split('/').pop().slice(0, 18)) + '\u2026' + tag + '</span><span class="when">open \u2197</span>';
+      el.innerHTML = '<span>' + esc(url.split('/').pop().slice(0, 18)) + '\u2026' + tag + '</span><span class="when">' +
+        esc(when || '') + 'open \u2197</span>';
       box.appendChild(el);
     };
     const note = (text) => {
@@ -541,6 +598,8 @@ const launcherPageHTML = `<!doctype html>
       } else if (bridges.length) {
         note(bridges.length + ' bridge session' + (bridges.length > 1 ? 's' : '') + ' hidden \u2014 enable in Settings.');
       }
+      const past = (j.history || []).filter(h => h && safeClaudeUrl(h.url) && !shown.has(h.url));
+      for (const h of past) { shown.add(h.url); renderLink(h.url, false, fmtWhen(h.at) + ' \u00b7 '); }
       const s = j.sessions || [];
       if (!s.length && !shown.size && !bridges.length) { info.textContent = 'No sessions yet for this workspace.'; return; }
       info.remove();
@@ -605,6 +664,27 @@ const launcherPageHTML = `<!doctype html>
       wrap.appendChild(b);
     }
     return wrap;
+  }
+
+  function stopControl(id) {
+    const b = document.createElement('button');
+    b.className = 'stopb'; b.textContent = 'Stop';
+    b.onclick = async () => {
+      b.disabled = true; b.textContent = 'Stopping…';
+      try {
+        const r = await fetch('/launch/stop', { method: 'POST', headers: auth,
+          body: JSON.stringify({ workspace: id }) });
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.error || r.status);
+        setTimeout(load, 1200);
+      } catch (e) {
+        b.disabled = false; b.textContent = 'Stop';
+        const err = document.createElement('div');
+        err.className = 'msg err'; err.textContent = '✗ ' + e.message;
+        b.parentElement.appendChild(err);
+      }
+    };
+    return b;
   }
 
   async function startSession(id, btn) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.20.43"
+var APP_VERSION = "1.20.44"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -122,6 +122,7 @@ corgi agent serve --foreground   # run it in this terminal and watch
 | `corgi agent workspaces` | list, `forget`, `relocate` |
 | `corgi agent resolve <name>` | what "the recipe app" resolves to |
 | `corgi agent brief [id]` | what the last session was working on before it restarted |
+| `corgi agent logs <workspace>` | the session timeline: starts, exits and why, links |
 | `corgi agent stop` | stop the daemon |
 
 ## Restarts, and being told about them
@@ -134,6 +135,37 @@ reboot. corgi restarts it with capped backoff and **says so**:
 The notification matters. A relaunched Remote Control starts a **new** session,
 so the previous conversation's context is gone. Restarting silently would look
 like continuity and cost you an hour of confusion.
+
+### Notifications on your phone
+
+By default notifications are desktop only. Add a `notifyUrl` to the trusted
+agent config and every one is also POSTed there — title in the `Title` header,
+body as plain text, which is exactly what [ntfy.sh](https://ntfy.sh) topics
+expect:
+
+```yaml
+# <agent data dir>/config.yml
+notifyUrl: https://ntfy.sh/your-private-topic
+```
+
+Subscribe to the topic in the ntfy app and session failures reach your phone
+even when the launcher page is closed. Trusted config only: the URL receives
+restart reasons, so a committed repo file can never set it.
+
+### The timeline
+
+Every start, exit (with its classified cause), disable, and captured session
+link is appended to a small per-workspace timeline — never session output,
+which can hold secrets and is not persisted:
+
+```bash
+corgi agent logs api            # newest first: started, exited · why, links
+corgi agent logs api --json     # same, for scripts and agents
+```
+
+The launcher's per-workspace session list is fed from the same timeline, so
+past sessions survive daemon restarts, and the `corgi_session_events` MCP tool
+exposes it to a connected Claude.
 
 ### The handover brief
 
@@ -355,12 +387,13 @@ Leave it off (the default) for anything you would not let run unattended.
 
 ## The MCP tools
 
-`corgi mcp` gains ten tools. A Remote Control session calls them from your
+`corgi mcp` gains eleven tools. A Remote Control session calls them from your
 phone; they also work from any other MCP client.
 
 | tool | what it does |
 |---|---|
 | `corgi_session_brief` | what the previous session was working on before it restarted |
+| `corgi_session_events` | the workspace timeline: starts, exits and why, session links |
 | `corgi_workspaces` | every stack registered on this machine |
 | `corgi_workspace_resolve` | "the recipe app" → one stack, or candidates |
 | `corgi_worktrees_materialize` | a worktree per repo, all on one branch |

--- a/docs/remote-app.md
+++ b/docs/remote-app.md
@@ -21,8 +21,16 @@ What is left is the half Remote Control has no concept of:
 | is the agent daemon up, under which account | no | **yes** |
 | which stacks exist, on which machine | no | **yes** |
 | stack health, ports, start/stop, logs | no | **yes** |
+| start/stop a session in any registered workspace | no | **yes** |
+| per-workspace session timeline across restarts | no | **yes** |
+| session failure push (via `notifyUrl`) | no | **yes** |
 | **cross-repo diff** | no | **yes** |
 | live preview: URL, state, freeze, TTL | no | **yes** |
+
+The session rows are machine-scoped, which is why they belong here: claude.ai
+lists sessions per *account*, corgi's timeline lists them per *workspace on a
+machine*, with the daemon's exit reasons attached. The launcher page (`/app`)
+already ships that view in a browser; the app is its multi-machine version.
 
 Two apps side by side: Claude for the conversation, corgi-remote for the
 machine. That division is what keeps this small enough to finish.
@@ -46,9 +54,15 @@ corgi already speaks a protocol the app can use. Do not invent a second one.
         ├─► corgi_status / _ps        service health, ports
         ├─► corgi_up / _down          start and stop the stack
         ├─► corgi_logs                tail a service
+        ├─► corgi_session_start/_stop start a session anywhere, end it
+        ├─► corgi_session_events      the timeline: starts, exits and why, links
         ├─► corgi_diff                cross-repo change  ← the payoff screen
         └─► corgi_preview_*           URL, state, freeze, teardown
 ```
+
+The `/launch/*` REST endpoints behind the same bearer token mirror the session
+tools for the launcher page. The app uses the MCP tools — one protocol, typed
+once — and leaves `/launch/*` to the browser.
 
 Three consequences worth stating:
 
@@ -96,10 +110,53 @@ endpoint reachable — working insecurely is worse than not working.
 Try LAN first, fall back to the tunnel. **Show connection state honestly** —
 *"last seen 4m ago"* beats a green dot that lies.
 
+## Multiple machines
+
+The app's core model is a list of machines, each paired independently:
+
+```
+machine = { name, lanUrl?, tunnelUrl, deviceToken }   ← token in secure store
+```
+
+- Pairing is per machine (each runs its own `corgi mcp`); adding a laptop is
+  scanning one more QR. Revocation stays per machine + per device.
+- The home screen aggregates: every workspace from every reachable machine,
+  grouped by machine, with per-machine connection state. A machine that is
+  asleep renders as *"last seen …"*, its workspaces greyed but listed — the
+  registry outlives the connection.
+- No cross-machine server, no sync: the phone is the only place the list
+  exists, which is exactly the trust model of a remote control.
+- Same workspace name on two machines is fine — everything is keyed
+  (machine, workspace), never workspace alone.
+
+## Notifications
+
+corgi's daemon can now POST every notification (restarts, failures, remote
+starts) to a `notifyUrl` — title in the `Title` header, plain-text body, the
+[ntfy](https://ntfy.sh) contract. That gives three tiers, in build order:
+
+1. **None (v1):** the app polls while open. Remote Control keeps pushing the
+   conversation-side notifications that matter most.
+2. **ntfy app (zero code):** the user sets `notifyUrl` to a private topic and
+   subscribes in the ntfy app. Documented in agent.md; nothing for
+   corgi-remote to build.
+3. **In-app (later, still no server):** the app subscribes to the same topics
+   itself over ntfy's SSE/WebSocket API, one subscription per machine, so
+   machine alerts land in the same app that can act on them. Self-hosted ntfy
+   works unchanged for people who do not want a third party in the path.
+
+Native APNs/FCM push stays a non-goal: it is the tier that needs server
+infrastructure, credentials, and a token lifecycle, for latency ntfy already
+delivers.
+
 ## Screens
 
-Six. Anything beyond these is scope creep.
+Seven. Anything beyond these is scope creep.
 
+0. **Sessions** — per workspace: Start (with profile picker), Stop, and the
+   timeline from `corgi_session_events` — each captured link opens the
+   conversation in the Claude app, each exit shows its reason. This is the
+   launcher page as a native screen, across machines.
 1. **Daemons** — one card per paired daemon, from `corgi_agent_status`. Surface
    the **Claude account per workspace**: this is the one place the app can catch
    agent mode's silent wrong-account failure, and it costs one line. Show
@@ -127,18 +184,20 @@ Expo + TypeScript, `expo-router`, TanStack Query, `@modelcontextprotocol/sdk`,
 Deliberately absent: Redux, GraphQL, code generation, an offline write queue, a
 design system. This app polls JSON and renders it.
 
-**Polling, not push.** There is no push channel, and building one means a server
-component, APNs/FCM credentials, and a token lifecycle. Remote Control already
-pushes the notifications that matter. Poll every few seconds on a screen that
-needs it, back off when idle, stop on background.
+**Polling for state, ntfy for push.** Poll every few seconds on a screen that
+needs it, back off when idle, stop on background. Alerts arrive through the
+notifyUrl tiers above — never through a bespoke push server.
 
 ## Build order
 
-**D1 — pair and see.** Pairing, daemon list, honest connection state.
+**D1 — pair and see.** Pairing (multi-machine from day one), daemon list,
+honest connection state.
 **D2 — diff.** *This milestone decides whether the app is worth continuing.*
-**D3 — workspaces and control.** Health, ports, start/stop.
-**D4 — preview and logs.**
-**D5 — background/foreground, error states, provisioning.**
+**D3 — sessions.** Start/stop + timeline; the launcher page stops being needed.
+**D4 — workspaces and control.** Health, ports, start/stop.
+**D5 — preview and logs.**
+**D6 — in-app ntfy subscriptions, background/foreground, error states,
+provisioning.**
 
 **Decide iOS provisioning before D1.** A free Apple account rebuilds every seven
 days, which turns a personal tool into a weekly chore and is how projects like

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.20.43",
+  "version": "1.20.44",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -160,7 +160,10 @@ user has work and personal logins, check it.
 
 ### If a session died
 
-`corgi agent status` shows `lastReason`. The common ones:
+`corgi agent status` shows `lastReason`, and `corgi agent logs <workspace>`
+(or the `corgi_session_events` tool) shows the whole timeline — every start,
+exit with its classified cause, and captured session link, newest first. Use
+the timeline when the current reason is not enough. The common reasons:
 
 | reason | what to say |
 |---|---|
@@ -191,6 +194,8 @@ corgi_session_start { "workspace": "the recipe app", "profile": "work" }
   `corgi agent session stop <name>`.
 - Every remote start and stop raises a desktop notification on the laptop, by
   design — the machine's owner always sees what began running.
+- Phone push for those notifications: set `notifyUrl` in the trusted agent
+  config (an ntfy.sh topic works out of the box). See docs/agent.md.
 
 ### Setting it up from a session on the laptop
 

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -49,6 +49,8 @@ type UserConfig struct {
 	Version    int                        `yaml:"version"`
 	Workspaces map[string]WorkspaceConfig `yaml:"workspaces"`
 	Defaults   WorkspaceConfig            `yaml:"defaults"`
+	// NotifyUrl gets a POST per daemon notification; trusted config only.
+	NotifyUrl string `yaml:"notifyUrl"`
 	// Profiles are named setting bundles pickable at session-start time —
 	// "work", "personal" — for running one workspace under different Claude
 	// accounts. Trusted like everything else here: a remote caller sends only

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -17,6 +17,7 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/brief"
 	"andriiklymiuk/corgi/utils/agent/command"
+	"andriiklymiuk/corgi/utils/agent/events"
 	"andriiklymiuk/corgi/utils/agent/supervisor"
 )
 
@@ -70,6 +71,7 @@ type Daemon struct {
 	Start supervisor.Starter
 	// Notify reports restarts. Defaults to corgi's desktop notification.
 	Notify func(title, body string)
+	Events *events.Log
 	// CaptureBrief probes what an ending session left on disk. Injected because
 	// enumerating a stack's repositories means parsing a compose file, which the
 	// daemon has no business knowing about. Nil disables briefs entirely.
@@ -109,8 +111,17 @@ func New(version, dir string) *Daemon {
 		Dir:           dir,
 		Start:         supervisor.StartProcess,
 		Notify:        utils.Notify,
+		Events:        events.NewLog(dir),
 		publishSignal: make(chan struct{}, 1),
 		nudge:         make(chan struct{}, 1),
+	}
+}
+
+func (d *Daemon) recordEvent(workspaceID string) func(supervisor.RunEvent) {
+	return func(e supervisor.RunEvent) {
+		d.Events.Append(workspaceID, events.Event{
+			Kind: e.Kind, PID: e.PID, Cause: e.Cause, Reason: e.Reason, URL: e.URL,
+		})
 	}
 }
 
@@ -367,6 +378,7 @@ func (d *Daemon) buildRunners(configs []supervisor.SpawnConfig) {
 		r.Notify = d.Notify
 		r.OnChange = d.requestPublish
 		r.OnSessionEnd = d.sessionEndHook(cfg, r)
+		r.OnEvent = d.recordEvent(cfg.WorkspaceID)
 		d.runners = append(d.runners, r)
 		d.diags = append(d.diags, diagnose(cfg, env))
 	}
@@ -461,6 +473,7 @@ func (d *Daemon) startWorkspace(ctx context.Context, c command.Command, launch f
 	r.Notify = d.Notify
 	r.OnChange = d.requestPublish
 	r.OnSessionEnd = d.sessionEndHook(cfg, r)
+	r.OnEvent = d.recordEvent(cfg.WorkspaceID)
 	d.replaceRunner(r, diagnose(cfg, os.Environ()))
 	launch(r)
 	d.announceRemote(c, "session started remotely")

--- a/utils/agent/events/events.go
+++ b/utils/agent/events/events.go
@@ -1,0 +1,125 @@
+// Package events keeps a small per-workspace timeline of supervisor lifecycle
+// events. It never records session output, which can carry secrets.
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Event struct {
+	At     time.Time `json:"at"`
+	Kind   string    `json:"kind"`
+	PID    int       `json:"pid,omitempty"`
+	Cause  string    `json:"cause,omitempty"`
+	Reason string    `json:"reason,omitempty"`
+	URL    string    `json:"url,omitempty"`
+}
+
+const (
+	maxFileBytes = 64 << 10
+	maxKeep      = 200
+)
+
+type Log struct {
+	dir string
+	mu  sync.Mutex
+}
+
+func NewLog(dir string) *Log {
+	return &Log{dir: filepath.Join(dir, "events")}
+}
+
+func (l *Log) Append(workspaceID string, e Event) {
+	if l == nil || workspaceID == "" {
+		return
+	}
+	if e.At.IsZero() {
+		e.At = time.Now()
+	}
+	line, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := os.MkdirAll(l.dir, 0o700); err != nil {
+		return
+	}
+	path := l.path(workspaceID)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	_, werr := f.Write(append(line, '\n'))
+	_ = f.Close()
+	if werr != nil {
+		return
+	}
+	l.trimLocked(path)
+}
+
+func (l *Log) trimLocked(path string) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() <= maxFileBytes {
+		return
+	}
+	lines := readLines(path)
+	if len(lines) > maxKeep {
+		lines = lines[len(lines)-maxKeep:]
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}
+
+func (l *Log) Read(workspaceID string, limit int) []Event {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	lines := readLines(l.path(workspaceID))
+	l.mu.Unlock()
+
+	out := make([]Event, 0, len(lines))
+	for i := len(lines) - 1; i >= 0; i-- {
+		var e Event
+		if json.Unmarshal([]byte(lines[i]), &e) != nil {
+			continue
+		}
+		out = append(out, e)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func (l *Log) path(workspaceID string) string {
+	return filepath.Join(l.dir, sanitizeID(workspaceID)+".jsonl")
+}
+
+func sanitizeID(id string) string {
+	return strings.NewReplacer("/", "-", "\\", "-", ":", "-", "..", "-").Replace(id)
+}
+
+func readLines(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) > 0 {
+			out = append(out, string(line))
+		}
+	}
+	return out
+}

--- a/utils/agent/events/events_test.go
+++ b/utils/agent/events/events_test.go
@@ -75,6 +75,63 @@ func TestWorkspaceIDCannotEscapeTheDir(t *testing.T) {
 	}
 }
 
+func TestAppendEmptyWorkspaceIsIgnored(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLog(dir)
+	l.Append("", Event{Kind: "started"})
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) != 0 {
+		t.Errorf("an empty id must write nothing, found %v", entries)
+	}
+}
+
+func TestAppendSurvivesUnwritableDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "events"), []byte("a file, not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	l := NewLog(dir)
+	l.Append("acme", Event{Kind: "started"})
+	if got := l.Read("acme", 0); len(got) != 0 {
+		t.Errorf("append must be a no-op when the dir cannot exist, got %v", got)
+	}
+}
+
+func TestAppendSurvivesUnopenableFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "events", "acme.jsonl"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	l := NewLog(dir)
+	l.Append("acme", Event{Kind: "started"})
+	if got := l.Read("acme", 0); len(got) != 0 {
+		t.Errorf("append must be a no-op when the file cannot open, got %v", got)
+	}
+}
+
+func TestReadSkipsMalformedLines(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLog(dir)
+	l.Append("acme", Event{Kind: "started"})
+	path := filepath.Join(dir, "events", "acme.jsonl")
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("{torn write\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	l.Append("acme", Event{Kind: "exited"})
+
+	got := l.Read("acme", 0)
+	if len(got) != 2 {
+		t.Fatalf("events = %+v, want the 2 valid entries", got)
+	}
+	if got[0].Kind != "exited" || got[1].Kind != "started" {
+		t.Errorf("order = %v, %v", got[0].Kind, got[1].Kind)
+	}
+}
+
 func TestNilLogIsSafe(t *testing.T) {
 	var l *Log
 	l.Append("acme", Event{Kind: "started"})

--- a/utils/agent/events/events_test.go
+++ b/utils/agent/events/events_test.go
@@ -1,0 +1,93 @@
+package events
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppendAndReadNewestFirst(t *testing.T) {
+	l := NewLog(t.TempDir())
+	l.Append("acme", Event{Kind: "started", PID: 42})
+	l.Append("acme", Event{Kind: "session", URL: "https://claude.ai/code/session_01A"})
+	l.Append("acme", Event{Kind: "exited", Cause: "crash", Reason: "boom"})
+
+	got := l.Read("acme", 0)
+	if len(got) != 3 {
+		t.Fatalf("events = %d, want 3", len(got))
+	}
+	if got[0].Kind != "exited" || got[2].Kind != "started" {
+		t.Errorf("order must be newest first, got %v then %v", got[0].Kind, got[2].Kind)
+	}
+	if got[0].At.IsZero() {
+		t.Error("Append must stamp a time")
+	}
+}
+
+func TestReadLimit(t *testing.T) {
+	l := NewLog(t.TempDir())
+	for i := 0; i < 5; i++ {
+		l.Append("acme", Event{Kind: "started"})
+	}
+	if got := l.Read("acme", 2); len(got) != 2 {
+		t.Errorf("limit 2 must cap the result, got %d", len(got))
+	}
+}
+
+func TestMissingFileIsEmpty(t *testing.T) {
+	l := NewLog(t.TempDir())
+	if got := l.Read("nope", 0); len(got) != 0 {
+		t.Errorf("a missing timeline is empty, got %v", got)
+	}
+}
+
+func TestTrimKeepsNewestEntries(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLog(dir)
+	long := strings.Repeat("x", 400)
+	for i := 0; i < 300; i++ {
+		l.Append("acme", Event{Kind: "exited", Reason: long})
+	}
+	info, err := os.Stat(filepath.Join(dir, "events", "acme.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Size() > int64(maxKeep*600) {
+		t.Errorf("file did not trim: %d bytes", info.Size())
+	}
+	if got := l.Read("acme", 0); len(got) > maxKeep {
+		t.Errorf("kept %d entries, cap is %d", len(got), maxKeep)
+	}
+}
+
+func TestWorkspaceIDCannotEscapeTheDir(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLog(dir)
+	l.Append("../evil", Event{Kind: "started"})
+	if _, err := os.Stat(filepath.Join(dir, "evil.jsonl")); err == nil {
+		t.Error("a path-traversal id must not write outside events/")
+	}
+	if got := l.Read("../evil", 0); len(got) != 1 {
+		t.Errorf("the sanitized id must still round-trip, got %d", len(got))
+	}
+}
+
+func TestNilLogIsSafe(t *testing.T) {
+	var l *Log
+	l.Append("acme", Event{Kind: "started"})
+	if got := l.Read("acme", 0); got != nil {
+		t.Errorf("nil log reads empty, got %v", got)
+	}
+}
+
+func TestExplicitTimestampKept(t *testing.T) {
+	l := NewLog(t.TempDir())
+	at := time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC)
+	l.Append("acme", Event{Kind: "started", At: at})
+	if got := l.Read("acme", 1); !got[0].At.Equal(at) {
+		t.Errorf("timestamp rewritten: %v", got[0].At)
+	}
+}

--- a/utils/agent/supervisor/runner.go
+++ b/utils/agent/supervisor/runner.go
@@ -48,6 +48,16 @@ type RunState struct {
 // not grow status.json without limit. Oldest entries fall off first.
 const maxTrackedSessions = 20
 
+// RunEvent carries classification and links only — never process output,
+// which can hold env values and tokens and must not leave this process.
+type RunEvent struct {
+	Kind   string
+	PID    int
+	Cause  string
+	Reason string
+	URL    string
+}
+
 // Runner supervises one workspace's remote-control process.
 type Runner struct {
 	Config   SpawnConfig
@@ -71,6 +81,7 @@ type Runner struct {
 	// OnChange fires after the run state changes, so a watcher can republish
 	// without polling. Called without the lock held.
 	OnChange func()
+	OnEvent  func(RunEvent)
 	// IdleAfter overrides how long the session must be quiet before the idle
 	// wake lock lets the machine sleep. Zero means WakeLockIdleTimeout.
 	IdleAfter time.Duration
@@ -122,7 +133,14 @@ func (r *Runner) addSessionLink(id string) {
 		r.state.Sessions = r.state.Sessions[len(r.state.Sessions)-maxTrackedSessions:]
 	}
 	r.mu.Unlock()
+	r.emit(RunEvent{Kind: "session", URL: url})
 	r.notifyChange()
+}
+
+func (r *Runner) emit(e RunEvent) {
+	if r.OnEvent != nil {
+		r.OnEvent(e)
+	}
 }
 
 // recordActivity stamps the last-output time for the idle wake lock. On the
@@ -407,6 +425,7 @@ func (r *Runner) markRunning(proc Process, startedAt time.Time) {
 	r.state.PID = proc.Pid()
 	r.state.StartedAt = startedAt
 	r.mu.Unlock()
+	r.emit(RunEvent{Kind: "started", PID: proc.Pid()})
 	r.notifyChange()
 }
 
@@ -420,6 +439,11 @@ func (r *Runner) notifyChange() {
 
 func (r *Runner) record(d Decision, pid int, disabled bool) {
 	r.recordLocked(d, pid, disabled)
+	kind := "exited"
+	if disabled {
+		kind = "disabled"
+	}
+	r.emit(RunEvent{Kind: kind, Cause: string(d.Cause), Reason: d.Reason})
 	r.notifyChange()
 }
 

--- a/utils/agent/supervisor/runner_events_test.go
+++ b/utils/agent/supervisor/runner_events_test.go
@@ -1,0 +1,64 @@
+package supervisor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunnerEmitsLifecycleEvents(t *testing.T) {
+	start, _ := scriptedStarter(
+		&fakeProcess{pid: 7, code: 0, uptime: 20 * time.Millisecond},
+	)
+	r := testRunner(t, start)
+
+	var mu sync.Mutex
+	var got []RunEvent
+	r.OnEvent = func(e RunEvent) {
+		mu.Lock()
+		got = append(got, e)
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = r.Run(ctx) }()
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(got) >= 2
+	})
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got[0].Kind != "started" || got[0].PID != 7 {
+		t.Errorf("first event = %+v, want started pid 7", got[0])
+	}
+	var exited *RunEvent
+	for i := range got {
+		if got[i].Kind == "exited" {
+			exited = &got[i]
+			break
+		}
+	}
+	if exited == nil || exited.Cause == "" {
+		t.Errorf("an exit must carry its cause, events: %+v", got)
+	}
+}
+
+func TestRunnerEmitsSessionEvent(t *testing.T) {
+	r := testRunner(t, nil)
+	var got []RunEvent
+	r.OnEvent = func(e RunEvent) { got = append(got, e) }
+
+	r.addSessionLink("session_01A")
+	r.addSessionLink("session_01A")
+
+	if len(got) != 1 || got[0].Kind != "session" || got[0].URL != "https://claude.ai/code/session_01A" {
+		t.Errorf("events = %+v, want one session event with the canonical URL", got)
+	}
+}


### PR DESCRIPTION
## What

- **Session timeline** — the daemon records every start, exit (with classified cause + reason), disable, and captured session link per workspace (`<agent-dir>/events/<ws>.jsonl`, capped, 0600). Session output is never persisted. Read it three ways:
  - `corgi agent logs <workspace>` (aliases: `events`, `timeline`, `--json`)
  - `corgi_session_events` MCP tool (a connected Claude can answer "why did my session die")
  - the launcher: per-workspace session history that now **survives daemon restarts**, with "2h ago" times
- **Stop from the phone** — `/launch/stop` (same code path as `corgi_session_stop`) + a Stop button on running workspace cards.
- **Push notifications** — `notifyUrl` in the trusted user config POSTs every daemon notification (`Title` header + plain-text body — the ntfy.sh contract, so the ntfy app gives phone push with zero infra). Invalid URLs warn at startup; titles are ASCII-sanitized for the header. Trusted config only, off by default.
- **Doctor trust checks** — `corgi agent doctor` now has one row per workspace: has Claude accepted the folder-trust dialog under that workspace's account, with the exact fix. (The failure mode that bit real setups.)
- **Spec** — `docs/remote-app.md` updated: multi-machine pairing model, three notification tiers (poll → ntfy app → in-app ntfy subscribe, never a bespoke push server), a Sessions screen, updated build order.

## Notes

- Includes the #45 launcher commits (branched on top); merge #45 first and this diff shrinks to the agent work.
- All opt-in and non-breaking: old daemon + new CLI → friendly "no events yet"; new launcher + old daemon → empty history.
- Timeline deliberately records classification only — never process output, which can carry tokens (the existing exec.go invariant).

## Verified

- `gofmt`, `go vet`, native + Windows builds clean
- `go test -race -count=1 ./cmd/ ./utils/agent/...` — 1108 pass across 9 packages
- launcher JS passes `node --check`; diff leak-scanned