### PR TITLE
Agent up: remember tunnel settings, provider preflight, ngrok polish

### DIFF
--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -16,6 +18,7 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/workspace"
+	"andriiklymiuk/corgi/utils/tunnel"
 
 	qrcode "github.com/skip2/go-qrcode"
 	"github.com/spf13/cobra"
@@ -65,20 +68,31 @@ type agentUpResult struct {
 }
 
 func runAgentUp(cmd *cobra.Command, _ []string) {
-	addr, _ := cmd.Flags().GetString("http")
-	provider, _ := cmd.Flags().GetString("provider")
-	tunnelName, _ := cmd.Flags().GetString("tunnel-name")
-	tunnelHost, _ := cmd.Flags().GetString("tunnel-hostname")
 	fresh, _ := cmd.Flags().GetBool("fresh")
-
-	tunnel, err := tunnelArgs(provider, tunnelName, tunnelHost)
-	if err != nil {
-		exitWithError("agent_up_tunnel", err, 2)
-	}
 
 	dir, err := agentDir()
 	if err != nil {
 		exitWithError("agent_data_dir", err, 1)
+	}
+
+	// Flags given now win; anything not given falls back to what the last
+	// `up` used, so `agent restart` keeps the named tunnel without retyping it.
+	cur := upSettingsFromFlags(cmd)
+	settings, reused := mergeUpSettings(cur, cmd.Flags().Changed, loadUpSettings(dir))
+	if reused != "" {
+		utils.Infof("using saved settings from the last up: %s (pass the flags to change them)\n", reused)
+	}
+	addr := settings.HTTP
+	if addr == "" {
+		addr = defaultMCPAddr
+	}
+
+	tunnel, err := tunnelArgs(settings.Provider, settings.TunnelName, settings.TunnelHostname)
+	if err != nil {
+		exitWithError("agent_up_tunnel", err, 2)
+	}
+	if err := tunnelPreflight(settings.Provider, settings.TunnelName, settings.TunnelHostname); err != nil {
+		exitWithError("agent_up_tunnel", err, 2)
 	}
 
 	// One `agent up` at a time. Two racing invocations both pass the listening
@@ -159,6 +173,7 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		exitWithError("agent_up_mcp", fmt.Errorf("%w — see %s", err, res.LogPath), 1)
 	}
