### PR TITLE
Agent up: named tunnel hostname, longer pairing codes

### DIFF
--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -68,7 +68,13 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 	addr, _ := cmd.Flags().GetString("http")
 	provider, _ := cmd.Flags().GetString("provider")
 	tunnelName, _ := cmd.Flags().GetString("tunnel-name")
+	tunnelHost, _ := cmd.Flags().GetString("tunnel-hostname")
 	fresh, _ := cmd.Flags().GetBool("fresh")
+
+	tunnel, err := tunnelArgs(provider, tunnelName, tunnelHost)
+	if err != nil {
+		exitWithError("agent_up_tunnel", err, 2)
+	}
 
 	dir, err := agentDir()
 	if err != nil {
@@ -144,7 +150,7 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	if err := spawnDetachedMCP(dir, addr, provider, tunnelName); err != nil {
+	if err := spawnDetachedMCP(dir, addr, tunnel); err != nil {
 		exitWithError("agent_up_mcp", err, 1)
 	}
 	res.MCPStarted = true
@@ -227,16 +233,29 @@ func ensureDaemon(dir string) (*daemon.Info, error) {
 	return nil, fmt.Errorf("daemon did not come up — see %s", filepath.Join(dir, "serve.log"))
 }
 
-func spawnDetachedMCP(dir, addr, provider, tunnelName string) error {
-	args := []string{"mcp", "--http", addr, "--tunnel", "--pair"}
+// tunnelArgs turns the up flags into `corgi mcp` tunnel flags. A named tunnel
+// needs its hostname: cloudflared never reports one, and without it the
+// printed launcher URL would be "https:///app".
+func tunnelArgs(provider, name, host string) ([]string, error) {
+	var args []string
 	if provider != "" {
 		args = append(args, "--tunnel-provider", provider)
 	}
-	// A named tunnel gives a stable public URL, so the launcher can be
-	// bookmarked / saved to a home screen and survive a restart of `agent up`.
-	if tunnelName != "" {
-		args = append(args, "--tunnel-name", tunnelName)
+	if name == "" && host == "" {
+		return args, nil
 	}
+	if host == "" {
+		return nil, fmt.Errorf("--tunnel-name %s needs --tunnel-hostname <host>: the DNS name you routed to it "+
+			"(cloudflared tunnel route dns %s corgi.yourdomain.com)", name, name)
+	}
+	if name != "" {
+		args = append(args, "--tunnel-name", name)
+	}
+	return append(args, "--tunnel-hostname", host), nil
+}
+
+func spawnDetachedMCP(dir, addr string, tunnel []string) error {
+	args := append([]string{"mcp", "--http", addr, "--tunnel", "--pair"}, tunnel...)
 	// Truncate the old log first: awaitMCPLog must not read a previous run's
 	// URL or pairing code as this one's.
 	_ = os.Remove(filepath.Join(dir, mcpLogName))
@@ -628,7 +647,8 @@ func readAgentPidFile(path string) (int, bool) {
 func addAgentUpFlags(c *cobra.Command) {
 	c.Flags().String("http", defaultMCPAddr, "Local MCP address")
 	c.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
-	c.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — gives a stable public URL you can bookmark (needs a one-time `cloudflared tunnel create`; see docs/tunnel.md)")
+	c.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — a stable public URL you can bookmark, and a phone that stays paired (needs a one-time `cloudflared tunnel create` and --tunnel-hostname; see docs/agent.md)")
+	c.Flags().String("tunnel-hostname", "", "Public hostname of the named tunnel, e.g. corgi.yourdomain.com (the DNS name routed to it)")
 	c.Flags().Bool("fresh", false, "Replace a corgi MCP already holding the port: new tunnel + a new single-use pairing window (a phone mid-session on the old URL is cut)")
 }
 

--- a/cmd/agent_up_test.go
+++ b/cmd/agent_up_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -275,5 +276,24 @@ func TestRunAgentRestartRunsDownThenFreshUp(t *testing.T) {
 	}
 	if !freshWhenUpRan {
 		t.Error("restart must force --fresh before up runs")
+	}
+}
+
+func TestTunnelArgs(t *testing.T) {
+	if args, err := tunnelArgs("", "", ""); err != nil || len(args) != 0 {
+		t.Errorf("quick tunnel: %v %v", args, err)
+	}
+	if args, err := tunnelArgs("ngrok", "", ""); err != nil || strings.Join(args, " ") != "--tunnel-provider ngrok" {
+		t.Errorf("provider only: %v %v", args, err)
+	}
+	if _, err := tunnelArgs("", "corgi-agent", ""); err == nil || !strings.Contains(err.Error(), "--tunnel-hostname") {
+		t.Errorf("a name without a hostname must be refused with the fix, got %v", err)
+	}
+	args, err := tunnelArgs("", "corgi-agent", "corgi.example.com")
+	if err != nil || strings.Join(args, " ") != "--tunnel-name corgi-agent --tunnel-hostname corgi.example.com" {
+		t.Errorf("named: %v %v", args, err)
+	}
+	if args, err := tunnelArgs("ngrok", "", "x.ngrok-free.app"); err != nil || strings.Join(args, " ") != "--tunnel-provider ngrok --tunnel-hostname x.ngrok-free.app" {
+		t.Errorf("hostname only (ngrok static domain): %v %v", args, err)
 	}
 }

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -80,8 +80,13 @@ cloudflared tunnel create corgi-agent
 cloudflared tunnel route dns corgi-agent corgi.yourdomain.com
 
 # then always:
-corgi agent up --tunnel-name corgi-agent
+corgi agent up --tunnel-name corgi-agent --tunnel-hostname corgi.yourdomain.com
 ```
+
+Both flags: the name picks the tunnel, the hostname is the URL corgi prints
+(cloudflared does not report it). The launcher then lives at
+`https://corgi.yourdomain.com/app`, and because the origin never changes the
+phone stays paired across restarts.
 
 The launcher now lives at the same hostname forever — save it to the phone's home
 screen once. Provider notes (ngrok's free static `*.ngrok-free.dev` domain,

--- a/plugins/corgi/commands/corgi-remote.md
+++ b/plugins/corgi/commands/corgi-remote.md
@@ -17,8 +17,9 @@ Follow the `agent` skill (`plugins/corgi/skills/agent/SKILL.md`) — the
    pairing URL for the user to scan. Port already held by a healthy corgi MCP →
    it reports as already up; a NEW pairing window needs `corgi agent up --fresh`.
 2. Reboot survival: offer `corgi agent install` (start at login).
-3. Permanent URL: offer the named tunnel (`--tunnel-name`, one-time
-   `cloudflared tunnel create` — the skill + docs/tunnel.md carry the steps).
+3. Permanent URL: offer the named tunnel (`--tunnel-name <name> --tunnel-hostname <host>`,
+   one-time `cloudflared tunnel create` + `route dns` — docs/agent.md carries the
+   steps). Same origin every restart, so the phone never re-pairs.
 4. Separate Claude accounts: `corgi agent init --config-dir <dir>` per
    workspace, or `corgi agent profile add <name> --config-dir <dir>` to pick at
    start time. Per-workspace open target (Claude app vs browser vs Chrome) is

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -212,8 +212,9 @@ so you can run it and keep working. No port to remember. `--json` emits the URL
 and pairing code for a caller that wants them structured. A busy MCP port
 self-heals: when the holder is identifiably corgi's own server, `up` stops it
 and opens a fresh tunnel + pairing window instead of refusing. For a launcher
-URL that survives restarts, pass `--tunnel-name <name>` (cloudflared named
-tunnel — see docs/tunnel.md). The mirror is `corgi agent down`: stops the
+URL that survives restarts — and a phone that stays paired, since the origin
+never changes — pass `--tunnel-name <name> --tunnel-hostname <host>` (cloudflared
+named tunnel; both flags, see docs/agent.md). The mirror is `corgi agent down`: stops the
 daemon AND the detached MCP + tunnel (`agent stop` stops only the daemon).
 `corgi agent restart` is `down` + `up --fresh` in one — recommend it after a
 corgi upgrade so the daemon and launcher run the new binary.

--- a/utils/agent/pairing/pairing.go
+++ b/utils/agent/pairing/pairing.go
@@ -51,9 +51,10 @@ const TokenPrefix = "corgi_dev_"
 // off a screen and typed by hand, which is the fallback when a camera fails.
 const codeAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
-// codeLength gives ~50 bits of entropy, which is far more than a two-minute
-// window with an attempt cap requires.
-const codeLength = 10
+// codeLength gives ~100 bits of entropy. The code rides in the QR / link
+// fragment and is read by the pair page, so length costs the user nothing;
+// hand-typing it is only the fallback when a camera fails.
+const codeLength = 20
 
 // Device is one paired client.
 //

--- a/utils/tunnel/runner.go
+++ b/utils/tunnel/runner.go
@@ -62,6 +62,11 @@ func Run(ctx context.Context, provider Provider, service string, port int, named
 	}
 
 	if named != nil {
+		if named.Hostname == "" {
+			send(ctx, events, Event{Service: service, Port: port, Done: true,
+				Err: fmt.Errorf("named tunnel %q has no hostname — pass the DNS name routed to it (cloudflared tunnel route dns %s <host>)", named.Name, named.Name)})
+			return
+		}
 		send(ctx, events, Event{Service: service, Port: port, URL: "https://" + named.Hostname})
 	}
 

--- a/utils/tunnel/runner_test.go
+++ b/utils/tunnel/runner_test.go
@@ -207,3 +207,25 @@ func TestRunNamedHostnameEmitted(t *testing.T) {
 		t.Errorf("missing hostname url: %v", urls)
 	}
 }
+
+func TestRunNamedWithoutHostnameFails(t *testing.T) {
+	events := make(chan Event, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		Run(ctx, fakeProvider{}, "svc", 3000, &NamedConfig{Name: "mytun"}, events)
+		close(events)
+	}()
+	var errs []error
+	for ev := range events {
+		if ev.URL != "" {
+			t.Errorf("a hostname-less named tunnel must not emit a URL, got %q", ev.URL)
+		}
+		if ev.Err != nil {
+			errs = append(errs, ev.Err)
+		}
+	}
+	if len(errs) == 0 || !strings.Contains(errs[0].Error(), "mytun") {
+		t.Errorf("expected an error naming the tunnel, got %v", errs)
+	}
+}


### PR DESCRIPTION
## What

- **Named tunnels were broken from `agent up`**: `--tunnel-name` alone printed `https:///app` — cloudflared never reports a hostname and the runner emitted `https://` + empty. `agent up` / `agent restart` now take `--tunnel-hostname`, refuse a name without one (the error carries the exact `cloudflared tunnel route dns` command), and the tunnel runner errors instead of emitting a bare scheme. Docs, skill and the `/corgi-remote` command show both flags.
- **Pairing codes: 10 → 20 characters** (~50 → ~100 bits, Crockford base32). The code rides in the QR fragment and is read by the pair page, so the extra length costs the user nothing; the 2-minute window and 10-attempt cap stay.

## Why the hostname matters

Quick tunnels change origin on every restart, so the phone's stored device token (per-origin localStorage) is lost and it must re-pair each time. A named tunnel keeps the origin, so one pairing lasts.

## Verified

- `gofmt`, `go vet`, native + Windows builds clean
- `go test` green for cmd, utils/tunnel, utils/agent/pairing — new tests for `tunnelArgs` and the hostname-less runner path