### PR TITLE
Agent: corgi agent restart shortcut

### DIFF
--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -589,6 +589,28 @@ func runAgentDown(_ *cobra.Command, _ []string) {
 	}
 }
 
+// ---------------------------------------------------------------- restart
+
+var agentRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "corgi agent down && corgi agent up --fresh, in one command",
+	Long: `Stops everything ` + "`corgi agent up`" + ` started, then brings it back up with
+--fresh: a new tunnel and a new single-use pairing window. The one command to
+run after upgrading corgi so the daemon and launcher are the new binary.`,
+	Run: runAgentRestart,
+}
+
+var (
+	restartDown = runAgentDown
+	restartUp   = runAgentUp
+)
+
+func runAgentRestart(cmd *cobra.Command, args []string) {
+	restartDown(cmd, args)
+	_ = cmd.Flags().Set("fresh", "true")
+	restartUp(cmd, args)
+}
+
 // readAgentPidFile reads a pid written by spawnDetached. A missing or malformed
 // file just means there is nothing to stop.
 func readAgentPidFile(path string) (int, bool) {
@@ -603,10 +625,15 @@ func readAgentPidFile(path string) (int, bool) {
 	return pid, true
 }
 
+func addAgentUpFlags(c *cobra.Command) {
+	c.Flags().String("http", defaultMCPAddr, "Local MCP address")
+	c.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
+	c.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — gives a stable public URL you can bookmark (needs a one-time `cloudflared tunnel create`; see docs/tunnel.md)")
+	c.Flags().Bool("fresh", false, "Replace a corgi MCP already holding the port: new tunnel + a new single-use pairing window (a phone mid-session on the old URL is cut)")
+}
+
 func init() {
-	agentUpCmd.Flags().String("http", defaultMCPAddr, "Local MCP address")
-	agentUpCmd.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
-	agentUpCmd.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — gives a stable public URL you can bookmark (needs a one-time `cloudflared tunnel create`; see docs/tunnel.md)")
-	agentUpCmd.Flags().Bool("fresh", false, "Replace a corgi MCP already holding the port: new tunnel + a new single-use pairing window (a phone mid-session on the old URL is cut)")
-	agentCmd.AddCommand(agentUpCmd)
+	addAgentUpFlags(agentUpCmd)
+	addAgentUpFlags(agentRestartCmd)
+	agentCmd.AddCommand(agentUpCmd, agentRestartCmd)
 }

--- a/cmd/agent_up_test.go
+++ b/cmd/agent_up_test.go
@@ -10,6 +10,8 @@ import (
 	"andriiklymiuk/corgi/utils"
 
 	"andriiklymiuk/corgi/utils/agent/workspace"
+
+	"github.com/spf13/cobra"
 )
 
 func TestParseMCPLogNeedsBothURLAndCode(t *testing.T) {
@@ -251,5 +253,27 @@ func TestReadAgentPidFile(t *testing.T) {
 		if _, ok := readAgentPidFile(path); ok {
 			t.Errorf("a malformed pid %q must report not-ok", bad)
 		}
+	}
+}
+
+func TestRunAgentRestartRunsDownThenFreshUp(t *testing.T) {
+	origDown, origUp := restartDown, restartUp
+	defer func() { restartDown, restartUp = origDown, origUp }()
+
+	var order []string
+	freshWhenUpRan := false
+	restartDown = func(*cobra.Command, []string) { order = append(order, "down") }
+	restartUp = func(cmd *cobra.Command, _ []string) {
+		order = append(order, "up")
+		freshWhenUpRan, _ = cmd.Flags().GetBool("fresh")
+	}
+
+	runAgentRestart(agentRestartCmd, nil)
+
+	if len(order) != 2 || order[0] != "down" || order[1] != "up" {
+		t.Fatalf("order = %v, want down then up", order)
+	}
+	if !freshWhenUpRan {
+		t.Error("restart must force --fresh before up runs")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.20.44"
+var APP_VERSION = "1.20.45"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -123,6 +123,7 @@ corgi agent serve --foreground   # run it in this terminal and watch
 | `corgi agent resolve <name>` | what "the recipe app" resolves to |
 | `corgi agent brief [id]` | what the last session was working on before it restarted |
 | `corgi agent logs <workspace>` | the session timeline: starts, exits and why, links |
+| `corgi agent restart` | `down` + `up --fresh` in one — run it after `corgi upgrade` |
 | `corgi agent stop` | stop the daemon |
 
 ## Restarts, and being told about them

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.20.44",
+  "version": "1.20.45",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -215,6 +215,8 @@ and opens a fresh tunnel + pairing window instead of refusing. For a launcher
 URL that survives restarts, pass `--tunnel-name <name>` (cloudflared named
 tunnel — see docs/tunnel.md). The mirror is `corgi agent down`: stops the
 daemon AND the detached MCP + tunnel (`agent stop` stops only the daemon).
+`corgi agent restart` is `down` + `up --fresh` in one — recommend it after a
+corgi upgrade so the daemon and launcher run the new binary.
 
 The user scans the QR (or opens the printed URL) on their phone, names the
 device, and gets a per-device token. After pairing, the same page offers **Open


### PR DESCRIPTION
## What

`corgi agent restart` = `corgi agent down && corgi agent up --fresh` in one command. Shares `up`'s flags (`--http`, `--provider`, `--tunnel-name`), forces `--fresh` so the relaunched MCP always opens a new tunnel + pairing window.

The post-upgrade ritual is now one command: `corgi upd && corgi agent restart`.

Docs table + agent skill updated to recommend it.

## Verified

- `gofmt`, `go vet`, native + Windows builds clean
- `go test -race -count=1 ./cmd/` — 853 pass, including the new order + forced-fresh test
- Smoke: `corgi agent restart --help` renders correctly