+	_ = saveUpSettings(dir, settings)
 	res.PublicURL = parsed.publicURL
 	res.PairCode = parsed.pairCode
 	if res.PublicURL != "" && res.PairCode != "" {
@@ -231,6 +246,89 @@ func ensureDaemon(dir string) (*daemon.Info, error) {
 		time.Sleep(200 * time.Millisecond)
 	}
 	return nil, fmt.Errorf("daemon did not come up — see %s", filepath.Join(dir, "serve.log"))
+}
+
+// upSettings is what the last successful `agent up` ran with, kept so a bare
+// `agent up` / `agent restart` repeats it instead of silently dropping the
+// named tunnel — and with it the stable URL the phone is paired to.
+type upSettings struct {
+	HTTP           string `json:"http,omitempty"`
+	Provider       string `json:"provider,omitempty"`
+	TunnelName     string `json:"tunnelName,omitempty"`
+	TunnelHostname string `json:"tunnelHostname,omitempty"`
+}
+
+const upSettingsName = "up.json"
+
+func upSettingsFromFlags(cmd *cobra.Command) upSettings {
+	var s upSettings
+	s.HTTP, _ = cmd.Flags().GetString("http")
+	s.Provider, _ = cmd.Flags().GetString("provider")
+	s.TunnelName, _ = cmd.Flags().GetString("tunnel-name")
+	s.TunnelHostname, _ = cmd.Flags().GetString("tunnel-hostname")
+	return s
+}
+
+// mergeUpSettings fills every flag the user did not pass from the saved run.
+// An explicitly passed flag always wins, including an explicit empty value —
+// `--tunnel-hostname ""` is how you go back to a quick tunnel. The returned
+// string names what was reused, for the notice.
+func mergeUpSettings(cur upSettings, changed func(string) bool, saved upSettings) (upSettings, string) {
+	var reused []string
+	pick := func(flag string, cur *string, saved string) {
+		if changed(flag) || saved == "" {
+			return
+		}
+		*cur = saved
+		reused = append(reused, "--"+flag+" "+saved)
+	}
+	pick("http", &cur.HTTP, saved.HTTP)
+	pick("provider", &cur.Provider, saved.Provider)
+	pick("tunnel-name", &cur.TunnelName, saved.TunnelName)
+	pick("tunnel-hostname", &cur.TunnelHostname, saved.TunnelHostname)
+	return cur, strings.Join(reused, " ")
+}
+
+func loadUpSettings(dir string) upSettings {
+	var s upSettings
+	data, err := os.ReadFile(filepath.Join(dir, upSettingsName))
+	if err != nil || json.Unmarshal(data, &s) != nil {
+		return upSettings{}
+	}
+	if s.HTTP == defaultMCPAddr {
+		s.HTTP = ""
+	}
+	return s
+}
+
+func saveUpSettings(dir string, s upSettings) error {
+	if s.HTTP == defaultMCPAddr {
+		s.HTTP = ""
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, upSettingsName), append(data, '\n'), 0o600)
+}
+
+// tunnelPreflight runs the provider's own auth check before anything is
+// spawned, so a missing ngrok token or cloudflared login fails here with the
+// provider's instructions instead of as a 90-second wait on a log.
+func tunnelPreflight(provider, name, host string) error {
+	if provider == "" {
+		provider = "cloudflared"
+	}
+	p, ok := tunnel.Providers[provider]
+	if !ok {
+		names := tunnel.Names()
+		sort.Strings(names)
+		return fmt.Errorf("unknown tunnel provider %q. Available: %s", provider, strings.Join(names, ", "))
+	}
+	if name == "" && host == "" {
+		return p.PreflightAuth()
+	}
+	return p.PreflightNamedAuth(tunnel.NamedConfig{Name: name, Hostname: host})
 }
 
 // tunnelArgs turns the up flags into `corgi mcp` tunnel flags. A named tunnel
@@ -426,8 +524,9 @@ var (
 	// Anchored to the newline so a code read mid-write ("pairing code: WOR"
 	// before "D-123\n" lands) is not captured truncated and QR-encoded wrong.
 	// The URL pattern needs no such guard: its /mcp suffix is the terminator.
-	mcpPairCodePattern = regexp.MustCompile(`pairing code: (\S+)\n`)
-	mcpFatalPattern    = regexp.MustCompile(`(?m)^(mcp server error:|corgi mcp --pair cannot|could not start pairing:|tunnel: )`)
+	mcpPairCodePattern  = regexp.MustCompile(`pairing code: (\S+)\n`)
+	mcpFatalPattern     = regexp.MustCompile(`(?m)^(mcp server error:|corgi mcp --pair cannot|could not start pairing:|tunnel: )`)
+	mcpTunnelErrPattern = regexp.MustCompile(`(?m)^🌐 ✗ tunnel: (.+)$`)
 )
 
 // parseMCPLog extracts what the summary needs from `corgi mcp`'s own output.
