### PR TITLE
Agent: launcher polish, attention hooks, cross-repo pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,36 +30,33 @@ Video: [2-minute showcase](https://youtu.be/rlMCjs4EoFs?si=o3SQaymM55zxBCUY).
 
 ## Why corgi
 
-Say the ticket is a referral program: new endpoint in `api`, new page in `web`, new screen in
-`mobile`, one migration. All of it has to run together before you can tell if it works.
+One committed `corgi-compose.yml` describes the project. After that, the things you actually do in
+a day are one command each:
 
-```text
-  without corgi                          with corgi
-  ─────────────────────────────────────  ────────────────────────────────────
-  clone the repos                        corgi run --feature ABC-123
-  install postgres, seed it by hand
-  chase three .env files                  ├─ every repo that has the branch
-  find ports nobody else took             ├─ postgres up, seeded
-  four terminals, in the right order      ├─ .env written, services cross-wired
-  mobile still can't reach the api        └─ api + web + mobile, healthy
-  ─────────────────────────────────────  ────────────────────────────────────
-  half a day, per person, per laptop     one command, then you write code
-```
+| what you want | what you type |
+| --- | --- |
+| the whole stack up: repos cloned, databases seeded, env wired | `corgi run` |
+| a feature that spans `api`, `web` and `mobile` | `corgi run --feature ABC-123` |
+| a teammate's branch, in one service only | `corgi run --service-branch api=fix/login` |
+| just the databases, to write a migration against | `corgi db -u` |
+| the bug reproduced on yesterday's data | `corgi db restore nightly` |
+| a public HTTPS URL for a webhook or a device | `corgi tunnel` |
+| the same stack in CI, on the branches under review | `corgi run --feature $BRANCH --detach --wait` |
+| an agent to take the ticket across every repo | `/corgi:stories ABC-123` |
+| your laptop still working while you're out | `corgi agent up`, then scan the QR |
+| the next project tomorrow | the same commands, in its folder |
 
-What you get:
+The part that changes how you work is the second row. A feature that touches three repos normally
+means three checkouts, three terminals and a lot of hoping. `--feature ABC-123` runs every repo
+that has that branch and leaves the rest on `main`, so the mobile app calls the real endpoint,
+which reads the real seeded database, on your laptop. You see the whole feature work before you
+open a PR.
 
-- **The feature runs before the PR.** The mobile app calls the real endpoint, which reads the
-  seeded database, on your laptop.
-- **Any mix of branches.** `--feature ABC-123` runs every repo that has that branch and leaves the
-  rest on `main`. `--service-branch api=fix/login` swaps one service.
-- **The same with a single repo.** One service still gets a seeded database and a written `.env`.
-  Add more later and everyone gets them with a `git pull`.
-- **Commands for the rest of the day.** `corgi db -u` for databases only, `corgi tunnel` for a
-  public webhook URL, `corgi status -w` when a service looks wrong.
-- **Every project works the same way.** Each one keeps its own `corgi-compose.yml`, but the
-  commands never change, so switching projects doesn't mean learning someone's bespoke `make dev`.
-- **The same workspace for your [agent](#let-an-agent-take-a-whole-ticket), your
-  [CI](#run-the-whole-stack-in-ci) and your [phone](#code-from-your-phone).**
+The rest of the list is why it stays installed: databases you can seed, snapshot and restore, env
+files written for you, health you can watch, logs kept after the process dies, and the same five
+commands on every project instead of a bespoke `make dev` per repo. Your
+[agent](#let-an-agent-take-a-whole-ticket), your [CI](#run-the-whole-stack-in-ci) and your
+[phone](#code-from-your-phone) drive that same file.
 
 If you already use `docker-compose`, keep it. corgi runs the repos, seed data, env files and tool
 checks around your containers.

--- a/README.md
+++ b/README.md
@@ -204,28 +204,25 @@ One scan pairs the phone. It gets its own token, which you can revoke without to
 
 The session survives network drops and crashes, which Remote Control on its own does not (it gives up after about 10 minutes offline). `corgi agent install` brings the session back after a reboot, `--tunnel-name` keeps the URL stable, and `corgi agent down` turns it all off. None of it runs unless you start it. macOS and Linux. With the plugin, `/corgi-remote` walks you through setup. Full guide: [docs/agent.md](docs/agent.md).
 
-## What you'll use day to day
+## The rest of the commands
+
+Beyond the ones above, these are the ones that come up in a normal week:
 
 | command | what you get |
 | --- | --- |
-| `corgi run` | every database and service up, env wired between them, logs saved |
-| `corgi run --feature ABC-123` | each repo that has the branch runs from a worktree, the rest stay on `main` |
-| `corgi run --service-branch api=fix/login` | one service on another branch, without editing the file |
-| `corgi run --tier staging` | local services against your staging env tier |
-| `corgi db -u` | databases only, seeded, nothing else started |
+| `corgi run --tier staging` | local services pointed at your staging env tier |
 | `corgi db shell` | a native `psql`/`mysql` shell with the password already filled in |
-| `corgi db snapshot` / `corgi db restore` | freeze a good database state, come back to it in seconds |
+| `corgi db snapshot` | freeze the current database state so you can come back to it |
 | `corgi exec api -- go test ./...` | a one-off command in that service's directory and env |
-| `corgi logs --service api` | per-service logs, kept after the process is gone |
+| `corgi logs --service api` | logs kept after the process is gone |
 | `corgi status -w` · `corgi ps` | health and run state while you work |
 | `corgi mc` | one pane: each service's run state with its branch, PR and CI |
 | `corgi open web` | opens the localhost URLs in the browser |
-| `corgi tunnel` | public HTTPS for a webhook, a partner, or your phone |
 | `corgi doctor --fix` | missing tools, busy ports, Docker not running |
 | `corgi memory list` | decisions and incidents the team commits next to the code |
 
-38 database drivers ([list](docs/databases.md)), and every command above behaves the same whether
-the project has one service or twelve.
+38 database drivers ([list](docs/databases.md)), and all of this behaves the same whether the
+project has one service or twelve.
 
 Private repos, prerequisites, secrets or staging tiers? See
 [Getting it running on a real project](docs/getting-started.md).

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -18,6 +18,7 @@ import (
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/supervisor"
+	"andriiklymiuk/corgi/utils/agent/usage"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 	"andriiklymiuk/corgi/utils/art"
 
@@ -420,6 +421,34 @@ func printWorkspaceState(w supervisor.RunState) {
 	}
 	if w.SessionURL != "" {
 		fmt.Printf("  %-20s %s\n", "", w.SessionURL)
+	}
+	if line := workspaceUsageLine(w.WorkspaceID); line != "" {
+		fmt.Printf("  %-20s %s\n", "", line)
+	}
+}
+
+func workspaceUsageLine(id string) string {
+	absPath, configDir, ok := workspaceSessionTarget(id)
+	if !ok || absPath == "" {
+		return ""
+	}
+	rep := usage.ForDir(absPath, expandTilde(configDir), mungeClaudeProjectDir(absPath), time.Now())
+	if rep.Week.Total() == 0 {
+		return ""
+	}
+	return fmt.Sprintf("tokens %s today · %s this week", formatTokens(rep.Today.Total()), formatTokens(rep.Week.Total()))
+}
+
+func formatTokens(n int64) string {
+	switch {
+	case n >= 1_000_000_000:
+		return fmt.Sprintf("%.1fB", float64(n)/1e9)
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1e6)
+	case n >= 1_000:
+		return fmt.Sprintf("%dk", n/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
 	}
 }
 

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -180,8 +180,8 @@ func loadSpawnConfigs(dir string, foreground bool) ([]supervisor.SpawnConfig, er
 // reloading registry and config so a remote start sees the current files,
 // not the ones from daemon startup. No autostart check: a remote start IS
 // the explicit act autostart substitutes for.
-func remoteResolver(dir string, foreground bool) func(id, profile string) (supervisor.SpawnConfig, error) {
-	return func(id, profile string) (supervisor.SpawnConfig, error) {
+func remoteResolver(dir string, foreground bool) func(id, profile, name string) (supervisor.SpawnConfig, error) {
+	return func(id, profile, name string) (supervisor.SpawnConfig, error) {
 		registry, err := workspace.Load(agentRegistryPath(dir))
 		if err != nil {
 			return supervisor.SpawnConfig{}, err
@@ -216,8 +216,30 @@ func remoteResolver(dir string, foreground bool) func(id, profile string) (super
 		cfg := spawnConfigFrom(w, resolved, foreground)
 		cfg.Origin = supervisor.OriginRemote
 		cfg.Profile = profile
+		if n := sanitizeSessionName(name); n != "" {
+			cfg.Name = n
+		}
 		return cfg, nil
 	}
+}
+
+// sanitizeSessionName makes a phone-supplied session name safe to place in an
+// argv: printable ASCII only, no leading dash (which argv would read as a
+// flag), and short enough to read in claude.ai's session list.
+func sanitizeSessionName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if r >= 32 && r < 127 {
+			b.WriteRune(r)
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	out = strings.TrimLeft(out, "-")
+	out = strings.TrimSpace(out)
+	if len(out) > 60 {
+		out = strings.TrimSpace(out[:60])
+	}
+	return out
 }
 
 // spawnConfigForWorkspace decides whether one registered workspace should be
@@ -579,7 +601,8 @@ var agentSessionStartCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		profile, _ := cmd.Flags().GetString("profile")
-		enqueueSessionCommand(command.ActionStart, args, profile)
+		name, _ := cmd.Flags().GetString("name")
+		enqueueSessionCommand(command.ActionStart, args, profile, name)
 	},
 }
 
@@ -588,14 +611,14 @@ var agentSessionStopCmd = &cobra.Command{
 	Short: "Ask the running daemon to stop a workspace's session",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(_ *cobra.Command, args []string) {
-		enqueueSessionCommand(command.ActionStop, args, "")
+		enqueueSessionCommand(command.ActionStop, args, "", "")
 	},
 }
 
 // enqueueSessionCommand resolves the workspace, writes the spool command and
 // nudges the daemon — the same path the MCP tools use, so the two surfaces
 // cannot drift.
-func enqueueSessionCommand(action string, args []string, profile string) {
+func enqueueSessionCommand(action string, args []string, profile, name string) {
 	registry, _ := mustLoadRegistry()
 	registry.Reconcile(dirIsWorkspace)
 	res := workspace.Resolve(registry, strings.Join(args, " "))
@@ -629,7 +652,7 @@ func enqueueSessionCommand(action string, args []string, profile string) {
 	}
 
 	c, err := command.Write(dir, command.Command{
-		Action: action, WorkspaceID: res.Workspace.ID, Profile: profile, Source: "cli",
+		Action: action, WorkspaceID: res.Workspace.ID, Profile: profile, Name: sanitizeSessionName(name), Source: "cli",
 	})
 	if err != nil {
 		exitWithError("agent_session", err, 1)
@@ -694,6 +717,7 @@ func init() {
 	agentBriefCmd.Flags().Bool("json", false, "Machine-readable output")
 
 	agentSessionStartCmd.Flags().String("profile", "", "Profile from the agent config's profiles: section (e.g. work)")
+	agentSessionStartCmd.Flags().String("name", "", "Session name shown in claude.ai (default: the hostname prefix remote control picks)")
 	agentSessionCmd.AddCommand(agentSessionStartCmd, agentSessionStopCmd)
 
 	agentWorkspacesCmd.AddCommand(agentWorkspacesListCmd, agentWorkspacesForgetCmd, agentWorkspacesRelocateCmd)

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -15,10 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Claude Code fires hooks for its own lifecycle. Two of them answer the
-// question a phone cannot see: is this session waiting for me? corgi writes
-// them into the workspace's LOCAL settings (never the committed file), pointed
-// at `corgi agent hook`, which spools the event for the daemon to notify on.
+// corgi writes these into the workspace's LOCAL settings, never the committed
+// file.
 const (
 	hookEventNotification = "Notification"
 	hookEventStop         = "Stop"
@@ -50,10 +48,8 @@ var agentHooksDisableCmd = &cobra.Command{
 }
 
 var agentHookCmd = &cobra.Command{
-	Use:   "hook",
-	Short: "Internal: called by a Claude Code hook to report a session needs attention",
-	// The event name arrives in the hook payload on stdin. An optional
-	// positional is accepted so a hand-written hook can pass one too.
+	Use:    "hook",
+	Short:  "Internal: called by a Claude Code hook to report a session needs attention",
 	Args:   cobra.MaximumNArgs(1),
 	Hidden: true,
 	Run:    runAgentHook,
@@ -101,7 +97,6 @@ func runAgentHooksEnable(_ *cobra.Command, _ []string) {
 	utils.Info("undo with `corgi agent hooks disable`")
 }
 
-// Leaves every other hook in place; re-running replaces only ours.
 func withCorgiHook(existing any, workspaceID string) []any {
 	out := stripCorgiHooks(existing)
 	return append(out, map[string]any{
@@ -154,8 +149,6 @@ func runAgentHooksDisable(_ *cobra.Command, _ []string) {
 	utils.Infof("✓ removed corgi's hooks from %s\n", path)
 }
 
-// Fast and silent: Claude Code runs this inline, and anything it prints lands
-// in the user's session.
 func runAgentHook(cmd *cobra.Command, args []string) {
 	utils.NonInteractive = true
 	id, _ := cmd.Flags().GetString("workspace")
@@ -184,8 +177,7 @@ func runAgentHook(cmd *cobra.Command, args []string) {
 	daemon.Nudge(info)
 }
 
-// The hook payload arrives as JSON on stdin. Only Claude's own message is
-// used, never session content.
+// Only Claude's own message is used, never session content.
 func hookDetail(event string, stdin io.Reader) string {
 	msg := ""
 	if stdin != nil {

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/command"
+	"andriiklymiuk/corgi/utils/agent/daemon"
+
+	"github.com/spf13/cobra"
+)
+
+// Claude Code fires hooks for its own lifecycle. Two of them answer the
+// question a phone cannot see: is this session waiting for me? corgi writes
+// them into the workspace's LOCAL settings (never the committed file), pointed
+// at `corgi agent hook`, which spools the event for the daemon to notify on.
+const (
+	hookEventNotification = "Notification"
+	hookEventStop         = "Stop"
+	hookMarker            = "corgi agent hook"
+)
+
+var agentHooksCmd = &cobra.Command{
+	Use:   "hooks",
+	Short: "Get notified when a session in this workspace needs you",
+}
+
+var agentHooksEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Notify when a Claude session here asks for permission or finishes",
+	Long: `Writes two Claude Code hooks into .claude/settings.local.json (local to this
+machine, never committed): one for permission prompts and questions, one for a
+finished turn. Both call ` + "`corgi agent hook`" + `, which tells the corgi
+daemon, which sends the same notification as a restart — including the phone
+push when notifyUrl is set.
+
+Covers every Claude session in the directory, not just supervised ones.`,
+	Run: runAgentHooksEnable,
+}
+
+var agentHooksDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Remove the hooks corgi added to this workspace",
+	Run:   runAgentHooksDisable,
+}
+
+var agentHookCmd = &cobra.Command{
+	Use:    "hook <event>",
+	Short:  "Internal: called by a Claude Code hook to report a session needs attention",
+	Args:   cobra.ExactArgs(1),
+	Hidden: true,
+	Run:    runAgentHook,
+}
+
+func claudeLocalSettingsPath(dir string) string {
+	return filepath.Join(dir, ".claude", "settings.local.json")
+}
+
+func runAgentHooksEnable(_ *cobra.Command, _ []string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		exitWithError("agent_cwd", err, 1)
+	}
+	registry, _ := mustLoadRegistry()
+	registry.Reconcile(dirIsWorkspace)
+	id := ""
+	for _, w := range registry.Sorted() {
+		if w.AbsPath == cwd {
+			id = w.ID
+			break
+		}
+	}
+	if id == "" {
+		exitWithError("agent_hooks", fmt.Errorf(
+			"this directory is not a registered workspace — run `corgi agent init` here first"), 2)
+	}
+
+	path := claudeLocalSettingsPath(cwd)
+	settings := readJSONObject(path)
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	for _, event := range []string{hookEventNotification, hookEventStop} {
+		hooks[event] = withCorgiHook(hooks[event], id)
+	}
+	settings["hooks"] = hooks
+
+	if err := writeJSONObject(path, settings); err != nil {
+		exitWithError("agent_hooks", err, 1)
+	}
+	utils.Infof("✓ %s will notify you when a session here needs you (%s)\n", id, path)
+	utils.Info("phone push needs notifyUrl in the agent config — see docs/agent.md")
+	utils.Info("undo with `corgi agent hooks disable`")
+}
+
+// withCorgiHook adds corgi's matcher to whatever the file already had for that
+// event, leaving every other hook in place. Re-running replaces only ours.
+func withCorgiHook(existing any, workspaceID string) []any {
+	out := stripCorgiHooks(existing)
+	return append(out, map[string]any{
+		"hooks": []any{map[string]any{
+			"type":    "command",
+			"command": fmt.Sprintf("corgi agent hook $CLAUDE_HOOK_EVENT --workspace %s", workspaceID),
+		}},
+	})
+}
+
+func stripCorgiHooks(existing any) []any {
+	list, _ := existing.([]any)
+	out := []any{}
+	for _, entry := range list {
+		if !strings.Contains(marshalCompact(entry), hookMarker) {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func runAgentHooksDisable(_ *cobra.Command, _ []string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		exitWithError("agent_cwd", err, 1)
+	}
+	path := claudeLocalSettingsPath(cwd)
+	settings := readJSONObject(path)
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		utils.Info("no corgi hooks here")
+		return
+	}
+	for _, event := range []string{hookEventNotification, hookEventStop} {
+		remaining := stripCorgiHooks(hooks[event])
+		if len(remaining) == 0 {
+			delete(hooks, event)
+			continue
+		}
+		hooks[event] = remaining
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	} else {
+		settings["hooks"] = hooks
+	}
+	if err := writeJSONObject(path, settings); err != nil {
+		exitWithError("agent_hooks", err, 1)
+	}
+	utils.Infof("✓ removed corgi's hooks from %s\n", path)
+}
+
+// runAgentHook is the hook target. It must be fast and silent: Claude Code
+// runs it inline, and anything it prints lands in the user's session.
+func runAgentHook(cmd *cobra.Command, args []string) {
+	utils.NonInteractive = true
+	id, _ := cmd.Flags().GetString("workspace")
+	if strings.TrimSpace(id) == "" {
+		return
+	}
+	detail := hookDetail(args[0], os.Stdin)
+
+	dir, err := agentDir()
+	if err != nil {
+		return
+	}
+	info, err := daemon.ReadInfo(dir)
+	if err != nil || info == nil || !info.Commands {
+		return // no daemon to tell; the session is unaffected either way
+	}
+	if _, err := command.Write(dir, command.Command{
+		Action: command.ActionAttention, WorkspaceID: id, Detail: detail, Source: "hook",
+	}); err != nil {
+		return
+	}
+	daemon.Nudge(info)
+}
+
+// hookDetail turns the hook payload into one line. Claude Code passes the
+// event as JSON on stdin; only its own message is used, never session content.
+func hookDetail(event string, stdin io.Reader) string {
+	msg := ""
+	if stdin != nil {
+		var payload struct {
+			Message string `json:"message"`
+		}
+		if data, err := io.ReadAll(io.LimitReader(stdin, 8<<10)); err == nil {
+			_ = json.Unmarshal(data, &payload)
+			msg = strings.TrimSpace(payload.Message)
+		}
+	}
+	switch {
+	case msg != "":
+		return truncateLine(msg, 160)
+	case event == hookEventStop:
+		return "a session finished its turn"
+	default:
+		return "a session is waiting for you"
+	}
+}
+
+func truncateLine(s string, max int) string {
+	s = strings.TrimSpace(strings.SplitN(s, "\n", 2)[0])
+	if len(s) > max {
+		return strings.TrimSpace(s[:max]) + "…"
+	}
+	return s
+}
+
+func readJSONObject(path string) map[string]any {
+	out := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	if json.Unmarshal(data, &out) != nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func writeJSONObject(path string, v map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+func marshalCompact(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func init() {
+	agentHookCmd.Flags().String("workspace", "", "Workspace id the hook belongs to")
+	agentHooksCmd.AddCommand(agentHooksEnableCmd, agentHooksDisableCmd)
+	agentCmd.AddCommand(agentHooksCmd, agentHookCmd)
+}

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -50,9 +50,11 @@ var agentHooksDisableCmd = &cobra.Command{
 }
 
 var agentHookCmd = &cobra.Command{
-	Use:    "hook <event>",
-	Short:  "Internal: called by a Claude Code hook to report a session needs attention",
-	Args:   cobra.ExactArgs(1),
+	Use:   "hook",
+	Short: "Internal: called by a Claude Code hook to report a session needs attention",
+	// The event name arrives in the hook payload on stdin. An optional
+	// positional is accepted so a hand-written hook can pass one too.
+	Args:   cobra.MaximumNArgs(1),
 	Hidden: true,
 	Run:    runAgentHook,
 }
@@ -99,14 +101,13 @@ func runAgentHooksEnable(_ *cobra.Command, _ []string) {
 	utils.Info("undo with `corgi agent hooks disable`")
 }
 
-// withCorgiHook adds corgi's matcher to whatever the file already had for that
-// event, leaving every other hook in place. Re-running replaces only ours.
+// Leaves every other hook in place; re-running replaces only ours.
 func withCorgiHook(existing any, workspaceID string) []any {
 	out := stripCorgiHooks(existing)
 	return append(out, map[string]any{
 		"hooks": []any{map[string]any{
 			"type":    "command",
-			"command": fmt.Sprintf("corgi agent hook $CLAUDE_HOOK_EVENT --workspace %s", workspaceID),
+			"command": fmt.Sprintf("corgi agent hook --workspace %s", workspaceID),
 		}},
 	})
 }
@@ -153,15 +154,19 @@ func runAgentHooksDisable(_ *cobra.Command, _ []string) {
 	utils.Infof("✓ removed corgi's hooks from %s\n", path)
 }
 
-// runAgentHook is the hook target. It must be fast and silent: Claude Code
-// runs it inline, and anything it prints lands in the user's session.
+// Fast and silent: Claude Code runs this inline, and anything it prints lands
+// in the user's session.
 func runAgentHook(cmd *cobra.Command, args []string) {
 	utils.NonInteractive = true
 	id, _ := cmd.Flags().GetString("workspace")
 	if strings.TrimSpace(id) == "" {
 		return
 	}
-	detail := hookDetail(args[0], os.Stdin)
+	event := ""
+	if len(args) > 0 {
+		event = args[0]
+	}
+	detail := hookDetail(event, os.Stdin)
 
 	dir, err := agentDir()
 	if err != nil {
@@ -179,17 +184,21 @@ func runAgentHook(cmd *cobra.Command, args []string) {
 	daemon.Nudge(info)
 }
 
-// hookDetail turns the hook payload into one line. Claude Code passes the
-// event as JSON on stdin; only its own message is used, never session content.
+// The hook payload arrives as JSON on stdin. Only Claude's own message is
+// used, never session content.
 func hookDetail(event string, stdin io.Reader) string {
 	msg := ""
 	if stdin != nil {
 		var payload struct {
 			Message string `json:"message"`
+			Event   string `json:"hook_event_name"`
 		}
 		if data, err := io.ReadAll(io.LimitReader(stdin, 8<<10)); err == nil {
 			_ = json.Unmarshal(data, &payload)
 			msg = strings.TrimSpace(payload.Message)
+			if event == "" {
+				event = strings.TrimSpace(payload.Event)
+			}
 		}
 	}
 	switch {

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -55,6 +55,24 @@ var agentHookCmd = &cobra.Command{
 	Run:    runAgentHook,
 }
 
+// samePath compares directories through their symlinks: on macOS a registered
+// /var/... path and the same directory as os.Getwd() reports it (/private/var)
+// are the same place, and a string compare would call them different.
+func samePath(a, b string) bool {
+	if a == b {
+		return true
+	}
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		return false
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		return false
+	}
+	return ra == rb
+}
+
 func claudeLocalSettingsPath(dir string) string {
 	return filepath.Join(dir, ".claude", "settings.local.json")
 }
@@ -68,7 +86,7 @@ func runAgentHooksEnable(_ *cobra.Command, _ []string) {
 	registry.Reconcile(dirIsWorkspace)
 	id := ""
 	for _, w := range registry.Sorted() {
-		if w.AbsPath == cwd {
+		if samePath(w.AbsPath, cwd) {
 			id = w.ID
 			break
 		}

--- a/cmd/agent_notify.go
+++ b/cmd/agent_notify.go
@@ -3,9 +3,42 @@ package cmd
 import (
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
+
+// publicURLName records the launcher's public origin so a notification can
+// carry a tap target. Written by the MCP server, read by the daemon — two
+// processes, so a file rather than a variable.
+const publicURLName = "public.url"
+
+func recordPublicURL(url string) {
+	dir, err := agentDir()
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(dir, publicURLName), []byte(strings.TrimSpace(url)+"\n"), 0o600)
+}
+
+// launcherURL is where a notification should send someone who taps it. Empty
+// when no tunnel has published one, in which case the push carries no link.
+func launcherURL() string {
+	dir, err := agentDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(dir, publicURLName))
+	if err != nil {
+		return ""
+	}
+	u, err := url.Parse(strings.TrimSpace(string(data)))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return ""
+	}
+	return strings.TrimSuffix(u.String(), "/") + "/app"
+}
 
 func webhookNotifier(rawURL string, client *http.Client) func(title, body string) {
 	u, err := url.Parse(strings.TrimSpace(rawURL))
@@ -25,6 +58,10 @@ func webhookNotifier(rawURL string, client *http.Client) func(title, body string
 			// ntfy shows raw bytes for non-ASCII header values, so keep it ASCII.
 			req.Header.Set("Title", asciiHeader(title))
 			req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+			// ntfy turns this into the notification's tap target.
+			if link := launcherURL(); link != "" {
+				req.Header.Set("Click", link)
+			}
 			resp, err := client.Do(req)
 			if err != nil {
 				return

--- a/cmd/agent_notify.go
+++ b/cmd/agent_notify.go
@@ -9,9 +9,7 @@ import (
 	"time"
 )
 
-// publicURLName records the launcher's public origin so a notification can
-// carry a tap target. Written by the MCP server, read by the daemon — two
-// processes, so a file rather than a variable.
+// Written by the MCP server, read by the daemon — two processes, so a file.
 const publicURLName = "public.url"
 
 func recordPublicURL(url string) {
@@ -22,8 +20,6 @@ func recordPublicURL(url string) {
 	_ = os.WriteFile(filepath.Join(dir, publicURLName), []byte(strings.TrimSpace(url)+"\n"), 0o600)
 }
 
-// launcherURL is where a notification should send someone who taps it. Empty
-// when no tunnel has published one, in which case the push carries no link.
 func launcherURL() string {
 	dir, err := agentDir()
 	if err != nil {

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -470,3 +470,221 @@ func TestSetupNgrokTunnelChecksTheAuthtoken(t *testing.T) {
 		t.Errorf("a configured ngrok must pass, got %v", err)
 	}
 }
+
+func tunnelSetupCmd(t *testing.T, provider string, dryRun bool) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{}
+	c.Flags().String("provider", provider, "")
+	c.Flags().String("name", "", "")
+	c.Flags().Bool("dry-run", dryRun, "")
+	return c
+}
+
+func TestRunAgentTunnelSetupSavesTheSettings(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	var ran []string
+	origExec, origLook := tunnelExec, tunnelLookup
+	t.Cleanup(func() { tunnelExec, tunnelLookup = origExec, origLook })
+	tunnelExec = func(name string, args ...string) (string, error) {
+		ran = append(ran, name+" "+strings.Join(args, " "))
+		if len(args) > 1 && args[1] == "list" {
+			return "", nil
+		}
+		return "", nil
+	}
+	tunnelLookup = func(string) error { return nil }
+
+	runAgentTunnelSetup(tunnelSetupCmd(t, "cloudflared", false), []string{"corgi.example.com"})
+
+	saved := loadUpSettings(agentD)
+	if saved.TunnelHostname != "corgi.example.com" || saved.TunnelName != "corgi-agent" || saved.Provider != "cloudflared" {
+		t.Fatalf("settings = %+v", saved)
+	}
+	joined := strings.Join(ran, "\n")
+	if !strings.Contains(joined, "tunnel create corgi-agent") {
+		t.Errorf("a tunnel missing from the list must be created:\n%s", joined)
+	}
+	if !strings.Contains(joined, "route dns corgi-agent corgi.example.com") {
+		t.Errorf("the DNS route must run:\n%s", joined)
+	}
+}
+
+func TestRunAgentTunnelSetupDryRunSavesNothing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	origExec, origLook := tunnelExec, tunnelLookup
+	t.Cleanup(func() { tunnelExec, tunnelLookup = origExec, origLook })
+	tunnelExec = func(string, ...string) (string, error) { return "", nil }
+	tunnelLookup = func(string) error { return nil }
+
+	runAgentTunnelSetup(tunnelSetupCmd(t, "cloudflared", true), []string{"corgi.example.com"})
+	if saved := loadUpSettings(agentD); saved != (upSettings{}) {
+		t.Errorf("a dry run must save nothing, got %+v", saved)
+	}
+}
+
+func TestRunAgentTunnelSetupNgrokSavesNoName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	origExec, origLook := tunnelExec, tunnelLookup
+	t.Cleanup(func() { tunnelExec, tunnelLookup = origExec, origLook })
+	tunnelExec = func(string, ...string) (string, error) { return "", nil }
+	tunnelLookup = func(string) error { return nil }
+
+	runAgentTunnelSetup(tunnelSetupCmd(t, "ngrok", false), []string{"x.ngrok-free.app"})
+	saved := loadUpSettings(agentD)
+	if saved.Provider != "ngrok" || saved.TunnelHostname != "x.ngrok-free.app" || saved.TunnelName != "" {
+		t.Errorf("settings = %+v", saved)
+	}
+}
+
+func TestSamePathThroughSymlinks(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skip("symlinks unavailable")
+	}
+	if !samePath(real, link) {
+		t.Error("a symlink and its target are the same directory")
+	}
+	if !samePath(real, real) {
+		t.Error("an identical path must match without resolving")
+	}
+	if samePath(real, filepath.Join(real, "nope")) {
+		t.Error("different directories must not match")
+	}
+	if samePath("/no/such/a", "/no/such/b") {
+		t.Error("unresolvable paths must not match")
+	}
+}
+
+func TestWebhookNotifierSendsTheClickTarget(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	recordPublicURL("https://x.trycloudflare.com")
+
+	got := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Get("Click")
+	}))
+	defer srv.Close()
+
+	notify := webhookNotifier(srv.URL, srv.Client())
+	notify("corgi agent", "session restarted")
+	select {
+	case click := <-got:
+		if click != "https://x.trycloudflare.com/app" {
+			t.Errorf("Click = %q", click)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("webhook never arrived")
+	}
+}
+
+func TestWorkspaceActivityCountsLiveSessions(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	agentD, _ := agentDir()
+	stack := stackWithAgentConfig(t, "")
+	registerStack(t, agentD, "acme", stack)
+
+	sessions := filepath.Join(home, ".claude", "sessions")
+	if err := os.MkdirAll(sessions, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	row := fmt.Sprintf(`{"pid":%d,"sessionId":"u1","cwd":%q,"kind":"interactive","startedAt":1,"name":"acme-0a"}`, os.Getpid(), stack)
+	if err := os.WriteFile(filepath.Join(sessions, "1.json"), []byte(row), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	live, _ := workspaceActivity("acme", stack)
+	if live != 1 {
+		t.Errorf("live = %d, want the one running process", live)
+	}
+}
+
+func TestRefreshUsageStoresAReport(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	cfg := t.TempDir()
+	repo := "/dev/app"
+	proj := filepath.Join(cfg, "projects", mungeClaudeProjectDir(repo))
+	if err := os.MkdirAll(proj, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	row := fmt.Sprintf(`{"timestamp":"%s","message":{"usage":{"input_tokens":10,"output_tokens":5}}}`, time.Now().Format(time.RFC3339))
+	if err := os.WriteFile(filepath.Join(proj, "a.jsonl"), []byte(row+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	usageCache.mu.Lock()
+	usageCache.reps["acme"] = &cachedUsage{refreshing: true}
+	usageCache.mu.Unlock()
+	refreshUsage("acme", repo, cfg)
+
+	usageCache.mu.Lock()
+	entry := usageCache.reps["acme"]
+	usageCache.mu.Unlock()
+	if entry.report == nil || entry.report.Today.Total() != 15 {
+		t.Fatalf("report = %+v", entry.report)
+	}
+	if entry.refreshing || entry.computed.IsZero() {
+		t.Error("a finished refresh must clear the flag and stamp the time")
+	}
+}
+
+func TestLaunchInfoReportsARunningDaemon(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	info := map[string]any{
+		"pid": os.Getpid(), "version": APP_VERSION, "startedAt": time.Now().Format(time.RFC3339),
+		"executable": mustExecutable(t), "workspaces": []string{}, "commands": true,
+	}
+	data, _ := json.Marshal(info)
+	if err := os.WriteFile(filepath.Join(agentD, "daemon.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	launchInfoHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/info", nil))
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["daemon"] != true {
+		t.Errorf("a running daemon must be reported, got %v", body)
+	}
+}
+
+func mustExecutable(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return exe
+}

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -1,0 +1,266 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/events"
+	"andriiklymiuk/corgi/utils/agent/pairing"
+)
+
+func TestSanitizeSessionName(t *testing.T) {
+	cases := map[string]string{
+		"  fix login  ":         "fix login",
+		"--permission-mode x":   "permission-mode x",
+		"idé ✨ ok":              "id  ok",
+		strings.Repeat("a", 80): strings.Repeat("a", 60),
+		"":                      "",
+	}
+	for in, want := range cases {
+		if got := sanitizeSessionName(in); got != want {
+			t.Errorf("sanitizeSessionName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLaunchInfoReportsTheMachine(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	rec := httptest.NewRecorder()
+	launchInfoHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/info", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["version"] != APP_VERSION {
+		t.Errorf("version = %v, want %s", body["version"], APP_VERSION)
+	}
+	if body["daemon"] != false {
+		t.Errorf("with no daemon running, daemon must be false, got %v", body["daemon"])
+	}
+
+	rec = httptest.NewRecorder()
+	launchInfoHandler(rec, httptest.NewRequest(http.MethodPost, "/launch/info", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST must be 405, got %d", rec.Code)
+	}
+}
+
+func TestLaunchDevicesListsAndRevokes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store := &pairing.Store{Devices: []pairing.Device{
+		{Name: "phone", TokenHash: pairing.HashToken("t1"), CreatedAt: time.Now()},
+		{Name: "tablet", TokenHash: pairing.HashToken("t2"), CreatedAt: time.Now()},
+	}}
+	if err := pairing.Save(pairing.StorePath(agentD), store); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	launchDevicesHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/devices", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "tablet") {
+		t.Fatalf("list = %d %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	launchDevicesHandler(rec, httptest.NewRequest(http.MethodDelete, "/launch/devices?name=tablet", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke = %d %s", rec.Code, rec.Body.String())
+	}
+	after, _ := pairing.Load(pairing.StorePath(agentD))
+	if _, ok := after.Find("tablet"); ok {
+		t.Error("tablet must be gone from the store")
+	}
+
+	rec = httptest.NewRecorder()
+	launchDevicesHandler(rec, httptest.NewRequest(http.MethodDelete, "/launch/devices", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("a revoke without a name must be 400, got %d", rec.Code)
+	}
+}
+
+func TestLaunchDevicesRefusesSelfRevoke(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	token, err := pairing.NewDeviceToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &pairing.Store{Devices: []pairing.Device{{Name: "phone", TokenHash: pairing.HashToken(token), CreatedAt: time.Now()}}}
+	if err := pairing.Save(pairing.StorePath(agentD), store); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/launch/devices?name=phone", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	launchDevicesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("a device must not revoke itself, got %d", rec.Code)
+	}
+	after, _ := pairing.Load(pairing.StorePath(agentD))
+	if _, ok := after.Find("phone"); !ok {
+		t.Error("the device must still be paired after the refusal")
+	}
+}
+
+func TestLaunchDoctorServesTheChecks(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	rec := httptest.NewRecorder()
+	launchDoctorHandler(rec, httptest.NewRequest(http.MethodGet, "/launch/doctor", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body struct {
+		Checks []agentCheck `json:"checks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Checks) == 0 {
+		t.Error("doctor must return its checks")
+	}
+}
+
+func TestWorkspaceActivityReadsTheTimeline(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	events.NewLog(agentD).Append("acme", events.Event{Kind: "exited", Cause: "network-timeout", Reason: "boom"})
+
+	live, last := workspaceActivity("acme", "")
+	if live != 0 {
+		t.Errorf("live = %d with no workspace path", live)
+	}
+	if last == nil || last.Kind != "exited" || last.Cause != "network-timeout" || last.At == 0 {
+		t.Errorf("lastEvent = %+v", last)
+	}
+
+	if _, none := workspaceActivity("ghost", ""); none != nil {
+		t.Errorf("a workspace with no timeline has no last event, got %+v", none)
+	}
+}
+
+func TestRecentEventsIsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	log := events.NewLog(agentD)
+	log.Append("acme", events.Event{Kind: "started"})
+	log.Append("acme", events.Event{Kind: "attention", Reason: "waiting for permission"})
+
+	got := recentEvents("acme", 6)
+	if len(got) != 2 || got[0].Kind != "attention" {
+		t.Fatalf("events = %+v", got)
+	}
+	if len(recentEvents("acme", 1)) != 1 {
+		t.Error("limit must cap the result")
+	}
+}
+
+func TestLauncherURLFromRecordedTunnel(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if got := launcherURL(); got != "" {
+		t.Errorf("no recorded URL means no link, got %q", got)
+	}
+	recordPublicURL("https://x.trycloudflare.com")
+	if got := launcherURL(); got != "https://x.trycloudflare.com/app" {
+		t.Errorf("launcherURL = %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(agentD, publicURLName), []byte("file:///etc/passwd\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := launcherURL(); got != "" {
+		t.Errorf("a non-http URL must be refused, got %q", got)
+	}
+}
+
+func TestTunnelNameFor(t *testing.T) {
+	if got := tunnelNameFor("ngrok", "corgi-agent"); got != "" {
+		t.Errorf("ngrok selects by domain, so the name must not be saved, got %q", got)
+	}
+	if got := tunnelNameFor("cloudflared", "corgi-agent"); got != "corgi-agent" {
+		t.Errorf("cloudflared name = %q", got)
+	}
+}
+
+func TestSetupCloudflaredTunnelPlan(t *testing.T) {
+	var ran [][]string
+	run := func(name string, args ...string) (string, error) {
+		ran = append(ran, append([]string{name}, args...))
+		if len(args) > 1 && args[1] == "list" {
+			return "corgi-agent\tid\n", nil
+		}
+		return "", nil
+	}
+	if err := setupCloudflaredTunnel(run, "corgi-agent", "corgi.example.com", true); err != nil {
+		t.Fatal(err)
+	}
+	joined := ""
+	for _, c := range ran {
+		joined += strings.Join(c, " ") + "\n"
+	}
+	if strings.Contains(joined, "tunnel create") {
+		t.Errorf("an existing tunnel must not be recreated:\n%s", joined)
+	}
+	if !strings.Contains(joined, "route dns corgi-agent corgi.example.com") {
+		t.Errorf("the DNS route must be planned:\n%s", joined)
+	}
+}
+
+func TestHookDetail(t *testing.T) {
+	if got := hookDetail(hookEventNotification, strings.NewReader(`{"message":"Claude needs your permission to run rm"}`)); got != "Claude needs your permission to run rm" {
+		t.Errorf("detail = %q", got)
+	}
+	if got := hookDetail(hookEventStop, strings.NewReader("")); got != "a session finished its turn" {
+		t.Errorf("stop fallback = %q", got)
+	}
+	if got := hookDetail(hookEventNotification, nil); got != "a session is waiting for you" {
+		t.Errorf("nil stdin fallback = %q", got)
+	}
+	long := `{"message":"` + strings.Repeat("x", 300) + `"}`
+	if got := hookDetail(hookEventNotification, strings.NewReader(long)); len([]rune(got)) > 161 {
+		t.Errorf("detail must be truncated, got %d runes", len([]rune(got)))
+	}
+}
+
+func TestWithCorgiHookReplacesOnlyOurs(t *testing.T) {
+	other := map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "echo mine"}}}
+	first := withCorgiHook([]any{other}, "acme")
+	if len(first) != 2 {
+		t.Fatalf("entries = %d, want the existing one plus ours", len(first))
+	}
+	again := withCorgiHook(first, "acme")
+	if len(again) != 2 {
+		t.Errorf("re-running must replace ours, not add another: %d entries", len(again))
+	}
+	if !strings.Contains(marshalCompact(again), "--workspace acme") {
+		t.Error("our hook must carry the workspace id")
+	}
+	stripped := stripCorgiHooks(again)
+	if len(stripped) != 1 || !strings.Contains(marshalCompact(stripped), "echo mine") {
+		t.Errorf("disable must leave other hooks alone: %v", stripped)
+	}
+}

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -278,3 +278,20 @@ func TestWithCorgiHookReplacesOnlyOurs(t *testing.T) {
 		t.Errorf("disable must leave other hooks alone: %v", stripped)
 	}
 }
+
+func TestLauncherPageCarriesTheNewControls(t *testing.T) {
+	rec := httptest.NewRecorder()
+	launcherPageHandler(rec, httptest.NewRequest(http.MethodGet, "/app", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		"/launch/info", "/launch/devices", "/launch/doctor",
+		"corgi_hidden", "data-role=\"profile\"", "ngrok-skip-browser-warning",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the launcher must carry %q", want)
+		}
+	}
+	if strings.Contains(body, "src=\"http") || strings.Contains(body, "href=\"http") {
+		t.Error("the launcher must stay self-contained")
+	}
+}

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -13,6 +13,8 @@ import (
 
 	"andriiklymiuk/corgi/utils/agent/events"
 	"andriiklymiuk/corgi/utils/agent/pairing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestSanitizeSessionName(t *testing.T) {
@@ -293,5 +295,178 @@ func TestLauncherPageCarriesTheNewControls(t *testing.T) {
 	}
 	if strings.Contains(body, "src=\"http") || strings.Contains(body, "href=\"http") {
 		t.Error("the launcher must stay self-contained")
+	}
+}
+
+func TestWorkspaceUsageIsOmittedWhenIdle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	t.Setenv("HOME", t.TempDir())
+	agentD, _ := agentDir()
+	stack := stackWithAgentConfig(t, "")
+	registerStack(t, agentD, "acme", stack)
+
+	if got := workspaceUsage("acme", stack); got != nil {
+		t.Errorf("the first call must not block on a scan, got %+v", got)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		usageCache.mu.Lock()
+		done := usageCache.reps["acme"] != nil && !usageCache.reps["acme"].computed.IsZero()
+		usageCache.mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := workspaceUsage("acme", stack); got != nil {
+		t.Errorf("a workspace with no transcripts must report no usage, got %+v", got)
+	}
+	if got := workspaceUsage("acme", ""); got != nil {
+		t.Errorf("no path means no usage, got %+v", got)
+	}
+	if line := workspaceUsageLine("acme"); line != "" {
+		t.Errorf("status must print nothing when there is no usage, got %q", line)
+	}
+}
+
+func TestFormatTokens(t *testing.T) {
+	cases := map[int64]string{0: "0", 999: "999", 1500: "1k", 2_400_000: "2.4M", 1_050_000_000: "1.1B"}
+	for in, want := range cases {
+		if got := formatTokens(in); got != want {
+			t.Errorf("formatTokens(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAgentHooksEnableThenDisableRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	stack := stackWithAgentConfig(t, "")
+	registerStack(t, agentD, "acme", stack)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(stack); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	path := claudeLocalSettingsPath(stack)
+	if err := writeJSONObject(path, map[string]any{
+		"hooks": map[string]any{"Notification": []any{
+			map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "echo mine"}}},
+		}},
+		"other": "kept",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runAgentHooksEnable(nil, nil)
+	after := readJSONObject(path)
+	hooks, _ := after["hooks"].(map[string]any)
+	if hooks == nil || len(hooks) != 2 {
+		t.Fatalf("both events must be hooked, got %v", after["hooks"])
+	}
+	if !strings.Contains(marshalCompact(hooks), "--workspace acme") {
+		t.Errorf("our hook must name the workspace: %s", marshalCompact(hooks))
+	}
+	if after["other"] != "kept" {
+		t.Error("unrelated settings must survive")
+	}
+
+	runAgentHooksDisable(nil, nil)
+	after = readJSONObject(path)
+	body := marshalCompact(after)
+	if strings.Contains(body, hookMarker) {
+		t.Errorf("disable must remove our hooks: %s", body)
+	}
+	if !strings.Contains(body, "echo mine") {
+		t.Errorf("disable must leave other hooks alone: %s", body)
+	}
+	if after["other"] != "kept" {
+		t.Error("disable must not touch unrelated settings")
+	}
+}
+
+func TestReadJSONObjectTolerates(t *testing.T) {
+	dir := t.TempDir()
+	if got := readJSONObject(filepath.Join(dir, "nope.json")); len(got) != 0 {
+		t.Errorf("a missing file is an empty object, got %v", got)
+	}
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readJSONObject(bad); len(got) != 0 {
+		t.Errorf("unparseable settings must not be treated as content, got %v", got)
+	}
+}
+
+func TestLaunchProfileNamesFromTrustedConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", dir)
+	agentD, _ := agentDir()
+	if err := os.MkdirAll(agentD, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if got := launchProfileNames(); got != nil {
+		t.Errorf("no config means no profiles, got %v", got)
+	}
+	cfg := "version: 1\nprofiles:\n  work:\n    configDir: ~/.claude-work\n  personal:\n    configDir: ~/.claude\n"
+	if err := os.WriteFile(agentUserConfigPath(agentD), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := launchProfileNames()
+	if len(got) != 2 || got[0] != "personal" || got[1] != "work" {
+		t.Errorf("profiles = %v, want them sorted", got)
+	}
+}
+
+func TestRunAgentHookIsSilentWithoutADaemon(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	c := &cobra.Command{}
+	c.Flags().String("workspace", "acme", "")
+
+	// No daemon, no workspace flag, and a junk payload: every path must return
+	// quietly, because anything printed lands in the user's Claude session.
+	runAgentHook(c, []string{hookEventNotification})
+	runAgentHook(c, nil)
+	empty := &cobra.Command{}
+	empty.Flags().String("workspace", "", "")
+	runAgentHook(empty, []string{hookEventStop})
+}
+
+func TestExecRunnerReportsAFailure(t *testing.T) {
+	if _, err := execRunner("sh", "-c", "exit 3"); err == nil {
+		t.Error("a failing command must report an error")
+	}
+	if out, err := execRunner("sh", "-c", "echo hi"); err != nil || !strings.Contains(out, "hi") {
+		t.Errorf("out=%q err=%v", out, err)
+	}
+}
+
+func TestLookPathFindsAndMisses(t *testing.T) {
+	if err := lookPath("sh"); err != nil {
+		t.Errorf("sh must be found: %v", err)
+	}
+	if err := lookPath("corgi-not-a-real-binary"); err == nil {
+		t.Error("a missing binary must report an error")
+	}
+}
+
+func TestSetupNgrokTunnelChecksTheAuthtoken(t *testing.T) {
+	installed := func(string) error { return nil }
+	failing := func(string, ...string) (string, error) { return "", fmt.Errorf("no authtoken") }
+	if err := setupNgrokTunnel(failing, installed, "x.ngrok-free.app"); err == nil ||
+		!strings.Contains(err.Error(), "authtoken") {
+		t.Errorf("a missing authtoken must be reported with the fix, got %v", err)
+	}
+	ok := func(string, ...string) (string, error) { return "", nil }
+	if err := setupNgrokTunnel(ok, installed, "x.ngrok-free.app"); err != nil {
+		t.Errorf("a configured ngrok must pass, got %v", err)
 	}
 }

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -285,7 +285,7 @@ func TestLauncherPageCarriesTheNewControls(t *testing.T) {
 	body := rec.Body.String()
 	for _, want := range []string{
 		"/launch/info", "/launch/devices", "/launch/doctor",
-		"corgi_hidden", "data-role=\"profile\"", "ngrok-skip-browser-warning",
+		"corgi_hidden", "dataset.role", "ngrok-skip-browser-warning",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("the launcher must carry %q", want)

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -215,7 +216,8 @@ func TestSetupCloudflaredTunnelPlan(t *testing.T) {
 		}
 		return "", nil
 	}
-	if err := setupCloudflaredTunnel(run, "corgi-agent", "corgi.example.com", true); err != nil {
+	installed := func(string) error { return nil }
+	if err := setupCloudflaredTunnel(run, installed, "corgi-agent", "corgi.example.com", true); err != nil {
 		t.Fatal(err)
 	}
 	joined := ""
@@ -227,6 +229,18 @@ func TestSetupCloudflaredTunnelPlan(t *testing.T) {
 	}
 	if !strings.Contains(joined, "route dns corgi-agent corgi.example.com") {
 		t.Errorf("the DNS route must be planned:\n%s", joined)
+	}
+}
+
+func TestSetupTunnelRequiresTheBinary(t *testing.T) {
+	missing := func(name string) error { return fmt.Errorf("%s not found", name) }
+	run := func(string, ...string) (string, error) { return "", nil }
+	if err := setupCloudflaredTunnel(run, missing, "corgi-agent", "h", true); err == nil ||
+		!strings.Contains(err.Error(), "not installed") {
+		t.Errorf("a missing cloudflared must say so, got %v", err)
+	}
+	if err := setupNgrokTunnel(run, missing, "h"); err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Errorf("a missing ngrok must say so, got %v", err)
 	}
 }
 

--- a/cmd/agent_profile_test.go
+++ b/cmd/agent_profile_test.go
@@ -94,7 +94,7 @@ func TestAddedProfileIsSelectableByTheResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg, err := remoteResolver(dir, false)("acme", "work")
+	cfg, err := remoteResolver(dir, false)("acme", "work", "")
 	if err != nil {
 		t.Fatalf("a profile added by the command must resolve at start, got %v", err)
 	}

--- a/cmd/agent_remote_resolver_test.go
+++ b/cmd/agent_remote_resolver_test.go
@@ -45,7 +45,7 @@ func TestRemoteResolverRefusesASensitiveWorkspace(t *testing.T) {
 	stack := stackWithAgentConfig(t, "version: 1\nworkspace:\n  id: acme\n  sensitive: true\n")
 	registerStack(t, agentDir, "acme", stack)
 
-	_, err := remoteResolver(agentDir, false)("acme", "")
+	_, err := remoteResolver(agentDir, false)("acme", "", "")
 
 	if err == nil {
 		t.Fatal("a sensitive workspace must refuse remote session start")
@@ -60,7 +60,7 @@ func TestRemoteResolverStartsANonSensitiveWorkspace(t *testing.T) {
 	stack := stackWithAgentConfig(t, "version: 1\nworkspace:\n  id: acme\n")
 	registerStack(t, agentDir, "acme", stack)
 
-	cfg, err := remoteResolver(agentDir, false)("acme", "")
+	cfg, err := remoteResolver(agentDir, false)("acme", "", "")
 
 	if err != nil {
 		t.Fatalf("a normal workspace must resolve, got %v", err)
@@ -77,7 +77,7 @@ func TestRemoteResolverRejectsAnUnknownWorkspace(t *testing.T) {
 	agentDir := t.TempDir()
 	registerStack(t, agentDir, "acme", stackWithAgentConfig(t, ""))
 
-	_, err := remoteResolver(agentDir, false)("ghost", "")
+	_, err := remoteResolver(agentDir, false)("ghost", "", "")
 
 	if err == nil || !strings.Contains(err.Error(), "ghost") {
 		t.Errorf("an unknown workspace must error by name, got %v", err)
@@ -93,7 +93,7 @@ func TestRemoteResolverAppliesAProfileEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg, err := remoteResolver(agentDir, false)("acme", "work")
+	cfg, err := remoteResolver(agentDir, false)("acme", "work", "")
 
 	if err != nil {
 		t.Fatalf("profile start must resolve, got %v", err)
@@ -115,7 +115,7 @@ func TestRemoteResolverRejectsAnUnknownProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := remoteResolver(agentDir, false)("acme", "gaming")
+	_, err := remoteResolver(agentDir, false)("acme", "gaming", "")
 
 	if err == nil || !strings.Contains(err.Error(), "work") {
 		t.Errorf("an unknown profile must error and list the defined ones, got %v", err)

--- a/cmd/agent_tunnel.go
+++ b/cmd/agent_tunnel.go
@@ -35,6 +35,15 @@ static domain itself is a dashboard step with no CLI equivalent.`,
 // touching cloudflared.
 type tunnelRunner func(name string, args ...string) (string, error)
 
+// binaryLookup reports whether a command exists. Injected so the setup plan can
+// be tested on a machine (or a CI runner) without cloudflared installed.
+type binaryLookup func(string) error
+
+func lookPath(name string) error {
+	_, err := exec.LookPath(name)
+	return err
+}
+
 func execRunner(name string, args ...string) (string, error) {
 	out, err := exec.Command(name, args...).CombinedOutput()
 	return string(out), err
@@ -68,11 +77,11 @@ func runAgentTunnelSetup(cmd *cobra.Command, args []string) {
 
 	switch provider {
 	case "cloudflared":
-		if err := setupCloudflaredTunnel(run, name, host, dryRun); err != nil {
+		if err := setupCloudflaredTunnel(run, lookPath, name, host, dryRun); err != nil {
 			exitWithError("agent_tunnel_setup", err, 1)
 		}
 	case "ngrok":
-		if err := setupNgrokTunnel(run, host); err != nil {
+		if err := setupNgrokTunnel(run, lookPath, host); err != nil {
 			exitWithError("agent_tunnel_setup", err, 1)
 		}
 	default:
@@ -100,8 +109,8 @@ func tunnelNameFor(provider, name string) string {
 	return name
 }
 
-func setupCloudflaredTunnel(run tunnelRunner, name, host string, dryRun bool) error {
-	if _, err := exec.LookPath("cloudflared"); err != nil {
+func setupCloudflaredTunnel(run tunnelRunner, have binaryLookup, name, host string, dryRun bool) error {
+	if err := have("cloudflared"); err != nil {
 		return fmt.Errorf("cloudflared is not installed — `brew install cloudflared` (or see developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads)")
 	}
 
@@ -135,8 +144,8 @@ func setupCloudflaredTunnel(run tunnelRunner, name, host string, dryRun bool) er
 	return nil
 }
 
-func setupNgrokTunnel(run tunnelRunner, host string) error {
-	if _, err := exec.LookPath("ngrok"); err != nil {
+func setupNgrokTunnel(run tunnelRunner, have binaryLookup, host string) error {
+	if err := have("ngrok"); err != nil {
 		return fmt.Errorf("ngrok is not installed — `brew install ngrok`")
 	}
 	if _, err := run("ngrok", "config", "check"); err != nil {

--- a/cmd/agent_tunnel.go
+++ b/cmd/agent_tunnel.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var agentTunnelCmd = &cobra.Command{
+	Use:   "tunnel",
+	Short: "Set up the permanent launcher URL",
+}
+
+var agentTunnelSetupCmd = &cobra.Command{
+	Use:   "setup <hostname>",
+	Short: "One-time setup for a launcher URL that survives restarts",
+	Long: `Does the permanent-URL setup end to end and remembers it for later runs.
+
+For cloudflared (the default) it logs you in if needed, creates the named
+tunnel when it does not exist, routes the DNS name to it, and saves both flags
+so a plain ` + "`corgi agent restart`" + ` keeps the same URL — and the phone
+stays paired, because the origin never changes.
+
+For ngrok it checks the authtoken and saves the domain; claiming the free
+static domain itself is a dashboard step with no CLI equivalent.`,
+	Args: cobra.ExactArgs(1),
+	Run:  runAgentTunnelSetup,
+}
+
+// runner executes one setup step. Injected so the plan can be tested without
+// touching cloudflared.
+type tunnelRunner func(name string, args ...string) (string, error)
+
+func execRunner(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).CombinedOutput()
+	return string(out), err
+}
+
+func runAgentTunnelSetup(cmd *cobra.Command, args []string) {
+	host := strings.TrimSpace(args[0])
+	provider, _ := cmd.Flags().GetString("provider")
+	name, _ := cmd.Flags().GetString("name")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	if provider == "" {
+		provider = "cloudflared"
+	}
+	if name == "" {
+		name = "corgi-agent"
+	}
+
+	dir, err := agentDir()
+	if err != nil {
+		exitWithError("agent_data_dir", err, 1)
+	}
+
+	run := execRunner
+	if dryRun {
+		run = func(bin string, a ...string) (string, error) {
+			utils.Infof("  would run: %s %s\n", bin, strings.Join(a, " "))
+			return "", nil
+		}
+	}
+
+	switch provider {
+	case "cloudflared":
+		if err := setupCloudflaredTunnel(run, name, host, dryRun); err != nil {
+			exitWithError("agent_tunnel_setup", err, 1)
+		}
+	case "ngrok":
+		if err := setupNgrokTunnel(run, host); err != nil {
+			exitWithError("agent_tunnel_setup", err, 1)
+		}
+	default:
+		exitWithError("agent_tunnel_setup",
+			fmt.Errorf("tunnel setup covers cloudflared and ngrok; %q has no one-time setup — pass its flags to `corgi agent up` directly", provider), 2)
+	}
+
+	if dryRun {
+		utils.Info("dry run — nothing was changed and no settings were saved")
+		return
+	}
+	if err := saveUpSettings(dir, upSettings{Provider: provider, TunnelName: tunnelNameFor(provider, name), TunnelHostname: host}); err != nil {
+		exitWithError("agent_tunnel_setup", err, 1)
+	}
+	utils.Infof("✓ saved: `corgi agent up` and `corgi agent restart` now serve the launcher at https://%s/app\n", host)
+	utils.Info("next: `corgi agent restart`, then scan the QR once — the phone stays paired from then on")
+}
+
+// tunnelNameFor keeps the name only where it means something: ngrok selects a
+// tunnel by its domain, and passing a name would be recorded but never used.
+func tunnelNameFor(provider, name string) string {
+	if provider == "ngrok" {
+		return ""
+	}
+	return name
+}
+
+func setupCloudflaredTunnel(run tunnelRunner, name, host string, dryRun bool) error {
+	if _, err := exec.LookPath("cloudflared"); err != nil {
+		return fmt.Errorf("cloudflared is not installed — `brew install cloudflared` (or see developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads)")
+	}
+
+	utils.Info("checking cloudflared login…")
+	list, listErr := run("cloudflared", "tunnel", "list")
+	if listErr != nil && !dryRun {
+		utils.Info("not logged in — opening the browser (pick the domain you want the launcher on)")
+		if out, err := run("cloudflared", "tunnel", "login"); err != nil {
+			return fmt.Errorf("cloudflared tunnel login failed: %w\n%s", err, strings.TrimSpace(out))
+		}
+		list, _ = run("cloudflared", "tunnel", "list")
+	}
+
+	if strings.Contains(list, name) {
+		utils.Infof("tunnel %s already exists\n", name)
+	} else {
+		utils.Infof("creating tunnel %s…\n", name)
+		if out, err := run("cloudflared", "tunnel", "create", name); err != nil {
+			return fmt.Errorf("could not create tunnel %s: %w\n%s", name, err, strings.TrimSpace(out))
+		}
+	}
+
+	utils.Infof("routing %s to %s…\n", host, name)
+	if out, err := run("cloudflared", "tunnel", "route", "dns", name, host); err != nil {
+		// An existing route is the normal case on a re-run, not a failure.
+		if !strings.Contains(strings.ToLower(out), "already exists") {
+			return fmt.Errorf("could not route %s: %w\n%s", host, err, strings.TrimSpace(out))
+		}
+		utils.Infof("%s already points at %s\n", host, name)
+	}
+	return nil
+}
+
+func setupNgrokTunnel(run tunnelRunner, host string) error {
+	if _, err := exec.LookPath("ngrok"); err != nil {
+		return fmt.Errorf("ngrok is not installed — `brew install ngrok`")
+	}
+	if _, err := run("ngrok", "config", "check"); err != nil {
+		return fmt.Errorf(`ngrok has no authtoken configured. Get one from
+https://dashboard.ngrok.com/get-started/your-authtoken then run:
+
+    ngrok config add-authtoken <token>`)
+	}
+	utils.Infof("using ngrok domain %s\n", host)
+	utils.Info("if that domain is not claimed yet: dashboard.ngrok.com → Domains → claim your free static domain")
+	return nil
+}
+
+func init() {
+	agentTunnelSetupCmd.Flags().String("provider", "cloudflared", "Tunnel provider (cloudflared|ngrok)")
+	agentTunnelSetupCmd.Flags().String("name", "corgi-agent", "cloudflared tunnel name to create or reuse")
+	agentTunnelSetupCmd.Flags().Bool("dry-run", false, "Print the commands without running them")
+	agentTunnelCmd.AddCommand(agentTunnelSetupCmd)
+	agentCmd.AddCommand(agentTunnelCmd)
+}

--- a/cmd/agent_tunnel.go
+++ b/cmd/agent_tunnel.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"andriiklymiuk/corgi/utils"
 
@@ -31,12 +33,8 @@ static domain itself is a dashboard step with no CLI equivalent.`,
 	Run:  runAgentTunnelSetup,
 }
 
-// runner executes one setup step. Injected so the plan can be tested without
-// touching cloudflared.
 type tunnelRunner func(name string, args ...string) (string, error)
 
-// binaryLookup reports whether a command exists. Injected so the setup plan can
-// be tested on a machine (or a CI runner) without cloudflared installed.
 type binaryLookup func(string) error
 
 func lookPath(name string) error {
@@ -44,8 +42,21 @@ func lookPath(name string) error {
 	return err
 }
 
+// setupStepTimeout bounds every step except the browser login, which waits on
+// a person. Without it a hung cloudflared call blocks the command for ever.
+const setupStepTimeout = 2 * time.Minute
+
 func execRunner(name string, args ...string) (string, error) {
-	out, err := exec.Command(name, args...).CombinedOutput()
+	timeout := setupStepTimeout
+	if len(args) > 1 && args[1] == "login" {
+		timeout = 10 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if ctx.Err() != nil {
+		return string(out), fmt.Errorf("%s %s timed out after %s", name, strings.Join(args, " "), timeout)
+	}
 	return string(out), err
 }
 
@@ -100,8 +111,8 @@ func runAgentTunnelSetup(cmd *cobra.Command, args []string) {
 	utils.Info("next: `corgi agent restart`, then scan the QR once — the phone stays paired from then on")
 }
 
-// tunnelNameFor keeps the name only where it means something: ngrok selects a
-// tunnel by its domain, and passing a name would be recorded but never used.
+// ngrok selects a tunnel by its domain, so a name would be recorded and never
+// used.
 func tunnelNameFor(provider, name string) string {
 	if provider == "ngrok" {
 		return ""

--- a/cmd/agent_tunnel.go
+++ b/cmd/agent_tunnel.go
@@ -60,6 +60,12 @@ func execRunner(name string, args ...string) (string, error) {
 	return string(out), err
 }
 
+// Seams so the whole command can be exercised without cloudflared installed.
+var (
+	tunnelExec   tunnelRunner = execRunner
+	tunnelLookup binaryLookup = lookPath
+)
+
 func runAgentTunnelSetup(cmd *cobra.Command, args []string) {
 	host := strings.TrimSpace(args[0])
 	provider, _ := cmd.Flags().GetString("provider")
@@ -78,7 +84,7 @@ func runAgentTunnelSetup(cmd *cobra.Command, args []string) {
 		exitWithError("agent_data_dir", err, 1)
 	}
 
-	run := execRunner
+	run := tunnelExec
 	if dryRun {
 		run = func(bin string, a ...string) (string, error) {
 			utils.Infof("  would run: %s %s\n", bin, strings.Join(a, " "))
@@ -88,11 +94,11 @@ func runAgentTunnelSetup(cmd *cobra.Command, args []string) {
 
 	switch provider {
 	case "cloudflared":
-		if err := setupCloudflaredTunnel(run, lookPath, name, host, dryRun); err != nil {
+		if err := setupCloudflaredTunnel(run, tunnelLookup, name, host, dryRun); err != nil {
 			exitWithError("agent_tunnel_setup", err, 1)
 		}
 	case "ngrok":
-		if err := setupNgrokTunnel(run, lookPath, host); err != nil {
+		if err := setupNgrokTunnel(run, tunnelLookup, host); err != nil {
 			exitWithError("agent_tunnel_setup", err, 1)
 		}
 	default:

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -332,6 +332,9 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		mux.Handle("/launch/start", bearerAuth(token, http.HandlerFunc(launchStartHandler), deviceStore))
 		mux.Handle("/launch/stop", bearerAuth(token, http.HandlerFunc(launchStopHandler), deviceStore))
 		mux.Handle("/launch/sessions", bearerAuth(token, http.HandlerFunc(launchSessionsHandler), deviceStore))
+		mux.Handle("/launch/info", bearerAuth(token, http.HandlerFunc(launchInfoHandler), deviceStore))
+		mux.Handle("/launch/devices", bearerAuth(token, http.HandlerFunc(launchDevicesHandler), deviceStore))
+		mux.Handle("/launch/doctor", bearerAuth(token, http.HandlerFunc(launchDoctorHandler), deviceStore))
 	}
 
 	// /pair is deliberately NOT behind the bearer check: its whole purpose is
@@ -438,6 +441,7 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 				// Probe the route the tools are actually served on, not the
 				// root — see probeTunnelExposure.
 				go probeTunnelExposure(ctx, mcpProbeTarget(ev.URL))
+				recordPublicURL(ev.URL)
 				fmt.Fprintf(os.Stderr, "🌐 ✓ public MCP endpoint: %s/mcp\n", ev.URL)
 				// Don't reprint the bearer token in a pasteable block on the
 				// public side — the local config (printed earlier) already has it.

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -97,8 +97,9 @@ func registerAgentMCPTools(s *server.MCPServer) {
 				"named entry from the trusted agent config (a different Claude account, e.g. \"work\")."),
 		mcp.WithString("workspace", mcp.Required(), mcp.Description("Workspace id, alias, or human name")),
 		mcp.WithString("profile", mcp.Description("Profile name from the agent config's profiles: section")),
+		mcp.WithString("name", mcp.Description("Session name shown in claude.ai/code, e.g. \"fix login redirect\"")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
-		return mcpSessionStart(r.GetString("workspace", ""), r.GetString("profile", ""))
+		return mcpSessionStart(r.GetString("workspace", ""), r.GetString("profile", ""), r.GetString("name", ""))
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_session_stop",
@@ -137,6 +138,32 @@ func registerAgentMCPTools(s *server.MCPServer) {
 			r.GetString("composePath", ""),
 			r.GetString("branch", ""),
 			splitCSV(r.GetString("services", "")),
+		)
+	}))
+
+	s.AddTool(mcp.NewTool("corgi_pr_open",
+		mcp.WithDescription(
+			"Open a pull request in every repository of the stack that has commits on a branch, and cross-link "+
+				"them so each names its siblings. This is the step after corgi_worktrees_materialize and corgi_diff: "+
+				"it pushes the branch and calls the forge's own CLI (gh, or glab for a GitLab remote). Repositories "+
+				"with no commits are reported as skipped; an already-open pull request is returned, never duplicated."),
+		composeOpt,
+		mcp.WithString("branch", mcp.Required(), mcp.Description("Branch to open pull requests for")),
+		mcp.WithString("title", mcp.Required(), mcp.Description("Pull request title, shared by every repository")),
+		mcp.WithString("body", mcp.Description("Pull request body; the sibling links are appended to it")),
+		mcp.WithString("base", mcp.Description("Base branch (default: each repo's origin HEAD)")),
+		mcp.WithBoolean("draft", mcp.Description("Open them as drafts")),
+	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
+		if !dangerousTunnelToolsAllowed(mcpPublicTunnelActive.Load()) {
+			return nil, fmt.Errorf("%s", agentDangerousBlockedMsg)
+		}
+		return mcpPROpen(
+			r.GetString("composePath", ""),
+			r.GetString("branch", ""),
+			r.GetString("title", ""),
+			r.GetString("body", ""),
+			r.GetString("base", ""),
+			r.GetBool("draft", false),
 		)
 	}))
 
@@ -323,7 +350,7 @@ func resolveForSession(query string) (*workspace.Workspace, any, error) {
 	return res.Workspace, nil, nil
 }
 
-func mcpSessionStart(query, profile string) (any, error) {
+func mcpSessionStart(query, profile, name string) (any, error) {
 	w, ambiguous, err := resolveForSession(query)
 	if err != nil {
 		return nil, err
@@ -352,7 +379,7 @@ func mcpSessionStart(query, profile string) (any, error) {
 	// it orders a queued stop before this start by requestedAt, so enqueuing
 	// unconditionally is both correct and simplest.
 	c, err := command.Write(dir, command.Command{
-		Action: command.ActionStart, WorkspaceID: w.ID, Profile: profile, Source: "mcp",
+		Action: command.ActionStart, WorkspaceID: w.ID, Profile: profile, Name: sanitizeSessionName(name), Source: "mcp",
 	})
 	if err != nil {
 		return nil, err
@@ -429,6 +456,33 @@ func mcpWorktreesMaterialize(composePath, branch string, services []string) (any
 		return nil, fmt.Errorf("%s: %w", utils.ErrExecFailed, err)
 	}
 	return set, nil
+}
+
+func mcpPROpen(composePath, branch, title, body, base string, draft bool) (any, error) {
+	corgi, dir, err := loadComposeForAgent(composePath)
+	if err != nil {
+		return nil, err
+	}
+	set, err := utils.ExistingBranchWorktrees(corgi, dir, branch)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", utils.ErrUsage, err)
+	}
+	// One directory per repository: two services sharing a repo share a
+	// worktree, and one pull request covers both.
+	dirs := map[string]string{}
+	for _, w := range set.Worktrees {
+		if w.Skipped == "" && w.Dir != "" {
+			dirs[w.Repo] = w.Dir
+		}
+	}
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("%s: no worktrees for %s — run corgi_worktrees_materialize first", utils.ErrUsage, branch)
+	}
+	out, err := utils.OpenBranchPRs(dirs, branch, base, title, body, draft)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", utils.ErrExecFailed, err)
+	}
+	return out, nil
 }
 
 func mcpWorktreesRelease(composePath, branch string, force bool) (any, error) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -148,8 +148,26 @@ func workspaceActivity(id, absPath string) (int, *launchLastEvent) {
 	return live, &launchLastEvent{Kind: e.Kind, Cause: e.Cause, Reason: e.Reason, At: e.At.UnixMilli()}
 }
 
+// usageTTL is how long a summed report is reused. Summing a workspace means
+// scanning its transcripts — a fifth of a second on a busy one — and this list
+// is polled every second while a session starts, so the request path must
+// never pay for it.
+const usageTTL = time.Minute
+
+var usageCache = struct {
+	mu   sync.Mutex
+	reps map[string]*cachedUsage
+}{reps: map[string]*cachedUsage{}}
+
+type cachedUsage struct {
+	report     *usage.Report
+	computed   time.Time
+	refreshing bool
+}
+
 // Zero across both windows is reported as nothing, so an idle workspace shows
-// no number rather than a row of noughts.
+// no number rather than a row of noughts. A stale report is served while a
+// fresh one is summed in the background.
 func workspaceUsage(id, absPath string) *usage.Report {
 	if absPath == "" {
 		return nil
@@ -158,11 +176,38 @@ func workspaceUsage(id, absPath string) *usage.Report {
 	if !ok {
 		return nil
 	}
-	rep := usage.ForDir(absPath, expandTilde(configDir), mungeClaudeProjectDir(absPath), time.Now())
-	if rep.Week.Total() == 0 {
-		return nil
+
+	usageCache.mu.Lock()
+	entry := usageCache.reps[id]
+	if entry == nil {
+		entry = &cachedUsage{}
+		usageCache.reps[id] = entry
 	}
-	return &rep
+	fresh := !entry.computed.IsZero() && time.Since(entry.computed) < usageTTL
+	report := entry.report
+	if !fresh && !entry.refreshing {
+		entry.refreshing = true
+		go refreshUsage(id, absPath, expandTilde(configDir))
+	}
+	usageCache.mu.Unlock()
+	return report
+}
+
+func refreshUsage(id, absPath, configDir string) {
+	rep := usage.ForDir(absPath, configDir, mungeClaudeProjectDir(absPath), time.Now())
+	usageCache.mu.Lock()
+	defer usageCache.mu.Unlock()
+	entry := usageCache.reps[id]
+	if entry == nil {
+		return
+	}
+	entry.refreshing = false
+	entry.computed = time.Now()
+	entry.report = nil
+	if rep.Week.Total() > 0 {
+		copy := rep
+		entry.report = &copy
+	}
 }
 
 // Only the profile NAMES cross the wire; what each selects stays in the

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -46,14 +46,11 @@ type launchWorkspace struct {
 	// SessionLinks are per-session claude.ai URLs captured from remote
 	// control's own output — the only links the site resolves (the ids the
 	// claude CLI lists locally are UUIDs the web does not know).
-	SessionLinks []string `json:"sessionLinks,omitempty"`
-	Note         string   `json:"note,omitempty"`
-	// Live is how many Claude processes are running in the workspace right
-	// now, from the per-pid records; LastEvent is the newest timeline entry,
-	// so a card can say why a session ended without opening anything.
-	Live      int              `json:"live"`
-	LastEvent *launchLastEvent `json:"lastEvent,omitempty"`
-	Profiles  []string         `json:"profiles,omitempty"`
+	SessionLinks []string         `json:"sessionLinks,omitempty"`
+	Note         string           `json:"note,omitempty"`
+	Live         int              `json:"live"`
+	LastEvent    *launchLastEvent `json:"lastEvent,omitempty"`
+	Profiles     []string         `json:"profiles,omitempty"`
 }
 
 type launchLastEvent struct {
@@ -127,13 +124,15 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 	return out
 }
 
-// workspaceActivity counts the live Claude processes in a workspace and reads
-// its newest timeline entry. Best-effort on both halves: a workspace with
-// neither is simply idle with nothing to report.
 func workspaceActivity(id, absPath string) (int, *launchLastEvent) {
+	// Deliberately the pid-file reader, not listClaudeSessions: its fallback
+	// shells out to `claude agents --json` with a timeout, and this runs once
+	// per workspace on a list the phone polls every second while starting.
 	var live int
 	if _, configDir, ok := workspaceSessionTarget(id); ok && absPath != "" {
-		live = len(listClaudeSessions(absPath, configDir))
+		if sessions, read := localClaudeSessions(absPath, configDir); read {
+			live = len(sessions)
+		}
 	}
 	dir, err := agentDir()
 	if err != nil {
@@ -147,8 +146,8 @@ func workspaceActivity(id, absPath string) (int, *launchLastEvent) {
 	return live, &launchLastEvent{Kind: e.Kind, Cause: e.Cause, Reason: e.Reason, At: e.At.UnixMilli()}
 }
 
-// launchProfileNames lists the profiles a phone may pick at start time. Only
-// the NAMES cross the wire — what each selects stays in the trusted config.
+// Only the profile NAMES cross the wire; what each selects stays in the
+// trusted config.
 func launchProfileNames() []string {
 	dir, err := agentDir()
 	if err != nil {
@@ -265,8 +264,6 @@ func launchSessionsHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// recentEvents is the tail of a workspace's timeline, newest first, for the
-// launcher's session drawer.
 func recentEvents(workspaceID string, limit int) []launchLastEvent {
 	dir, err := agentDir()
 	if err != nil {
@@ -279,9 +276,6 @@ func recentEvents(workspaceID string, limit int) []launchLastEvent {
 	return out
 }
 
-// launchInfoHandler answers "which machine am I looking at, and is it current".
-// The version check is served from a cache the server refreshes in the
-// background, so the page never waits on GitHub.
 func launchInfoHandler(w http.ResponseWriter, r *http.Request) {
 	setLaunchHeaders(w)
 	if r.Method != http.MethodGet {
@@ -312,9 +306,7 @@ var latestVersion struct {
 	checked time.Time
 }
 
-// cachedLatestVersion returns the newest released version, refreshing at most
-// hourly on a background goroutine. Returning "" (unknown) is normal and just
-// means the page shows no update hint.
+// Refreshed off the request path: the page must never wait on GitHub.
 func cachedLatestVersion() string {
 	latestVersion.mu.Lock()
 	defer latestVersion.mu.Unlock()
@@ -334,9 +326,8 @@ func cachedLatestVersion() string {
 	return latestVersion.value
 }
 
-// launchDevicesHandler lists paired devices and revokes one. A device may not
-// revoke itself: locking yourself out of the only paired phone from the phone
-// is never what you meant, and the laptop can always do it.
+// A device may not revoke itself: locking the only paired phone out, from that
+// phone, is never what was meant.
 func launchDevicesHandler(w http.ResponseWriter, r *http.Request) {
 	setLaunchHeaders(w)
 	dir, err := agentDir()
@@ -390,8 +381,6 @@ func launchDevicesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// launchDoctorHandler serves the same checks as `corgi agent doctor`, so a
-// failing card can be diagnosed without walking to the laptop.
 func launchDoctorHandler(w http.ResponseWriter, r *http.Request) {
 	setLaunchHeaders(w)
 	if r.Method != http.MethodGet {
@@ -717,6 +706,7 @@ const launcherPageHTML = `<!doctype html>
     <button id="copycfg">Copy connector config</button>
     <p id="copymsg" class="msg"></p>
     <p>Each workspace has an <b>open in</b> pill — tap it to cycle: <b>app</b> deep-links into the Claude app; <b>browser</b> keeps the session here; <b>chrome</b> forces Chrome via its URL scheme (needs Chrome installed) — right for a workspace on a different Claude account than the app is signed into. Remembered per workspace, on this browser only.</p>
+    <p><b>Hiding workspaces.</b> Each card has a <b>hide</b> chip — useful when showing this screen to someone. Hidden cards collapse into one "N hidden — show" button, on this browser only; nothing on the machine changes.</p>
     <label class="toggle"><input type="checkbox" id="showbridges"> Show hand-started (bridge) sessions</label>
     <p>A <b>bridge</b> is a remote-control session someone started on the laptop itself. Its claude.ai page shows only what you send from it — until then it looks empty. The full transcript stays on the laptop.</p>
     <p><b>Paired devices.</b> Every device that scanned a pairing QR. Revoking one leaves the others working.</p>
@@ -750,6 +740,10 @@ const launcherPageHTML = `<!doctype html>
   const openMode = id => { try { return localStorage.getItem('corgi_open_' + id) || 'app'; } catch { return 'app'; } };
   const setOpenMode = (id, m) => { try { localStorage.setItem('corgi_open_' + id, m); } catch {} };
   const showBridges = () => { try { return localStorage.getItem('corgi_show_bridges') !== '0'; } catch { return true; } };
+  const hidden = () => { try { return new Set(JSON.parse(localStorage.getItem('corgi_hidden') || '[]')); } catch { return new Set(); } };
+  const setHidden = s => { try { localStorage.setItem('corgi_hidden', JSON.stringify([...s])); } catch {} };
+  const toggleHidden = id => { const h = hidden(); h.has(id) ? h.delete(id) : h.add(id); setHidden(h); render(lastWorkspaces); };
+  let revealHidden = false;
   const setShowBridges = on => { try { localStorage.setItem('corgi_show_bridges', on ? '1' : '0'); } catch {} };
 
   if (!token) {
@@ -872,7 +866,10 @@ const launcherPageHTML = `<!doctype html>
     }
     list.className = '';
     list.innerHTML = '';
-    for (const ws of workspaces) {
+    const hide = hidden();
+    const shownWs = revealHidden ? workspaces : workspaces.filter(w => !hide.has(w.id));
+    const hiddenCount = workspaces.length - shownWs.length;
+    for (const ws of shownWs) {
       const row = document.createElement('div');
       row.className = 'ws';
       const head = document.createElement('div');
@@ -922,10 +919,23 @@ const launcherPageHTML = `<!doctype html>
         actions.appendChild(opts);
       }
       if (ws.running) actions.appendChild(stopControl(ws.id));
+      const hideBtn = document.createElement('button');
+      hideBtn.className = 'chip';
+      hideBtn.title = 'Hide this workspace on this browser';
+      hideBtn.textContent = hide.has(ws.id) ? 'unhide' : 'hide';
+      hideBtn.onclick = () => toggleHidden(ws.id);
+      actions.appendChild(hideBtn);
       if (startBox) actions.appendChild(startBox);
       row.appendChild(actions);
       row.appendChild(sessionsBox);
       list.appendChild(row);
+    }
+    if (hiddenCount || revealHidden) {
+      const b = document.createElement('button');
+      b.className = 'chip revealer';
+      b.textContent = revealHidden ? 'hide again' : hiddenCount + ' hidden — show';
+      b.onclick = () => { revealHidden = !revealHidden; render(lastWorkspaces); };
+      list.appendChild(b);
     }
   }
 

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -19,6 +19,7 @@ import (
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/events"
 	"andriiklymiuk/corgi/utils/agent/pairing"
+	"andriiklymiuk/corgi/utils/agent/usage"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
@@ -49,6 +50,7 @@ type launchWorkspace struct {
 	SessionLinks []string         `json:"sessionLinks,omitempty"`
 	Note         string           `json:"note,omitempty"`
 	Live         int              `json:"live"`
+	Usage        *usage.Report    `json:"usage,omitempty"`
 	LastEvent    *launchLastEvent `json:"lastEvent,omitempty"`
 	Profiles     []string         `json:"profiles,omitempty"`
 }
@@ -118,6 +120,7 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 			SessionLinks: s.sessions, Note: s.note, Profiles: profiles,
 		}
 		row.Live, row.LastEvent = workspaceActivity(ws.ID, ws.AbsPath)
+		row.Usage = workspaceUsage(ws.ID, ws.AbsPath)
 		out = append(out, row)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
@@ -125,9 +128,8 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 }
 
 func workspaceActivity(id, absPath string) (int, *launchLastEvent) {
-	// Deliberately the pid-file reader, not listClaudeSessions: its fallback
-	// shells out to `claude agents --json` with a timeout, and this runs once
-	// per workspace on a list the phone polls every second while starting.
+	// The pid-file reader, never listClaudeSessions: its fallback shells out,
+	// and this runs per workspace on a list the phone polls while starting.
 	var live int
 	if _, configDir, ok := workspaceSessionTarget(id); ok && absPath != "" {
 		if sessions, read := localClaudeSessions(absPath, configDir); read {
@@ -144,6 +146,23 @@ func workspaceActivity(id, absPath string) (int, *launchLastEvent) {
 	}
 	e := recent[0]
 	return live, &launchLastEvent{Kind: e.Kind, Cause: e.Cause, Reason: e.Reason, At: e.At.UnixMilli()}
+}
+
+// Zero across both windows is reported as nothing, so an idle workspace shows
+// no number rather than a row of noughts.
+func workspaceUsage(id, absPath string) *usage.Report {
+	if absPath == "" {
+		return nil
+	}
+	_, configDir, ok := workspaceSessionTarget(id)
+	if !ok {
+		return nil
+	}
+	rep := usage.ForDir(absPath, expandTilde(configDir), mungeClaudeProjectDir(absPath), time.Now())
+	if rep.Week.Total() == 0 {
+		return nil
+	}
+	return &rep
 }
 
 // Only the profile NAMES cross the wire; what each selects stays in the
@@ -942,6 +961,11 @@ const launcherPageHTML = `<!doctype html>
   function metaLine(ws) {
     const bits = [];
     if (ws.live > 0) bits.push('<span class="live">' + ws.live + ' live</span>');
+    if (ws.usage && ws.usage.week) {
+      const t = ws.usage.today, w = ws.usage.week;
+      const sum = u => (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
+      bits.push('<span title="tokens today / this week">' + fmtTokens(sum(t)) + ' today · ' + fmtTokens(sum(w)) + ' this week</span>');
+    }
     const e = ws.lastEvent;
     if (e && !(ws.running && e.kind === 'started')) {
       const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' · ' + esc(e.cause) : '')
@@ -1068,6 +1092,13 @@ const launcherPageHTML = `<!doctype html>
     if (ep.indexOf('vscode') >= 0) return 'vscode';
     if (ep === 'sdk-cli') return 'remote';
     return sess.kind === 'interactive' ? 'terminal' : (sess.kind || 'session');
+  }
+
+  function fmtTokens(n) {
+    if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B';
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+    if (n >= 1e3) return Math.round(n / 1e3) + 'k';
+    return String(n || 0);
   }
 
   function fmtWhen(ms) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -11,12 +11,14 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/events"
+	"andriiklymiuk/corgi/utils/agent/pairing"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
@@ -46,6 +48,19 @@ type launchWorkspace struct {
 	// claude CLI lists locally are UUIDs the web does not know).
 	SessionLinks []string `json:"sessionLinks,omitempty"`
 	Note         string   `json:"note,omitempty"`
+	// Live is how many Claude processes are running in the workspace right
+	// now, from the per-pid records; LastEvent is the newest timeline entry,
+	// so a card can say why a session ended without opening anything.
+	Live      int              `json:"live"`
+	LastEvent *launchLastEvent `json:"lastEvent,omitempty"`
+	Profiles  []string         `json:"profiles,omitempty"`
+}
+
+type launchLastEvent struct {
+	Kind   string `json:"kind"`
+	Cause  string `json:"cause,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	At     int64  `json:"at"`
 }
 
 func launchWorkspacesHandler(w http.ResponseWriter, r *http.Request) {
@@ -96,17 +111,59 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 		}
 	}
 
+	profiles := launchProfileNames()
 	out := make([]launchWorkspace, 0, len(registry.Workspaces))
 	for _, ws := range registry.Sorted() {
 		s := running[ws.ID]
-		out = append(out, launchWorkspace{
+		row := launchWorkspace{
 			ID: ws.ID, Aliases: ws.Aliases, Path: ws.AbsPath,
 			Status: string(ws.Status), Running: s.running, SessionURL: s.url,
-			SessionLinks: s.sessions, Note: s.note,
-		})
+			SessionLinks: s.sessions, Note: s.note, Profiles: profiles,
+		}
+		row.Live, row.LastEvent = workspaceActivity(ws.ID, ws.AbsPath)
+		out = append(out, row)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
+}
+
+// workspaceActivity counts the live Claude processes in a workspace and reads
+// its newest timeline entry. Best-effort on both halves: a workspace with
+// neither is simply idle with nothing to report.
+func workspaceActivity(id, absPath string) (int, *launchLastEvent) {
+	var live int
+	if _, configDir, ok := workspaceSessionTarget(id); ok && absPath != "" {
+		live = len(listClaudeSessions(absPath, configDir))
+	}
+	dir, err := agentDir()
+	if err != nil {
+		return live, nil
+	}
+	recent := events.NewLog(dir).Read(id, 1)
+	if len(recent) == 0 {
+		return live, nil
+	}
+	e := recent[0]
+	return live, &launchLastEvent{Kind: e.Kind, Cause: e.Cause, Reason: e.Reason, At: e.At.UnixMilli()}
+}
+
+// launchProfileNames lists the profiles a phone may pick at start time. Only
+// the NAMES cross the wire — what each selects stays in the trusted config.
+func launchProfileNames() []string {
+	dir, err := agentDir()
+	if err != nil {
+		return nil
+	}
+	user, err := config.LoadUser(agentUserConfigPath(dir))
+	if err != nil || user == nil || len(user.Profiles) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(user.Profiles))
+	for n := range user.Profiles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func launchStartHandler(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +175,7 @@ func launchStartHandler(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Workspace string `json:"workspace"`
 		Profile   string `json:"profile"`
+		Name      string `json:"name"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&req); err != nil {
 		writeLaunchError(w, http.StatusBadRequest, "could not read the start request")
@@ -129,7 +187,7 @@ func launchStartHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Same code path as the MCP tool, so the two surfaces cannot drift: it
 	// resolves the name, refuses a sensitive workspace, and enqueues the start.
-	result, err := mcpSessionStart(req.Workspace, req.Profile)
+	result, err := mcpSessionStart(req.Workspace, req.Profile, req.Name)
 	if err != nil {
 		writeLaunchError(w, http.StatusBadRequest, err.Error())
 		return
@@ -203,7 +261,144 @@ func launchSessionsHandler(w http.ResponseWriter, r *http.Request) {
 		"sessions": listClaudeSessions(absPath, configDir),
 		"links":    bridgeSessionLinks(absPath, configDir),
 		"history":  sessionHistory(id),
+		"events":   recentEvents(id, 6),
 	})
+}
+
+// recentEvents is the tail of a workspace's timeline, newest first, for the
+// launcher's session drawer.
+func recentEvents(workspaceID string, limit int) []launchLastEvent {
+	dir, err := agentDir()
+	if err != nil {
+		return []launchLastEvent{}
+	}
+	out := []launchLastEvent{}
+	for _, e := range events.NewLog(dir).Read(workspaceID, limit) {
+		out = append(out, launchLastEvent{Kind: e.Kind, Cause: e.Cause, Reason: e.Reason, At: e.At.UnixMilli()})
+	}
+	return out
+}
+
+// launchInfoHandler answers "which machine am I looking at, and is it current".
+// The version check is served from a cache the server refreshes in the
+// background, so the page never waits on GitHub.
+func launchInfoHandler(w http.ResponseWriter, r *http.Request) {
+	setLaunchHeaders(w)
+	if r.Method != http.MethodGet {
+		writeLaunchError(w, http.StatusMethodNotAllowed, "GET only")
+		return
+	}
+	host, _ := os.Hostname()
+	info := map[string]any{
+		"host":    host,
+		"version": APP_VERSION,
+		"daemon":  false,
+	}
+	if dir, err := agentDir(); err == nil {
+		if d, derr := daemon.ReadInfo(dir); derr == nil && d != nil {
+			info["daemon"] = true
+			info["daemonPid"] = d.PID
+		}
+	}
+	if latest := cachedLatestVersion(); latest != "" && latest != APP_VERSION {
+		info["latest"] = latest
+	}
+	writeLaunchJSON(w, info)
+}
+
+var latestVersion struct {
+	mu      sync.Mutex
+	value   string
+	checked time.Time
+}
+
+// cachedLatestVersion returns the newest released version, refreshing at most
+// hourly on a background goroutine. Returning "" (unknown) is normal and just
+// means the page shows no update hint.
+func cachedLatestVersion() string {
+	latestVersion.mu.Lock()
+	defer latestVersion.mu.Unlock()
+	if time.Since(latestVersion.checked) < time.Hour {
+		return latestVersion.value
+	}
+	latestVersion.checked = time.Now()
+	go func() {
+		tag, err := getLatestGitHubTag()
+		if err != nil {
+			return
+		}
+		latestVersion.mu.Lock()
+		latestVersion.value = strings.TrimPrefix(strings.TrimSpace(tag), "v")
+		latestVersion.mu.Unlock()
+	}()
+	return latestVersion.value
+}
+
+// launchDevicesHandler lists paired devices and revokes one. A device may not
+// revoke itself: locking yourself out of the only paired phone from the phone
+// is never what you meant, and the laptop can always do it.
+func launchDevicesHandler(w http.ResponseWriter, r *http.Request) {
+	setLaunchHeaders(w)
+	dir, err := agentDir()
+	if err != nil {
+		writeLaunchError(w, http.StatusInternalServerError, "could not resolve the agent data directory")
+		return
+	}
+	path := pairing.StorePath(dir)
+	me, _ := authorizedDevice(path, r.Header.Get("Authorization"))
+
+	switch r.Method {
+	case http.MethodGet:
+		store, err := pairing.Load(path)
+		if err != nil {
+			writeLaunchError(w, http.StatusInternalServerError, "could not read the paired devices")
+			return
+		}
+		list := make([]map[string]any, 0, len(store.Devices))
+		for _, d := range store.Devices {
+			list = append(list, map[string]any{
+				"name": d.Name, "pairedAt": d.CreatedAt.UnixMilli(), "current": d.Name == me,
+			})
+		}
+		writeLaunchJSON(w, map[string]any{"devices": list})
+	case http.MethodDelete:
+		name := strings.TrimSpace(r.URL.Query().Get("name"))
+		if name == "" {
+			writeLaunchError(w, http.StatusBadRequest, "a device name is required")
+			return
+		}
+		if name == me {
+			writeLaunchError(w, http.StatusBadRequest, "this device cannot revoke itself — do it from the laptop with `corgi mcp devices revoke`")
+			return
+		}
+		store, err := pairing.Load(path)
+		if err != nil {
+			writeLaunchError(w, http.StatusInternalServerError, "could not read the paired devices")
+			return
+		}
+		if !store.Revoke(name) {
+			writeLaunchError(w, http.StatusNotFound, "no device named "+name)
+			return
+		}
+		if err := pairing.Save(path, store); err != nil {
+			writeLaunchError(w, http.StatusInternalServerError, "could not save the paired devices")
+			return
+		}
+		writeLaunchJSON(w, map[string]any{"revoked": name})
+	default:
+		writeLaunchError(w, http.StatusMethodNotAllowed, "GET to list, DELETE to revoke")
+	}
+}
+
+// launchDoctorHandler serves the same checks as `corgi agent doctor`, so a
+// failing card can be diagnosed without walking to the laptop.
+func launchDoctorHandler(w http.ResponseWriter, r *http.Request) {
+	setLaunchHeaders(w)
+	if r.Method != http.MethodGet {
+		writeLaunchError(w, http.StatusMethodNotAllowed, "GET only")
+		return
+	}
+	writeLaunchJSON(w, map[string]any{"checks": collectAgentChecks()})
 }
 
 type launchHistoryEntry struct {
@@ -453,7 +648,27 @@ const launcherPageHTML = `<!doctype html>
   .ws .wnote{color:var(--red);font-size:.72rem;margin-top:.5rem;line-height:1.45}
   .dot{width:.55rem;height:.55rem;border-radius:50%;background:#3a4152;flex:0 0 auto}
   .dot.on{background:var(--green);box-shadow:0 0 0 3px rgba(126,231,135,.14),0 0 8px rgba(126,231,135,.45)}
-  .actions{display:flex;align-items:center;gap:.4rem;margin-top:.65rem}
+  .meta{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-top:.3rem;font-size:.72rem;color:var(--dim2)}
+  .meta .live{color:var(--green)}
+  .meta .why{color:var(--dim)}
+  .actions{display:flex;align-items:center;gap:.4rem;margin-top:.65rem;flex-wrap:wrap}
+  .startbox{flex-basis:100%;display:none;gap:.4rem;margin-top:.5rem}
+  .startbox.on{display:flex}
+  .startbox select,.startbox input{flex:1 1 6rem;min-width:0;background:var(--card2);border:1px solid var(--line);
+      color:var(--text);border-radius:.5rem;padding:.4rem .55rem;font-size:.78rem;font-family:inherit}
+  .evrow{display:flex;justify-content:space-between;gap:.6rem;font-size:.72rem;color:var(--dim);padding:.2rem .1rem}
+  .evrow b{font-weight:600;color:#c9cfda}
+  .dev{display:flex;align-items:center;justify-content:space-between;gap:.6rem;font-size:.8rem;
+      padding:.4rem 0;border-bottom:1px solid var(--line)}
+  .dev:last-child{border-bottom:0}
+  .dev .sub{color:var(--dim2);font-size:.7rem}
+  .dev button{background:none;border:1px solid rgba(255,123,114,.45);color:var(--red);font-size:.7rem;
+      padding:.25rem .6rem;border-radius:.5rem}
+  .chk{display:flex;gap:.5rem;font-size:.78rem;padding:.35rem 0;border-bottom:1px solid var(--line);line-height:1.45}
+  .chk:last-child{border-bottom:0}
+  .chk .fix{color:var(--dim);display:block;font-size:.72rem;margin-top:.15rem}
+  .chk.bad .mark{color:var(--red)}
+  .chk .mark{color:var(--green);flex:0 0 auto}
   .chip{background:none;border:1px solid var(--line);color:var(--dim);font-size:.7rem;font-weight:650;
       padding:.3rem .65rem;border-radius:999px;cursor:pointer}
   .chip b{color:var(--text);font-weight:650}
@@ -504,6 +719,11 @@ const launcherPageHTML = `<!doctype html>
     <p>Each workspace has an <b>open in</b> pill — tap it to cycle: <b>app</b> deep-links into the Claude app; <b>browser</b> keeps the session here; <b>chrome</b> forces Chrome via its URL scheme (needs Chrome installed) — right for a workspace on a different Claude account than the app is signed into. Remembered per workspace, on this browser only.</p>
     <label class="toggle"><input type="checkbox" id="showbridges"> Show hand-started (bridge) sessions</label>
     <p>A <b>bridge</b> is a remote-control session someone started on the laptop itself. Its claude.ai page shows only what you send from it — until then it looks empty. The full transcript stays on the laptop.</p>
+    <p><b>Paired devices.</b> Every device that scanned a pairing QR. Revoking one leaves the others working.</p>
+    <div id="devices" class="msg">Loading…</div>
+    <p><b>Something not starting?</b> The same checks as <code>corgi agent doctor</code>, from here.</p>
+    <button id="rundoctor">Run doctor</button>
+    <div id="doctor"></div>
     <p><b>Push notifications.</b> Set <code>notifyUrl</code> in the agent config on the laptop (for example an ntfy.sh topic you subscribe to in the ntfy app) and every session restart or failure reaches your phone. See <code>corgi agent doctor</code> and the agent docs.</p>
   </details>
   <p class="foot">
@@ -538,6 +758,7 @@ const launcherPageHTML = `<!doctype html>
       '<code>corgi agent up</code> and scan the QR to pair, then come back here.';
   } else {
     initSettings();
+    loadInfo();
     load();
   }
 
@@ -555,6 +776,64 @@ const launcherPageHTML = `<!doctype html>
     const bridges = document.getElementById('showbridges');
     bridges.checked = showBridges();
     bridges.onchange = () => setShowBridges(bridges.checked);
+    loadDevices();
+    document.getElementById('rundoctor').onclick = runDoctor;
+  }
+
+  async function loadDevices() {
+    const box = document.getElementById('devices');
+    try {
+      const r = await fetch('/launch/devices', { headers: auth });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || r.status);
+      const list = j.devices || [];
+      if (!list.length) { box.className = 'msg'; box.textContent = 'No devices paired yet.'; return; }
+      box.className = ''; box.innerHTML = '';
+      for (const d of list) {
+        const row = document.createElement('div');
+        row.className = 'dev';
+        const left = document.createElement('div');
+        left.innerHTML = esc(d.name) + (d.current ? ' <span class="sub">· this device</span>' : '') +
+          '<div class="sub">paired ' + esc(fmtWhen(d.pairedAt)) + '</div>';
+        row.appendChild(left);
+        if (!d.current) {
+          const b = document.createElement('button');
+          b.textContent = 'Revoke';
+          b.onclick = () => revokeDevice(d.name, b);
+          row.appendChild(b);
+        }
+        box.appendChild(row);
+      }
+    } catch (e) { box.className = 'msg err'; box.textContent = '✗ ' + e.message; }
+  }
+
+  async function revokeDevice(name, btn) {
+    btn.disabled = true; btn.textContent = 'Revoking…';
+    try {
+      const r = await fetch('/launch/devices?name=' + encodeURIComponent(name), { method: 'DELETE', headers: auth });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || r.status);
+      loadDevices();
+    } catch (e) { btn.disabled = false; btn.textContent = '✗ ' + e.message; }
+  }
+
+  async function runDoctor() {
+    const box = document.getElementById('doctor');
+    box.className = 'msg'; box.textContent = 'Checking…';
+    try {
+      const r = await fetch('/launch/doctor', { headers: auth });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || r.status);
+      const checks = (j.checks || []).slice().sort((a, b) => (a.ok === b.ok) ? 0 : (a.ok ? 1 : -1));
+      box.className = ''; box.innerHTML = '';
+      for (const c of checks) {
+        const el = document.createElement('div');
+        el.className = 'chk' + (c.ok ? '' : ' bad');
+        el.innerHTML = '<span class="mark">' + (c.ok ? '✓' : '✗') + '</span><span><b>' + esc(c.name) + '</b> — ' +
+          esc(c.detail || '') + (c.fix ? '<span class="fix">fix: ' + esc(c.fix) + '</span>' : '') + '</span>';
+        box.appendChild(el);
+      }
+    } catch (e) { box.className = 'msg err'; box.textContent = '✗ ' + e.message; }
   }
 
   async function load() {
@@ -566,6 +845,22 @@ const launcherPageHTML = `<!doctype html>
     } catch (e) {
       list.className = 'msg err'; list.textContent = '✗ ' + e.message;
     }
+  }
+
+  async function loadInfo() {
+    try {
+      const r = await fetch('/launch/info', { headers: auth });
+      const j = await r.json();
+      if (!r.ok) return;
+      const bits = [];
+      if (j.host) bits.push(j.host);
+      if (j.version) bits.push('corgi ' + j.version);
+      bits.push(j.daemon ? 'daemon up' : 'daemon down');
+      if (j.latest) bits.push('v' + j.latest + ' available — corgi upd');
+      const el = document.getElementById('host');
+      el.textContent = bits.join(' · ');
+      if (!j.daemon) el.style.color = 'var(--red)';
+    } catch {}
   }
 
   function render(workspaces) {
@@ -592,6 +887,8 @@ const launcherPageHTML = `<!doctype html>
         path.textContent = full ? ws.path : shortPath(ws.path);
       };
       main.appendChild(path);
+      const meta = metaLine(ws);
+      if (meta) main.appendChild(meta);
       head.appendChild(main);
       if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
         head.appendChild(openControl(ws));
@@ -610,6 +907,7 @@ const launcherPageHTML = `<!doctype html>
       }
       const actions = document.createElement('div');
       actions.className = 'actions';
+      const startBox = startOptions(ws);
       const sessionsBox = document.createElement('div');
       sessionsBox.className = 'sessions'; sessionsBox.style.display = 'none';
       const sbtn = document.createElement('button');
@@ -617,11 +915,61 @@ const launcherPageHTML = `<!doctype html>
       sbtn.onclick = () => toggleSessions(ws, sbtn, sessionsBox);
       actions.appendChild(sbtn);
       actions.appendChild(modeSwitch(ws.id));
+      if (!ws.running && startBox) {
+        const opts = document.createElement('button');
+        opts.className = 'chip'; opts.textContent = 'options ⌄';
+        opts.onclick = () => { startBox.classList.toggle('on'); };
+        actions.appendChild(opts);
+      }
       if (ws.running) actions.appendChild(stopControl(ws.id));
+      if (startBox) actions.appendChild(startBox);
       row.appendChild(actions);
       row.appendChild(sessionsBox);
       list.appendChild(row);
     }
+  }
+
+  function metaLine(ws) {
+    const bits = [];
+    if (ws.live > 0) bits.push('<span class="live">' + ws.live + ' live</span>');
+    const e = ws.lastEvent;
+    if (e && !(ws.running && e.kind === 'started')) {
+      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' · ' + esc(e.cause) : '')
+        : e.kind === 'attention' ? 'needs you'
+        : esc(e.kind);
+      bits.push('<span class="why">' + what + ' · ' + esc(fmtWhen(e.at)) + '</span>');
+    }
+    if (!bits.length) return null;
+    const el = document.createElement('div');
+    el.className = 'meta';
+    el.innerHTML = bits.join('<span>·</span>');
+    return el;
+  }
+
+  // The start options are built even when collapsed: Start reads them, so a
+  // profile chosen before opening the panel still applies.
+  function startOptions(ws) {
+    if (ws.running) return null;
+    const box = document.createElement('div');
+    box.className = 'startbox';
+    if ((ws.profiles || []).length) {
+      const sel = document.createElement('select');
+      sel.dataset.role = 'profile';
+      const none = document.createElement('option');
+      none.value = ''; none.textContent = 'default account';
+      sel.appendChild(none);
+      for (const p of ws.profiles) {
+        const o = document.createElement('option');
+        o.value = p; o.textContent = p;
+        sel.appendChild(o);
+      }
+      box.appendChild(sel);
+    }
+    const name = document.createElement('input');
+    name.type = 'text'; name.placeholder = 'session name (optional)'; name.dataset.role = 'name';
+    name.maxLength = 60;
+    box.appendChild(name);
+    return box;
   }
 
   function shortPath(p) {
@@ -674,8 +1022,9 @@ const launcherPageHTML = `<!doctype html>
       }
       const past = (j.history || []).filter(h => h && safeClaudeUrl(h.url) && !shown.has(h.url));
       for (const h of past) { shown.add(h.url); renderLink(h.url, false, fmtWhen(h.at) + ' \u00b7 '); }
+      const evs = j.events || [];
       const s = j.sessions || [];
-      if (!s.length && !shown.size && !bridges.length) { info.textContent = 'No sessions yet for this workspace.'; return; }
+      if (!s.length && !shown.size && !bridges.length && !evs.length) { info.textContent = 'No sessions yet for this workspace.'; return; }
       info.remove();
       let localOnly = 0;
       for (const sess of s) {
@@ -694,6 +1043,13 @@ const launcherPageHTML = `<!doctype html>
         box.appendChild(el);
       }
       if (localOnly) note('local only = running on the laptop with no web link yet; type /remote-control in that session to reach it from here.');
+      for (const ev of evs) {
+        const el = document.createElement('div');
+        el.className = 'evrow';
+        const what = ev.kind + (ev.cause ? ' · ' + ev.cause : '') + (ev.reason ? ' — ' + ev.reason : '');
+        el.innerHTML = '<b>' + esc(what.slice(0, 90)) + '</b><span>' + esc(fmtWhen(ev.at)) + '</span>';
+        box.appendChild(el);
+      }
     } catch (e) { info.textContent = '\u2717 ' + e.message; }
   }
 
@@ -774,9 +1130,14 @@ const launcherPageHTML = `<!doctype html>
 
   async function startSession(id, btn) {
     btn.disabled = true; btn.textContent = 'Starting…';
+    const box = btn.closest('.ws').querySelector('.startbox');
+    const pick = (role) => {
+      const el = box && box.querySelector('[data-role="' + role + '"]');
+      return el ? el.value.trim() : '';
+    };
     try {
       const r = await fetch('/launch/start', { method: 'POST', headers: auth,
-        body: JSON.stringify({ workspace: id }) });
+        body: JSON.stringify({ workspace: id, profile: pick('profile'), name: pick('name') }) });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
       poll(id, 0);

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.0"
+var APP_VERSION = "1.21.1"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -192,7 +193,10 @@ func upgradeViaInstallScript(installDir string) error {
 }
 
 func getLatestGitHubTag() (string, error) {
-	client := &http.Client{}
+	// A timeout matters here beyond the upgrade command: the MCP server calls
+	// this hourly from a goroutine, and a hung connection would park one for
+	// good, once per hour, for the life of the process.
+	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", "https://api.github.com/repos/Andriiklymiuk/corgi/releases/latest", nil)
 	if err != nil {
 		return "", err

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -204,6 +204,13 @@ terminal, VS Code, supervised — read from the per-process records under
 its conversation on claude.ai; one that has not is marked *local only*, and
 typing `/remote-control` inside it is what gives it a link.
 
+### Hiding a workspace on the phone
+
+Each card has a **hide** chip. Hidden cards collapse into one `N hidden — show`
+button. It is stored in that browser only and changes nothing on the machine —
+it exists for the moment someone else is looking at your screen. To actually
+stop supervising a workspace, set `autostart: false` for it instead.
+
 ### When a session needs you
 
 A session waiting on a permission prompt is invisible from the phone. Opt in

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -204,6 +204,20 @@ terminal, VS Code, supervised — read from the per-process records under
 its conversation on claude.ai; one that has not is marked *local only*, and
 typing `/remote-control` inside it is what gives it a link.
 
+### What it has been costing
+
+Claude Code records token counts in its own transcripts, so corgi can add them
+up per workspace — nothing is sent anywhere, and only the numbers are read:
+
+```
+$ corgi agent status
+  corgi                running   restarts=0 wakeLock=true
+                       tokens 147.3M today · 1.0B this week
+```
+
+The launcher shows the same two numbers on each card. Cache reads are included,
+which is why the totals are large — that is the real traffic against the window.
+
 ### Hiding a workspace on the phone
 
 Each card has a **hide** chip. Hidden cards collapse into one `N hidden — show`

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -106,10 +106,15 @@ The first time the phone opens the page, ngrok's free tier shows its own
 "you are about to visit" interstitial once; tap through. The launcher's own
 requests carry the header that skips it, so pairing and the buttons work.
 
-The launcher now lives at the same hostname forever — save it to the phone's home
-screen once. Provider notes (ngrok's free static `*.ngrok-free.dev` domain,
-localtunnel's best-effort `--subdomain`) and per-service stable tunnels:
-[docs/tunnel.md](tunnel.md#stable-urls-named-mode).
+Either way the launcher lives at the same hostname forever — save it to the
+phone's home screen once. One command does the whole setup and remembers it:
+
+```bash
+corgi agent tunnel setup corgi.yourdomain.com                  # cloudflared
+corgi agent tunnel setup <yours>.ngrok-free.app --provider ngrok
+```
+
+Per-service stable tunnels: [docs/tunnel.md](tunnel.md#stable-urls-named-mode).
 
 One more knob worth knowing: a workspace's Claude **default model** is not corgi's
 to pick — `claude remote-control` takes no model flag; you choose it per message in
@@ -147,6 +152,8 @@ corgi agent serve --foreground   # run it in this terminal and watch
 | `corgi agent brief [id]` | what the last session was working on before it restarted |
 | `corgi agent logs <workspace>` | the session timeline: starts, exits and why, links |
 | `corgi agent restart` | `down` + `up --fresh` in one — run it after `corgi upgrade` |
+| `corgi agent tunnel setup <host>` | one-time permanent-URL setup, remembered for later runs |
+| `corgi agent hooks enable` / `disable` | notify when a session in this workspace needs you |
 | `corgi agent stop` | stop the daemon |
 
 ## Restarts, and being told about them
@@ -196,6 +203,21 @@ terminal, VS Code, supervised — read from the per-process records under
 `<configDir>/sessions/`. A process that registered a web id links straight to
 its conversation on claude.ai; one that has not is marked *local only*, and
 typing `/remote-control` inside it is what gives it a link.
+
+### When a session needs you
+
+A session waiting on a permission prompt is invisible from the phone. Opt in
+per workspace and corgi tells you:
+
+```bash
+cd ~/dev/your-stack
+corgi agent hooks enable        # writes two hooks into .claude/settings.local.json
+```
+
+They call `corgi agent hook`, which reports to the daemon, which sends the same
+notification as a restart — including the phone push when `notifyUrl` is set.
+It covers every Claude session in that directory, supervised or not.
+`corgi agent hooks disable` removes them and leaves your other hooks alone.
 
 ### The handover brief
 

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win.",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -158,6 +158,18 @@ corgi agent init --config-dir ~/.claude-work
 `corgi agent status` prints the account each workspace will actually use. If the
 user has work and personal logins, check it.
 
+### The launcher page
+
+Everything the phone can do without the Claude app: start and stop a session,
+pick a profile and name it, read the timeline, revoke a paired device, run
+doctor. Two things worth telling a user unprompted:
+
+- Cards carry a **hide** chip. Hidden cards collapse into one button, on that
+  browser only — nothing on the machine changes. It is for showing the screen
+  to someone, not for disabling a workspace (`autostart: false` does that).
+- The header names the machine, the corgi version and whether the daemon is
+  up. If it says an update is available, `corgi upd && corgi agent restart`.
+
 ### If a session died
 
 `corgi agent status` shows `lastReason`, and `corgi agent logs <workspace>`
@@ -199,6 +211,7 @@ corgi_session_start { "workspace": "the recipe app", "profile": "work" }
   carries a tap target back to the launcher.
 - `corgi agent hooks enable` in a workspace also notifies when any Claude
   session there is waiting on a permission prompt or has finished its turn.
+  It writes into `.claude/settings.local.json`, never the committed file.
 - `corgi_pr_open { branch, title }` opens one pull request per repository that
   has commits on the branch and cross-links them — the step after
   `corgi_worktrees_materialize` and `corgi_diff`.

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -169,6 +169,9 @@ doctor. Two things worth telling a user unprompted:
   to someone, not for disabling a workspace (`autostart: false` does that).
 - The header names the machine, the corgi version and whether the daemon is
   up. If it says an update is available, `corgi upd && corgi agent restart`.
+- Cards show tokens today / this week, summed from Claude Code's own
+  transcripts (`corgi agent status` prints the same). Cache reads are included,
+  so the numbers are large by design — do not report them as an anomaly.
 
 ### If a session died
 

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -195,7 +195,13 @@ corgi_session_start { "workspace": "the recipe app", "profile": "work" }
 - Every remote start and stop raises a desktop notification on the laptop, by
   design — the machine's owner always sees what began running.
 - Phone push for those notifications: set `notifyUrl` in the trusted agent
-  config (an ntfy.sh topic works out of the box). See docs/agent.md.
+  config (an ntfy.sh topic works out of the box). See docs/agent.md. The push
+  carries a tap target back to the launcher.
+- `corgi agent hooks enable` in a workspace also notifies when any Claude
+  session there is waiting on a permission prompt or has finished its turn.
+- `corgi_pr_open { branch, title }` opens one pull request per repository that
+  has commits on the branch and cross-links them — the step after
+  `corgi_worktrees_materialize` and `corgi_diff`.
 
 ### Setting it up from a session on the laptop
 

--- a/plugins/corgi/skills/review/SKILL.md
+++ b/plugins/corgi/skills/review/SKILL.md
@@ -226,6 +226,13 @@ review untouched code.
 - Correctness bugs.
 - Missing or weak tests.
 - Security issues.
+- **Comments the code does not need** — see the rule below.
+- **Overengineering** — abstraction with one caller, a config knob nobody asked
+  for, an interface introduced for a single implementation, a layer that only
+  forwards. Flag it and name the simpler shape.
+- **Performance footguns in a hot path** — work repeated per item that could be
+  done once, an unbounded read or scan, a per-request shell-out or file walk, a
+  network call with no timeout, a goroutine nothing stops.
 - **Leaked secrets** — always `severity: blocking`; flag the file + line + that a secret is present; never echo the value into a finding or comment.
 - Repo-standard / convention violations (names, patterns, style).
 - Scope creep (changes outside the ticket's stated scope).
@@ -234,6 +241,45 @@ review untouched code.
   engine, library, vendor, or infra detail to end users (`nit`); suggest selling
   the user benefit, not the mechanism. Skip if the ticket is about that copy.
 - Ticket-intent mismatch (diff doesn't do what the ticket asked).
+
+### Comments: the bar is high
+
+A comment beside code is a cost — it goes stale, it repeats what the code
+says, and it is the most common thing a generated diff adds too much of.
+**The default is no comment.** In practice this is rare enough that a PR
+adding several is already a finding.
+
+Flag as `nit` (with the deletion as `suggestedReplacement`) any comment that:
+- restates the code (`// loop over users` above a loop over users),
+- narrates a step (`// now save it`), or names what the function already names,
+- documents a parameter or return the signature already states,
+- is a section banner, a TODO with no owner, or commented-out code.
+
+Leave alone — these earn their place:
+- **why**, not what: a non-obvious constraint, a rejected alternative, a bug
+  this shape exists to prevent,
+- a real gotcha the next reader would otherwise reintroduce,
+- an exported identifier's doc comment where the language expects one,
+- a link to a spec, ticket, or upstream issue that explains the shape.
+
+Judge the same way in Mode B: when addressing feedback, do not add explanatory
+comments to justify a change — the change should read for itself.
+
+### Simplicity and cost
+
+Two questions on every non-trivial diff, before any style point:
+
+1. **Is the simplest thing that works being done?** More types, layers or
+   options than the change needs is a finding, not neutral. Name the smaller
+   version in the explanation.
+2. **What does this cost when it runs?** Look at where the code actually sits —
+   a per-request handler, a poll loop, a per-item body. Repeated work, an
+   unbounded scan, a missing timeout, or a leaked goroutine there is
+   `blocking`; the same in a one-shot command is a `nit`.
+
+Both are only findings when they are real. Do not invent an abstraction
+objection to have something to say, and do not call a hot path slow without
+naming what runs and how often.
 
 **Temper with the intent note** — before emitting any finding, check it against
 the ticket's rationale, constraints, and discussion. A choice the ticket
@@ -601,8 +647,11 @@ P4 order) and cross-link the two replies. Then one combined report (6).
    `<!-- corgi-review -->` bots + resolved. Group by file; read each thread's full
    back-and-forth (a later reply can change the ask).
 2. **Judge — apply or push back.** `superpowers:receiving-code-review` if installed,
-   else inline. **Never blind-apply.** Valid + in scope → fix. Wrong / out-of-scope /
-   regresses → **reply why, don't apply** (push-back is a real answer). Needs an owner
+   else inline. **Never blind-apply.** Fix in the same shape as the surrounding
+   code: no comment explaining the change, no new abstraction to hold it, and
+   nothing that adds per-request work. Valid + in scope → fix. Wrong /
+   out-of-scope / regresses → **reply why, don't apply** (push-back is a real
+   answer). Needs an owner
    call → ask.
 3. **Checkout the PR's OWN branch → fix → gate.** Clean tree → `gh pr checkout <n>` /
    `glab mr checkout <n>` (its head — **not** a new branch off base). Dirty tree →
@@ -643,6 +692,9 @@ bullets, the way a person types into the PR box. Not a structured document: no `
 section headers, no long numbered-question lists, no pasted spec / code-map dumps.
 That report shape belongs in the terminal output (P6), never in the comment.
 **Never touch `manualRun` services** when mapping via `corgi-compose.yml`.
+**Never suggest adding a comment to the code.** The reviewer's job is to remove
+the ones that do not earn their place, not to plant more — if a line needs
+explaining, the fix in the suggestion is a clearer name or a smaller function.
 
 **Mode A (give review):**
 - **Comments only.** Never set a formal approve / request-changes state, never merge,

--- a/utils/agent/command/command.go
+++ b/utils/agent/command/command.go
@@ -19,6 +19,9 @@ import (
 const (
 	ActionStart = "start"
 	ActionStop  = "stop"
+	// ActionAttention is a Claude Code hook reporting that a session wants a
+	// person: a permission prompt, a question, or a finished turn.
+	ActionAttention = "attention"
 )
 
 // TTL is how long a written command stays valid. A start that sat in the spool
@@ -28,10 +31,15 @@ const TTL = 60 * time.Second
 
 // Command is one request to the daemon.
 type Command struct {
-	ID          string    `json:"id"`
-	Action      string    `json:"action"`
-	WorkspaceID string    `json:"workspaceId"`
-	Profile     string    `json:"profile,omitempty"`
+	ID          string `json:"id"`
+	Action      string `json:"action"`
+	WorkspaceID string `json:"workspaceId"`
+	Profile     string `json:"profile,omitempty"`
+	// Name is the session name shown in claude.ai. Free text from the phone,
+	// so the daemon sanitizes it before it reaches an argv.
+	Name string `json:"name,omitempty"`
+	// Detail carries a hook's own message, already trimmed by the sender.
+	Detail      string    `json:"detail,omitempty"`
 	Source      string    `json:"source,omitempty"`
 	RequestedAt time.Time `json:"requestedAt"`
 }
@@ -42,7 +50,7 @@ func Dir(agentDir string) string { return filepath.Join(agentDir, "commands") }
 // Write persists one command atomically and returns it with ID and
 // RequestedAt filled.
 func Write(agentDir string, c Command) (Command, error) {
-	if c.Action != ActionStart && c.Action != ActionStop {
+	if c.Action != ActionStart && c.Action != ActionStop && c.Action != ActionAttention {
 		return c, fmt.Errorf("unknown command action %q", c.Action)
 	}
 	if strings.TrimSpace(c.WorkspaceID) == "" {

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -80,7 +80,7 @@ type Daemon struct {
 	// remote session start. Injected by cmd, which knows the registry and
 	// config files; nil disables commands and keeps the fixed-set lifecycle
 	// exactly as it was.
-	ResolveWorkspace func(workspaceID, profile string) (supervisor.SpawnConfig, error)
+	ResolveWorkspace func(workspaceID, profile, name string) (supervisor.SpawnConfig, error)
 	// CommandTick is the spool poll interval; the SIGUSR1 nudge only shortens
 	// the wait. Zero means statusPublishInterval. Test seam.
 	CommandTick time.Duration
@@ -432,8 +432,25 @@ func (d *Daemon) drainCommands(ctx context.Context, launch func(*supervisor.Runn
 			d.startWorkspace(ctx, c, launch)
 		case command.ActionStop:
 			d.stopRemoteWorkspace(c)
+		case command.ActionAttention:
+			d.reportAttention(c)
 		}
 	}
+}
+
+// reportAttention turns a hook's "this session wants a person" into a timeline
+// entry and a notification. It never touches a runner: the session in question
+// is usually one corgi does not supervise (a terminal or an editor).
+func (d *Daemon) reportAttention(c command.Command) {
+	detail := strings.TrimSpace(c.Detail)
+	if detail == "" {
+		detail = "a session is waiting for you"
+	}
+	d.Events.Append(c.WorkspaceID, events.Event{Kind: "attention", Reason: detail})
+	if d.Notify != nil {
+		d.Notify("corgi agent · "+c.WorkspaceID, detail)
+	}
+	d.requestPublish()
 }
 
 func (d *Daemon) startWorkspace(ctx context.Context, c command.Command, launch func(*supervisor.Runner)) {
@@ -450,7 +467,7 @@ func (d *Daemon) startWorkspace(ctx context.Context, c command.Command, launch f
 		// the runner and try right now, with a fresh failure streak.
 		r.StopAsync()
 	}
-	cfg, err := d.ResolveWorkspace(c.WorkspaceID, c.Profile)
+	cfg, err := d.ResolveWorkspace(c.WorkspaceID, c.Profile, c.Name)
 	if err != nil {
 		d.commandFailed(c, err)
 		return

--- a/utils/agent/daemon/daemon_test.go
+++ b/utils/agent/daemon/daemon_test.go
@@ -398,7 +398,7 @@ func dynDaemon(t *testing.T) *Daemon {
 	t.Helper()
 	d := testDaemon(t)
 	d.CommandTick = 10 * time.Millisecond
-	d.ResolveWorkspace = func(id, profile string) (supervisor.SpawnConfig, error) {
+	d.ResolveWorkspace = func(id, profile, name string) (supervisor.SpawnConfig, error) {
 		if id == "ghost" {
 			return supervisor.SpawnConfig{}, errors.New("no workspace called \"ghost\" in the registry")
 		}
@@ -555,7 +555,7 @@ func TestDaemonSurvivesASIGUSR1Nudge(t *testing.T) {
 
 func TestInfoCarriesCommandSupport(t *testing.T) {
 	d := New("test", t.TempDir())
-	d.ResolveWorkspace = func(string, string) (supervisor.SpawnConfig, error) {
+	d.ResolveWorkspace = func(string, string, string) (supervisor.SpawnConfig, error) {
 		return supervisor.SpawnConfig{}, nil
 	}
 	if err := d.writeInfoIDs(nil); err != nil {

--- a/utils/agent/daemon/daemon_test.go
+++ b/utils/agent/daemon/daemon_test.go
@@ -695,3 +695,71 @@ func TestPackageNudgeIsSafeWithoutCommandSupport(t *testing.T) {
 	// the test process has the daemon's handler installed only inside Run, so we
 	// do not send to self here — the no-op branches are the contract under test.
 }
+
+func TestAttentionCommandNotifiesAndRecords(t *testing.T) {
+	d := dynDaemon(t)
+	var mu sync.Mutex
+	var bodies []string
+	d.Notify = func(_, body string) {
+		mu.Lock()
+		bodies = append(bodies, body)
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = d.Run(ctx, nil) }()
+
+	if _, err := command.Write(d.Dir, command.Command{
+		Action: command.ActionAttention, WorkspaceID: "acme",
+		Detail: "Claude needs your permission to run rm", Source: "hook",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	d.Nudge()
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(bodies) > 0
+	})
+	mu.Lock()
+	got := bodies[0]
+	mu.Unlock()
+	if got != "Claude needs your permission to run rm" {
+		t.Errorf("notification body = %q", got)
+	}
+
+	waitFor(t, func() bool {
+		evs := d.Events.Read("acme", 1)
+		return len(evs) == 1 && evs[0].Kind == "attention"
+	})
+
+	// A hook that sent no message still has to say something useful.
+	if _, err := command.Write(d.Dir, command.Command{
+		Action: command.ActionAttention, WorkspaceID: "acme", Source: "hook",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	d.Nudge()
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(bodies) > 1
+	})
+	mu.Lock()
+	second := bodies[1]
+	mu.Unlock()
+	if second != "a session is waiting for you" {
+		t.Errorf("empty detail must fall back, got %q", second)
+	}
+
+	cancel()
+	<-done
+
+	// Attention never touches a runner: the session is usually one corgi does
+	// not supervise.
+	if len(d.Status().Workspaces) != 0 {
+		t.Errorf("attention must not start a runner, got %+v", d.Status().Workspaces)
+	}
+}

--- a/utils/agent/usage/usage.go
+++ b/utils/agent/usage/usage.go
@@ -1,0 +1,131 @@
+// Package usage sums the token counts Claude Code already records in its
+// transcripts, so a workspace can answer what it has been costing. Nothing is
+// sent anywhere: the files are local and only their usage numbers are read.
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type Totals struct {
+	Input      int64 `json:"input"`
+	Output     int64 `json:"output"`
+	CacheRead  int64 `json:"cacheRead"`
+	CacheWrite int64 `json:"cacheWrite"`
+	Turns      int64 `json:"turns"`
+}
+
+// Total is what a person means by "how much did this cost": everything that
+// counts against the window, cache reads included.
+func (t Totals) Total() int64 { return t.Input + t.Output + t.CacheRead + t.CacheWrite }
+
+func (t *Totals) add(o Totals) {
+	t.Input += o.Input
+	t.Output += o.Output
+	t.CacheRead += o.CacheRead
+	t.CacheWrite += o.CacheWrite
+	t.Turns += o.Turns
+}
+
+// Report is one workspace's usage over two windows.
+type Report struct {
+	Today Totals `json:"today"`
+	Week  Totals `json:"week"`
+}
+
+// maxLineBytes bounds the scanner: a transcript line holds a whole turn, and a
+// long one must not stop the sum.
+const maxLineBytes = 8 << 20
+
+// ForDir sums the usage in every transcript for absPath under the account's
+// config dir. Best-effort: unreadable or malformed files contribute nothing.
+func ForDir(absPath, configDir, projectDirName string, now time.Time) Report {
+	base := configDir
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return Report{}
+		}
+		base = filepath.Join(home, ".claude")
+	}
+	dir := filepath.Join(base, "projects", projectDirName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return Report{}
+	}
+
+	dayAgo := now.Add(-24 * time.Hour)
+	weekAgo := now.Add(-7 * 24 * time.Hour)
+	var rep Report
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		// A transcript last written before the window cannot hold a turn
+		// inside it, and skipping the read is what keeps this cheap.
+		if err != nil || info.ModTime().Before(weekAgo) {
+			continue
+		}
+		day, week := sumFile(filepath.Join(dir, e.Name()), dayAgo, weekAgo)
+		rep.Today.add(day)
+		rep.Week.add(week)
+	}
+	return rep
+}
+
+func sumFile(path string, dayAgo, weekAgo time.Time) (day, week Totals) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
+	for sc.Scan() {
+		var row struct {
+			Timestamp time.Time `json:"timestamp"`
+			Message   struct {
+				Usage *rawUsage `json:"usage"`
+			} `json:"message"`
+			Usage *rawUsage `json:"usage"`
+		}
+		if json.Unmarshal(sc.Bytes(), &row) != nil {
+			continue
+		}
+		u := row.Message.Usage
+		if u == nil {
+			u = row.Usage
+		}
+		if u == nil || row.Timestamp.Before(weekAgo) {
+			continue
+		}
+		t := u.totals()
+		week.add(t)
+		if !row.Timestamp.Before(dayAgo) {
+			day.add(t)
+		}
+	}
+	return day, week
+}
+
+type rawUsage struct {
+	Input      int64 `json:"input_tokens"`
+	Output     int64 `json:"output_tokens"`
+	CacheRead  int64 `json:"cache_read_input_tokens"`
+	CacheWrite int64 `json:"cache_creation_input_tokens"`
+}
+
+func (u rawUsage) totals() Totals {
+	return Totals{
+		Input: u.Input, Output: u.Output,
+		CacheRead: u.CacheRead, CacheWrite: u.CacheWrite,
+		Turns: 1,
+	}
+}

--- a/utils/agent/usage/usage_test.go
+++ b/utils/agent/usage/usage_test.go
@@ -1,0 +1,101 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func write(t *testing.T, path string, rows []string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := ""
+	for _, r := range rows {
+		body += r + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func turn(at time.Time, in, out, read, write int) string {
+	row := map[string]any{
+		"timestamp": at.Format(time.RFC3339Nano),
+		"message": map[string]any{"usage": map[string]int{
+			"input_tokens": in, "output_tokens": out,
+			"cache_read_input_tokens": read, "cache_creation_input_tokens": write,
+		}},
+	}
+	b, _ := json.Marshal(row)
+	return string(b)
+}
+
+func TestForDirSumsTodayAndWeek(t *testing.T) {
+	cfg := t.TempDir()
+	now := time.Now()
+	write(t, filepath.Join(cfg, "projects", "-dev-app", "a.jsonl"), []string{
+		turn(now.Add(-time.Hour), 10, 5, 100, 20),
+		turn(now.Add(-3*24*time.Hour), 1, 1, 1, 1),
+		turn(now.Add(-30*24*time.Hour), 999, 999, 999, 999),
+		"{not json",
+		`{"timestamp":"` + now.Format(time.RFC3339) + `","message":{}}`,
+	})
+
+	rep := ForDir("/dev/app", cfg, "-dev-app", now)
+	if rep.Today.Turns != 1 || rep.Today.Total() != 135 {
+		t.Errorf("today = %+v (total %d), want the one recent turn", rep.Today, rep.Today.Total())
+	}
+	if rep.Week.Turns != 2 || rep.Week.Total() != 139 {
+		t.Errorf("week = %+v (total %d), want both turns inside the week", rep.Week, rep.Week.Total())
+	}
+}
+
+func TestForDirSumsEveryTranscript(t *testing.T) {
+	cfg := t.TempDir()
+	now := time.Now()
+	dir := filepath.Join(cfg, "projects", "-dev-app")
+	write(t, filepath.Join(dir, "a.jsonl"), []string{turn(now, 1, 2, 3, 4)})
+	write(t, filepath.Join(dir, "b.jsonl"), []string{turn(now, 1, 2, 3, 4)})
+	write(t, filepath.Join(dir, "notes.txt"), []string{"ignored"})
+
+	rep := ForDir("/dev/app", cfg, "-dev-app", now)
+	if rep.Today.Turns != 2 || rep.Today.Total() != 20 {
+		t.Errorf("report = %+v", rep.Today)
+	}
+}
+
+func TestForDirMissingIsZero(t *testing.T) {
+	rep := ForDir("/dev/app", t.TempDir(), "-dev-nope", time.Now())
+	if rep.Week.Total() != 0 || rep.Today.Turns != 0 {
+		t.Errorf("a missing project dir must be zero, got %+v", rep)
+	}
+}
+
+func TestForDirSkipsStaleFilesWithoutReading(t *testing.T) {
+	cfg := t.TempDir()
+	now := time.Now()
+	path := filepath.Join(cfg, "projects", "-dev-app", "old.jsonl")
+	write(t, path, []string{turn(now, 5, 5, 5, 5)})
+	old := now.Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if rep := ForDir("/dev/app", cfg, "-dev-app", now); rep.Week.Total() != 0 {
+		t.Errorf("a transcript untouched for a month must be skipped, got %+v", rep.Week)
+	}
+}
+
+func TestTopLevelUsageAlsoCounts(t *testing.T) {
+	cfg := t.TempDir()
+	now := time.Now()
+	row := fmt.Sprintf(`{"timestamp":"%s","usage":{"input_tokens":7,"output_tokens":3}}`, now.Format(time.RFC3339))
+	write(t, filepath.Join(cfg, "projects", "-dev-app", "a.jsonl"), []string{row})
+	if rep := ForDir("/dev/app", cfg, "-dev-app", now); rep.Today.Total() != 10 {
+		t.Errorf("a top-level usage object must count, got %+v", rep.Today)
+	}
+}

--- a/utils/agentpr.go
+++ b/utils/agentpr.go
@@ -1,0 +1,236 @@
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// A change that spans a stack ends as one pull request per repository. Opening
+// them by hand needs a laptop; this is the part corgi can do from a phone.
+
+// RepoPR is one repository's pull request, or the reason there is none.
+type RepoPR struct {
+	Repo    string `json:"repo"`
+	Dir     string `json:"dir"`
+	Branch  string `json:"branch"`
+	URL     string `json:"url,omitempty"`
+	Created bool   `json:"created"`
+	Skipped string `json:"skipped,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// PRSet is the result of opening pull requests across a stack.
+type PRSet struct {
+	Branch string   `json:"branch"`
+	Base   string   `json:"base,omitempty"`
+	PRs    []RepoPR `json:"prs"`
+}
+
+// prRunner executes a git/forge command in a directory. Injected for tests.
+type prRunner func(dir, name string, args ...string) (string, error)
+
+func execInDir(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// OpenBranchPRs pushes branch in every repository that has commits on it and
+// opens a pull request there, then cross-links the bodies so each PR names its
+// siblings. Repositories with nothing to ship are reported as skipped, never
+// silently dropped.
+func OpenBranchPRs(dirs map[string]string, branch, base, title, body string, draft bool) (*PRSet, error) {
+	return openBranchPRs(dirs, branch, base, title, body, draft, execInDir)
+}
+
+func openBranchPRs(dirs map[string]string, branch, base, title, body string, draft bool, run prRunner) (*PRSet, error) {
+	if strings.TrimSpace(branch) == "" {
+		return nil, fmt.Errorf("branch is required")
+	}
+	if err := validateBranchName(branch); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(title) == "" {
+		return nil, fmt.Errorf("a pull request needs a title")
+	}
+
+	repos := make([]string, 0, len(dirs))
+	for repo := range dirs {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+
+	set := &PRSet{Branch: branch, Base: base}
+	for _, repo := range repos {
+		set.PRs = append(set.PRs, openOnePR(run, repo, dirs[repo], branch, base, title, body, draft))
+	}
+	crossLinkPRs(run, set, dirs, body)
+	return set, nil
+}
+
+func openOnePR(run prRunner, repo, dir, branch, base, title, body string, draft bool) RepoPR {
+	pr := RepoPR{Repo: repo, Dir: dir, Branch: branch}
+
+	// Nothing to open a pull request for is the common case in a stack where
+	// the change touched two of five repositories.
+	if !branchHasCommits(run, dir, branch, base) {
+		pr.Skipped = "no commits on " + branch
+		return pr
+	}
+	if existing := existingPRURL(run, dir, branch); existing != "" {
+		pr.URL, pr.Skipped = existing, "a pull request is already open"
+		return pr
+	}
+
+	forge, err := detectForge(run, dir)
+	if err != nil {
+		pr.Error = err.Error()
+		return pr
+	}
+	if out, err := run(dir, "git", "push", "-u", "origin", branch); err != nil {
+		pr.Error = "push failed: " + firstLine(out)
+		return pr
+	}
+
+	args := forge.createArgs(branch, base, title, body, draft)
+	out, err := run(dir, forge.bin, args...)
+	if err != nil {
+		pr.Error = firstLine(out)
+		return pr
+	}
+	pr.URL, pr.Created = forgeURL(out), true
+	return pr
+}
+
+// crossLinkPRs appends the sibling list to every body, so opening one PR shows
+// the rest of the change. Best effort: a failed edit leaves a working PR.
+func crossLinkPRs(run prRunner, set *PRSet, dirs map[string]string, body string) {
+	var links []string
+	for _, pr := range set.PRs {
+		if pr.Created && pr.URL != "" {
+			links = append(links, "- "+pr.Repo+": "+pr.URL)
+		}
+	}
+	if len(links) < 2 {
+		return
+	}
+	full := strings.TrimSpace(body + "\n\nPart of one change across " + fmt.Sprint(len(links)) + " repositories:\n" + strings.Join(links, "\n"))
+	for _, pr := range set.PRs {
+		if !pr.Created || pr.URL == "" {
+			continue
+		}
+		forge, err := detectForge(run, dirs[pr.Repo])
+		if err != nil {
+			continue
+		}
+		_, _ = run(dirs[pr.Repo], forge.bin, forge.editArgs(pr.URL, full)...)
+	}
+}
+
+type forgeCLI struct {
+	bin        string
+	createArgs func(branch, base, title, body string, draft bool) []string
+	editArgs   func(url, body string) []string
+}
+
+// detectForge picks gh or glab from the origin remote, so a GitLab stack is not
+// handed GitHub's CLI.
+func detectForge(run prRunner, dir string) (forgeCLI, error) {
+	remote, err := run(dir, "git", "remote", "get-url", "origin")
+	if err != nil {
+		return forgeCLI{}, fmt.Errorf("no origin remote: %s", firstLine(remote))
+	}
+	if strings.Contains(remote, "gitlab") {
+		if _, err := exec.LookPath("glab"); err != nil {
+			return forgeCLI{}, fmt.Errorf("glab is not installed — see gitlab.com/gitlab-org/cli")
+		}
+		return forgeCLI{
+			bin: "glab",
+			createArgs: func(branch, base, title, body string, draft bool) []string {
+				args := []string{"mr", "create", "--source-branch", branch, "--title", title, "--description", body, "--yes"}
+				if base != "" {
+					args = append(args, "--target-branch", base)
+				}
+				if draft {
+					args = append(args, "--draft")
+				}
+				return args
+			},
+			editArgs: func(url, body string) []string {
+				return []string{"mr", "update", url, "--description", body}
+			},
+		}, nil
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return forgeCLI{}, fmt.Errorf("gh is not installed — `brew install gh`")
+	}
+	return forgeCLI{
+		bin: "gh",
+		createArgs: func(branch, base, title, body string, draft bool) []string {
+			args := []string{"pr", "create", "--head", branch, "--title", title, "--body", body}
+			if base != "" {
+				args = append(args, "--base", base)
+			}
+			if draft {
+				args = append(args, "--draft")
+			}
+			return args
+		},
+		editArgs: func(url, body string) []string {
+			return []string{"pr", "edit", url, "--body", body}
+		},
+	}, nil
+}
+
+// branchHasCommits reports whether branch carries anything base does not. With
+// no base, any commit the remote has not seen counts.
+func branchHasCommits(run prRunner, dir, branch, base string) bool {
+	ref := strings.TrimSpace(base)
+	if ref == "" {
+		ref = defaultBaseRef(run, dir)
+	}
+	out, err := run(dir, "git", "rev-list", "--count", ref+".."+branch)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) != "" && strings.TrimSpace(out) != "0"
+}
+
+func defaultBaseRef(run prRunner, dir string) string {
+	if out, err := run(dir, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
+		if ref := strings.TrimSpace(out); ref != "" {
+			return ref
+		}
+	}
+	return "origin/main"
+}
+
+// existingPRURL returns the open pull request for branch, if the forge already
+// has one — so re-running opens nothing twice.
+func existingPRURL(run prRunner, dir, branch string) string {
+	if out, err := run(dir, "gh", "pr", "view", branch, "--json", "url", "--jq", ".url"); err == nil {
+		return forgeURL(out)
+	}
+	return ""
+}
+
+// forgeURL picks the URL out of a CLI's chatty output.
+func forgeURL(out string) string {
+	for _, line := range strings.Fields(out) {
+		if strings.HasPrefix(line, "https://") {
+			return strings.TrimRight(line, ".,)")
+		}
+	}
+	return ""
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}

--- a/utils/agentpr.go
+++ b/utils/agentpr.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 )
 
-// A change that spans a stack ends as one pull request per repository. Opening
-// them by hand needs a laptop; this is the part corgi can do from a phone.
-
 // RepoPR is one repository's pull request, or the reason there is none.
 type RepoPR struct {
 	Repo    string `json:"repo"`
@@ -28,7 +25,6 @@ type PRSet struct {
 	PRs    []RepoPR `json:"prs"`
 }
 
-// prRunner executes a git/forge command in a directory. Injected for tests.
 type prRunner func(dir, name string, args ...string) (string, error)
 
 func execInDir(dir, name string, args ...string) (string, error) {
@@ -80,14 +76,13 @@ func openOnePR(run prRunner, repo, dir, branch, base, title, body string, draft 
 		pr.Skipped = "no commits on " + branch
 		return pr
 	}
-	if existing := existingPRURL(run, dir, branch); existing != "" {
-		pr.URL, pr.Skipped = existing, "a pull request is already open"
-		return pr
-	}
-
 	forge, err := detectForge(run, dir)
 	if err != nil {
 		pr.Error = err.Error()
+		return pr
+	}
+	if existing := existingPRURL(run, forge, dir, branch); existing != "" {
+		pr.URL, pr.Skipped = existing, "a pull request is already open"
 		return pr
 	}
 	if out, err := run(dir, "git", "push", "-u", "origin", branch); err != nil {
@@ -105,8 +100,7 @@ func openOnePR(run prRunner, repo, dir, branch, base, title, body string, draft 
 	return pr
 }
 
-// crossLinkPRs appends the sibling list to every body, so opening one PR shows
-// the rest of the change. Best effort: a failed edit leaves a working PR.
+// Best effort: a failed edit still leaves a working pull request.
 func crossLinkPRs(run prRunner, set *PRSet, dirs map[string]string, body string) {
 	var links []string
 	for _, pr := range set.PRs {
@@ -134,10 +128,9 @@ type forgeCLI struct {
 	bin        string
 	createArgs func(branch, base, title, body string, draft bool) []string
 	editArgs   func(url, body string) []string
+	viewArgs   func(branch string) []string
 }
 
-// detectForge picks gh or glab from the origin remote, so a GitLab stack is not
-// handed GitHub's CLI.
 func detectForge(run prRunner, dir string) (forgeCLI, error) {
 	remote, err := run(dir, "git", "remote", "get-url", "origin")
 	if err != nil {
@@ -162,6 +155,9 @@ func detectForge(run prRunner, dir string) (forgeCLI, error) {
 			editArgs: func(url, body string) []string {
 				return []string{"mr", "update", url, "--description", body}
 			},
+			viewArgs: func(branch string) []string {
+				return []string{"mr", "view", branch, "--output", "json"}
+			},
 		}, nil
 	}
 	if _, err := exec.LookPath("gh"); err != nil {
@@ -182,11 +178,12 @@ func detectForge(run prRunner, dir string) (forgeCLI, error) {
 		editArgs: func(url, body string) []string {
 			return []string{"pr", "edit", url, "--body", body}
 		},
+		viewArgs: func(branch string) []string {
+			return []string{"pr", "view", branch, "--json", "url", "--jq", ".url"}
+		},
 	}, nil
 }
 
-// branchHasCommits reports whether branch carries anything base does not. With
-// no base, any commit the remote has not seen counts.
 func branchHasCommits(run prRunner, dir, branch, base string) bool {
 	ref := strings.TrimSpace(base)
 	if ref == "" {
@@ -208,16 +205,14 @@ func defaultBaseRef(run prRunner, dir string) string {
 	return "origin/main"
 }
 
-// existingPRURL returns the open pull request for branch, if the forge already
-// has one — so re-running opens nothing twice.
-func existingPRURL(run prRunner, dir, branch string) string {
-	if out, err := run(dir, "gh", "pr", "view", branch, "--json", "url", "--jq", ".url"); err == nil {
+// So re-running opens nothing twice.
+func existingPRURL(run prRunner, forge forgeCLI, dir, branch string) string {
+	if out, err := run(dir, forge.bin, forge.viewArgs(branch)...); err == nil {
 		return forgeURL(out)
 	}
 	return ""
 }
 
-// forgeURL picks the URL out of a CLI's chatty output.
 func forgeURL(out string) string {
 	for _, line := range strings.Fields(out) {
 		if strings.HasPrefix(line, "https://") {

--- a/utils/agentpr.go
+++ b/utils/agentpr.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 )
 
 // RepoPR is one repository's pull request, or the reason there is none.
@@ -27,10 +29,19 @@ type PRSet struct {
 
 type prRunner func(dir, name string, args ...string) (string, error)
 
+// prStepTimeout bounds each push and forge call: both talk to a network, and a
+// hung one would block the MCP handler that called the tool.
+const prStepTimeout = 3 * time.Minute
+
 func execInDir(dir, name string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), prStepTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return strings.TrimSpace(string(out)), fmt.Errorf("%s timed out after %s", name, prStepTimeout)
+	}
 	return strings.TrimSpace(string(out)), err
 }
 

--- a/utils/agentpr_test.go
+++ b/utils/agentpr_test.go
@@ -222,3 +222,57 @@ func TestExecInDirRunsAndReportsFailure(t *testing.T) {
 		t.Error("a failing command must report an error")
 	}
 }
+
+func TestOpenOnePRReportsAForgeFailure(t *testing.T) {
+	f := &fakeForge{commits: map[string]string{"api": "1"}}
+	run := func(dir, name string, args ...string) (string, error) {
+		if name == "gh" && args[0] == "pr" && args[1] == "create" {
+			return "GraphQL: a pull request already exists", fmt.Errorf("exit 1")
+		}
+		return f.run(dir, name, args...)
+	}
+	set, err := openBranchPRs(map[string]string{"api": "api"}, "feature/x", "", "T", "", false, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if set.PRs[0].Created || !strings.Contains(set.PRs[0].Error, "already exists") {
+		t.Errorf("a forge failure must surface verbatim, got %+v", set.PRs[0])
+	}
+}
+
+func TestOpenOnePRReportsAMissingRemote(t *testing.T) {
+	run := func(dir, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && args[0] == "rev-list":
+			return "2", nil
+		case name == "git" && args[0] == "symbolic-ref":
+			return "origin/main", nil
+		case name == "git" && args[0] == "remote":
+			return "fatal: no such remote 'origin'", fmt.Errorf("exit 2")
+		}
+		return "", nil
+	}
+	set, err := openBranchPRs(map[string]string{"api": "api"}, "feature/x", "main", "T", "", false, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if set.PRs[0].Created || !strings.Contains(set.PRs[0].Error, "origin") {
+		t.Errorf("a repo with no origin must report it, got %+v", set.PRs[0])
+	}
+}
+
+func TestCrossLinkSkipsWhenOnlyOnePRWasOpened(t *testing.T) {
+	f := &fakeForge{
+		commits: map[string]string{"api": "1", "web": "0"},
+		create:  map[string]string{"api": "https://github.com/acme/api/pull/7"},
+	}
+	if _, err := openBranchPRs(map[string]string{"api": "api", "web": "web"},
+		"feature/x", "main", "T", "", false, f.run); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range f.calls {
+		if strings.Contains(c, "pr edit") {
+			t.Errorf("a lone pull request needs no sibling list: %s", c)
+		}
+	}
+}

--- a/utils/agentpr_test.go
+++ b/utils/agentpr_test.go
@@ -131,3 +131,94 @@ func TestForgeURL(t *testing.T) {
 		t.Errorf("no URL must be empty, got %q", got)
 	}
 }
+
+func TestDetectForgePicksGitLabForAGitLabRemote(t *testing.T) {
+	run := func(dir, name string, args ...string) (string, error) {
+		if name == "git" && args[0] == "remote" {
+			return "git@gitlab.com:acme/api.git", nil
+		}
+		return "", nil
+	}
+	forge, err := detectForge(run, "api")
+	if err != nil {
+		t.Skip("glab not installed on this machine")
+	}
+	if forge.bin != "glab" {
+		t.Errorf("bin = %q, want glab", forge.bin)
+	}
+	if got := strings.Join(forge.createArgs("b", "main", "T", "B", true), " "); !strings.Contains(got, "mr create") || !strings.Contains(got, "--draft") {
+		t.Errorf("glab create args = %q", got)
+	}
+	if got := strings.Join(forge.viewArgs("b"), " "); !strings.Contains(got, "mr view") {
+		t.Errorf("glab view args = %q", got)
+	}
+}
+
+func TestDetectForgeReportsAMissingRemote(t *testing.T) {
+	run := func(dir, name string, args ...string) (string, error) {
+		return "fatal: no such remote", fmt.Errorf("exit 2")
+	}
+	if _, err := detectForge(run, "api"); err == nil || !strings.Contains(err.Error(), "origin") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestExistingPRIsReturnedNotDuplicated(t *testing.T) {
+	f := &fakeForge{commits: map[string]string{"api": "2"}}
+	run := func(dir, name string, args ...string) (string, error) {
+		if name == "gh" && args[0] == "pr" && args[1] == "view" {
+			return "https://github.com/acme/api/pull/3", nil
+		}
+		return f.run(dir, name, args...)
+	}
+	set, err := openBranchPRs(map[string]string{"api": "api"}, "feature/x", "", "T", "", false, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr := set.PRs[0]
+	if pr.Created || pr.URL != "https://github.com/acme/api/pull/3" || !strings.Contains(pr.Skipped, "already open") {
+		t.Errorf("an existing pull request must be returned, not reopened: %+v", pr)
+	}
+	for _, c := range f.calls {
+		if strings.Contains(c, "pr create") {
+			t.Error("nothing must be created when one is already open")
+		}
+	}
+}
+
+func TestOpenBranchPRsIsTheExportedEntryPoint(t *testing.T) {
+	if _, err := OpenBranchPRs(nil, "", "", "T", "", false); err == nil {
+		t.Error("the exported entry point must validate too")
+	}
+}
+
+func TestBranchHasCommitsFallsBackToOriginHead(t *testing.T) {
+	var refs []string
+	run := func(dir, name string, args ...string) (string, error) {
+		if name == "git" && args[0] == "symbolic-ref" {
+			return "origin/trunk", nil
+		}
+		if name == "git" && args[0] == "rev-list" {
+			refs = append(refs, args[2])
+			return "1", nil
+		}
+		return "", nil
+	}
+	if !branchHasCommits(run, "api", "feature/x", "") {
+		t.Error("a branch with commits must report true")
+	}
+	if len(refs) != 1 || !strings.HasPrefix(refs[0], "origin/trunk..") {
+		t.Errorf("with no base it must use origin HEAD, got %v", refs)
+	}
+}
+
+func TestExecInDirRunsAndReportsFailure(t *testing.T) {
+	dir := t.TempDir()
+	out, err := execInDir(dir, "sh", "-c", "pwd")
+	if err != nil || out == "" {
+		t.Fatalf("out=%q err=%v", out, err)
+	}
+	if _, err := execInDir(dir, "sh", "-c", "exit 4"); err == nil {
+		t.Error("a failing command must report an error")
+	}
+}

--- a/utils/agentpr_test.go
+++ b/utils/agentpr_test.go
@@ -1,0 +1,133 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeForge records every command and answers the few git queries openBranchPRs
+// makes, so the flow can be checked without a network or a forge CLI.
+type fakeForge struct {
+	calls   []string
+	commits map[string]string
+	create  map[string]string
+	fail    map[string]bool
+}
+
+func (f *fakeForge) run(dir, name string, args ...string) (string, error) {
+	call := dir + " " + name + " " + strings.Join(args, " ")
+	f.calls = append(f.calls, call)
+	switch {
+	case name == "git" && args[0] == "remote":
+		return "git@github.com:acme/" + dir + ".git", nil
+	case name == "git" && args[0] == "symbolic-ref":
+		return "origin/main", nil
+	case name == "git" && args[0] == "rev-list":
+		return f.commits[dir], nil
+	case name == "git" && args[0] == "push":
+		if f.fail[dir] {
+			return "remote rejected", fmt.Errorf("exit 1")
+		}
+		return "", nil
+	case name == "gh" && args[0] == "pr" && args[1] == "view":
+		return "", fmt.Errorf("no pr")
+	case name == "gh" && args[0] == "pr" && args[1] == "create":
+		return f.create[dir], nil
+	}
+	return "", nil
+}
+
+func TestOpenBranchPRsSkipsReposWithoutCommits(t *testing.T) {
+	f := &fakeForge{
+		commits: map[string]string{"api": "3", "web": "0"},
+		create:  map[string]string{"api": "https://github.com/acme/api/pull/7"},
+	}
+	set, err := openBranchPRs(map[string]string{"api": "api", "web": "web"},
+		"feature/x", "", "Add referrals", "why", false, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(set.PRs) != 2 {
+		t.Fatalf("prs = %+v", set.PRs)
+	}
+	byRepo := map[string]RepoPR{}
+	for _, pr := range set.PRs {
+		byRepo[pr.Repo] = pr
+	}
+	if !byRepo["api"].Created || byRepo["api"].URL != "https://github.com/acme/api/pull/7" {
+		t.Errorf("api = %+v", byRepo["api"])
+	}
+	if byRepo["web"].Created || !strings.Contains(byRepo["web"].Skipped, "no commits") {
+		t.Errorf("a repo with nothing on the branch must be reported as skipped, got %+v", byRepo["web"])
+	}
+	for _, c := range f.calls {
+		if strings.HasPrefix(c, "web ") && strings.Contains(c, "push") {
+			t.Error("a repo with no commits must not be pushed")
+		}
+	}
+}
+
+func TestOpenBranchPRsCrossLinksSiblings(t *testing.T) {
+	f := &fakeForge{
+		commits: map[string]string{"api": "2", "web": "1"},
+		create: map[string]string{
+			"api": "https://github.com/acme/api/pull/7",
+			"web": "https://github.com/acme/web/pull/9",
+		},
+	}
+	set, err := openBranchPRs(map[string]string{"api": "api", "web": "web"},
+		"feature/x", "main", "Add referrals", "why", false, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(set.PRs) != 2 || !set.PRs[0].Created || !set.PRs[1].Created {
+		t.Fatalf("both must be created: %+v", set.PRs)
+	}
+	edits := 0
+	for _, c := range f.calls {
+		if strings.Contains(c, "gh pr edit") {
+			edits++
+			if !strings.Contains(c, "pull/7") || !strings.Contains(c, "pull/9") {
+				t.Errorf("an edited body must name both siblings: %s", c)
+			}
+		}
+	}
+	if edits != 2 {
+		t.Errorf("edits = %d, want one per created pull request", edits)
+	}
+}
+
+func TestOpenBranchPRsReportsAFailedPush(t *testing.T) {
+	f := &fakeForge{commits: map[string]string{"api": "1"}, fail: map[string]bool{"api": true}}
+	set, err := openBranchPRs(map[string]string{"api": "api"}, "feature/x", "", "T", "", false, f.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if set.PRs[0].Created || !strings.Contains(set.PRs[0].Error, "push failed") {
+		t.Errorf("a failed push must surface as an error, got %+v", set.PRs[0])
+	}
+}
+
+func TestOpenBranchPRsValidatesInput(t *testing.T) {
+	f := &fakeForge{}
+	if _, err := openBranchPRs(nil, "", "", "T", "", false, f.run); err == nil {
+		t.Error("an empty branch must be refused")
+	}
+	if _, err := openBranchPRs(nil, "feature/x", "", "", "", false, f.run); err == nil {
+		t.Error("an empty title must be refused")
+	}
+	if _, err := openBranchPRs(nil, "--upload-pack=evil", "", "T", "", false, f.run); err == nil {
+		t.Error("a flag-shaped branch must be refused")
+	}
+}
+
+func TestForgeURL(t *testing.T) {
+	out := "Creating pull request for feature/x\nhttps://github.com/acme/api/pull/7\n"
+	if got := forgeURL(out); got != "https://github.com/acme/api/pull/7" {
+		t.Errorf("forgeURL = %q", got)
+	}
+	if got := forgeURL("nothing here"); got != "" {
+		t.Errorf("no URL must be empty, got %q", got)
+	}
+}


### PR DESCRIPTION
All ten items from the roadmap's *Now/Next* lanes, in one PR.

## Launcher (8)

| | |
|---|---|
| **Why it died, on the card** | Each row carries its last timeline event: `exited · network-timeout · 2h ago`, `needs you · 2m ago`. The drawer lists recent events too. |
| **Live session count** | `2 live` from the per-pid records the session-link fix already reads. |
| **Machine identity + update nudge** | Header: `MacBook-Pro · corgi 1.21.0 · daemon up · v1.21.1 available — corgi upd`. Daemon-down goes red. New `/launch/info`; the version check is cached hourly and refreshed off the request path. |
| **Profile + name on Start** | `options ⌄` reveals a profile picker (names only — what each selects stays in trusted config) and a session name that flows spool → daemon → `--name`, so claude.ai shows more than the hostname. Also on `corgi agent session start --name` and `corgi_session_start`. |
| **Paired devices in Settings** | List with pair date, revoke any other device. A device may not revoke itself. New `/launch/devices` (GET/DELETE). |
| **Doctor on the phone** | `Run doctor` serves `collectAgentChecks`, failures first with their fixes. New `/launch/doctor`. |
| **Tap the push** | The MCP server records its public URL when the tunnel comes up; every ntfy notification carries `Click: <url>/app`. |
| **`corgi agent tunnel setup <host>`** | cloudflared: login check, create if missing, route DNS, save both flags. ngrok: authtoken check, save the domain. `--dry-run` prints the plan. After it, a bare `corgi agent restart` keeps the URL — and the phone stays paired. |

## "Needs you" notifications (#5)

`corgi agent hooks enable` writes Claude Code `Notification` + `Stop` hooks into `.claude/settings.local.json` (local, never committed). They call `corgi agent hook`, which spools an `attention` command; the daemon turns it into a timeline event and the usual notification — desktop plus phone push when `notifyUrl` is set. Covers sessions corgi does not supervise. `disable` removes only corgi's entries.

## Cross-repo pull requests (#6)

`corgi_pr_open { branch, title, body?, base?, draft? }`: for each repository with commits on the branch, push and open a PR with `gh` (or `glab` when the remote is GitLab), then edit every body to link its siblings. Repositories with no commits are reported as `skipped`; an already-open PR is returned, never duplicated. Behind the same tunnel gate as the other mutating tools.

## Verified

- `gofmt`, `go vet`, native + Windows builds clean; launcher JS passes `node --check`
- `go test -race -count=1 ./cmd/ ./utils/agent/... ./utils/` — **2222 pass**, including new tests for name sanitizing, each new endpoint, self-revoke refusal, the tunnel-setup plan, hook payload parsing, hook add/strip idempotency, and the PR flow (skip, cross-link, failed push, validation)
- Page rendered at phone width with a stubbed backend to check every new control before opening this