@@ -453,6 +552,9 @@ func awaitMCPLog(path string, timeout time.Duration) (mcpLogInfo, error) {
 			log := string(data)
 			if mcpFatalPattern.MatchString(log) {
 				return last, fmt.Errorf("mcp failed to start")
+			}
+			if m := mcpTunnelErrPattern.FindStringSubmatch(log); m != nil {
+				return last, fmt.Errorf("tunnel: %s", strings.TrimSpace(m[1]))
 			}
 			info, done := parseMCPLog(log)
 			last = info
@@ -648,7 +750,7 @@ func addAgentUpFlags(c *cobra.Command) {
 	c.Flags().String("http", defaultMCPAddr, "Local MCP address")
 	c.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
 	c.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — a stable public URL you can bookmark, and a phone that stays paired (needs a one-time `cloudflared tunnel create` and --tunnel-hostname; see docs/agent.md)")
-	c.Flags().String("tunnel-hostname", "", "Public hostname of the named tunnel, e.g. corgi.yourdomain.com (the DNS name routed to it)")
+	c.Flags().String("tunnel-hostname", "", "Public hostname of the named tunnel, e.g. corgi.yourdomain.com (the DNS name routed to it; ngrok: your free static domain). Remembered for the next up/restart; pass \"\" to go back to a quick tunnel")
 	c.Flags().Bool("fresh", false, "Replace a corgi MCP already holding the port: new tunnel + a new single-use pairing window (a phone mid-session on the old URL is cut)")
 }
 

--- a/cmd/agent_up_test.go
+++ b/cmd/agent_up_test.go
@@ -297,3 +297,53 @@ func TestTunnelArgs(t *testing.T) {
 		t.Errorf("hostname only (ngrok static domain): %v %v", args, err)
 	}
 }
+
+func TestMergeUpSettingsReusesOnlyUnchangedFlags(t *testing.T) {
+	saved := upSettings{Provider: "cloudflared", TunnelName: "corgi-agent", TunnelHostname: "corgi.example.com"}
+	changed := func(f string) bool { return f == "tunnel-hostname" }
+	got, reused := mergeUpSettings(upSettings{TunnelHostname: ""}, changed, saved)
+	if got.TunnelHostname != "" {
+		t.Errorf("an explicitly passed empty hostname must win, got %q", got.TunnelHostname)
+	}
+	if got.TunnelName != "corgi-agent" || got.Provider != "cloudflared" {
+		t.Errorf("unchanged flags must come from the saved run, got %+v", got)
+	}
+	if !strings.Contains(reused, "--tunnel-name corgi-agent") || strings.Contains(reused, "hostname") {
+		t.Errorf("notice must name what was reused: %q", reused)
+	}
+	if _, reused := mergeUpSettings(upSettings{}, func(string) bool { return false }, upSettings{}); reused != "" {
+		t.Errorf("nothing saved means nothing reused, got %q", reused)
+	}
+}
+
+func TestUpSettingsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if got := loadUpSettings(dir); got != (upSettings{}) {
+		t.Errorf("no file means empty settings, got %+v", got)
+	}
+	in := upSettings{HTTP: defaultMCPAddr, Provider: "ngrok", TunnelHostname: "x.ngrok-free.app"}
+	if err := saveUpSettings(dir, in); err != nil {
+		t.Fatal(err)
+	}
+	got := loadUpSettings(dir)
+	if got.HTTP != "" || got.Provider != "ngrok" || got.TunnelHostname != "x.ngrok-free.app" {
+		t.Errorf("round trip = %+v (the default addr must not be pinned)", got)
+	}
+}
+
+func TestTunnelPreflightRejectsUnknownProvider(t *testing.T) {
+	if err := tunnelPreflight("nope", "", ""); err == nil || !strings.Contains(err.Error(), "unknown tunnel provider") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestAwaitMCPLogSurfacesTheTunnelError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.log")
+	if err := os.WriteFile(path, []byte("🌐 ✗ tunnel: ngrok authtoken not configured.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := awaitMCPLog(path, 2*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "authtoken") {
+		t.Errorf("the tunnel's own error must be returned at once, got %v", err)
+	}
+}

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -521,7 +521,7 @@ const launcherPageHTML = `<!doctype html>
   };
   const token = (() => { try { return localStorage.getItem('corgi_token') || ''; } catch { return ''; } })();
   const list = document.getElementById('list');
-  const auth = { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json' };
+  const auth = { 'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' };
   // Set in JS (not a static href) so the page source carries no external link;
   // this is a user navigation to the Claude session list, not a loaded asset.
   try { document.getElementById('allsessions').href = 'https://claude.ai/code'; } catch {}

--- a/cmd/mcp_pairing.go
+++ b/cmd/mcp_pairing.go
@@ -190,7 +190,7 @@ const pairPageHTML = `<!doctype html>
     const device = document.getElementById('device').value.trim() || 'my-phone';
     btn.disabled = true; btn.textContent = 'Pairing…';
     try {
-      const r = await fetch('/pair', {method:'POST', headers:{'Content-Type':'application/json'},
+      const r = await fetch('/pair', {method:'POST', headers:{'Content-Type':'application/json', 'ngrok-skip-browser-warning': '1'},
         body: JSON.stringify({code, device})});
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -88,6 +88,24 @@ Both flags: the name picks the tunnel, the hostname is the URL corgi prints
 `https://corgi.yourdomain.com/app`, and because the origin never changes the
 phone stays paired across restarts.
 
+`agent up` remembers the settings it last ran with, so from then on a bare
+`corgi agent restart` keeps the named tunnel. Pass the flags again to change
+them; `--tunnel-hostname ""` goes back to a quick tunnel.
+
+No domain on Cloudflare? ngrok's free tier includes one static domain and needs
+no DNS work:
+
+```bash
+brew install ngrok
+ngrok config add-authtoken <token>        # dashboard.ngrok.com → Your Authtoken
+# dashboard.ngrok.com → Domains → claim your free *.ngrok-free.app domain, then:
+corgi agent up --provider ngrok --tunnel-hostname <yours>.ngrok-free.app
+```
+
+The first time the phone opens the page, ngrok's free tier shows its own
+"you are about to visit" interstitial once; tap through. The launcher's own
+requests carry the header that skips it, so pairing and the buttons work.
+
 The launcher now lives at the same hostname forever — save it to the phone's home
 screen once. Provider notes (ngrok's free static `*.ngrok-free.dev` domain,
 localtunnel's best-effort `--subdomain`) and per-service stable tunnels:

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -217,7 +217,11 @@ never changes — pass `--tunnel-name <name> --tunnel-hostname <host>` (cloudfla
 named tunnel; both flags, see docs/agent.md). The mirror is `corgi agent down`: stops the
 daemon AND the detached MCP + tunnel (`agent stop` stops only the daemon).
 `corgi agent restart` is `down` + `up --fresh` in one — recommend it after a
-corgi upgrade so the daemon and launcher run the new binary.
+corgi upgrade so the daemon and launcher run the new binary. `up` remembers
+the tunnel flags it last ran with, so a bare `restart` keeps the named tunnel;
+`--tunnel-hostname ""` is the way back to a quick tunnel. ngrok works too:
+`--provider ngrok --tunnel-hostname <yours>.ngrok-free.app` (free static
+domain, no DNS) — its free tier shows an interstitial once on first open.
 
 The user scans the QR (or opens the printed URL) on their phone, names the
 device, and gets a per-device token. After pairing, the same page offers **Open


### PR DESCRIPTION
## What

- **`up` remembers its settings.** On success it saves `http`, `provider`, `tunnel-name`, `tunnel-hostname` to `<agent-dir>/up.json`; a bare `corgi agent up` / `corgi agent restart` reuses them and says so. Explicit flags win; `--tunnel-hostname ""` returns to a quick tunnel. No more alias needed for the named tunnel.
- **Provider preflight before spawning.** Missing ngrok authtoken / cloudflared login / tunnel name fails immediately with the provider's own instructions, instead of a 90-second wait ending in a LAN-only endpoint.
- **Tunnel errors surface at once.** `awaitMCPLog` returns the `🌐 ✗ tunnel:` line as the error.
- **ngrok free tier works from a phone.** Launcher and pair page send `ngrok-skip-browser-warning` on their own requests, so the interstitial cannot break pairing or the buttons (the first page open still shows it once). Docs + skill cover `--provider ngrok --tunnel-hostname <yours>.ngrok-free.app`.

## Verified

- `gofmt`, `go vet`, native + Windows builds clean; launcher JS passes `node --check`
- `go test -count=1 ./cmd/` green — new tests for the merge rules, settings round-trip, unknown provider, and the tunnel-error fast path