### PR TITLE
MCP: stop the tunnel probe poisoning its own hostname

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -440,7 +440,7 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 				mcpPublicTunnelActive.Store(true)
 				// Probe the route the tools are actually served on, not the
 				// root — see probeTunnelExposure.
-				go probeTunnelExposure(ctx, mcpProbeTarget(ev.URL))
+				go probeTunnelExposure(ctx, mcpProbeTarget(ev.URL), nil)
 				recordPublicURL(ev.URL)
 				fmt.Fprintf(os.Stderr, "🌐 ✓ public MCP endpoint: %s/mcp\n", ev.URL)
 				// Don't reprint the bearer token in a pasteable block on the
@@ -468,8 +468,28 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 // Runs in the background: nothing may wait on it, because the endpoint is
 // already serving by the time the URL is printed, and a gate that starts closed
 // and opens on evidence is the safe direction to be wrong in.
-func probeTunnelExposure(ctx context.Context, url string) {
-	result := exposureProbe(ctx, url)
+// probeDelays waits out DNS propagation before asking. A quick tunnel's
+// hostname does not resolve for a few seconds after cloudflared prints it, and
+// a query made in that window is answered NXDOMAIN — which resolvers cache
+// against the negative TTL on the zone's SOA, half an hour for trycloudflare.
+// Probing immediately therefore poisons the very hostname corgi just published,
+// for the machine and every device sharing its resolver.
+var probeDelays = []time.Duration{8 * time.Second, 20 * time.Second, 45 * time.Second}
+
+func probeTunnelExposure(ctx context.Context, url string, sleep func(context.Context, time.Duration) bool) {
+	if sleep == nil {
+		sleep = waitOrDone
+	}
+	var result tunnel.AccessResult
+	for _, delay := range probeDelays {
+		if !sleep(ctx, delay) {
+			return
+		}
+		result = exposureProbe(ctx, url)
+		if result.Protected || !probeNameUnresolved(result) {
+			break
+		}
+	}
 	if !result.Protected {
 		// Not a warning: this is the documented default. The block message
 		// already told them how to change it.
@@ -485,6 +505,26 @@ func probeTunnelExposure(ctx context.Context, url string) {
 // exposureProbe is the access check, swappable so a test can assert which URL
 // the gate is measured against without needing a trusted certificate.
 var exposureProbe = tunnel.ProbeAccess
+
+// probeNameUnresolved reports the one failure worth retrying: the hostname is
+// not in DNS yet. Anything else is a real answer about the endpoint.
+func probeNameUnresolved(r tunnel.AccessResult) bool {
+	d := strings.ToLower(r.Detail)
+	return strings.Contains(d, "no such host") || strings.Contains(d, "server misbehaving")
+}
+
+// waitOrDone sleeps unless the context ends first, reporting whether the wait
+// completed and the caller should carry on.
+func waitOrDone(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
 
 // mcpProbeTarget is the URL the exposure probe must measure: the route the
 // tools are served on, never the tunnel root.

--- a/cmd/mcp_dangerous_test.go
+++ b/cmd/mcp_dangerous_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"andriiklymiuk/corgi/utils/tunnel"
 )
@@ -90,7 +91,7 @@ func TestProbeTunnelExposureLeavesTheGateClosedOnAPublicEndpoint(t *testing.T) {
 	mcpTunnelPrivate.Store(false)
 	t.Cleanup(func() { mcpTunnelPrivate.Store(false) })
 
-	probeTunnelExposure(context.Background(), srv.URL)
+	probeTunnelExposure(context.Background(), srv.URL, noWait)
 
 	if mcpTunnelPrivate.Load() {
 		t.Fatal("probing a public endpoint must not mark the tunnel private")
@@ -124,7 +125,7 @@ func TestExposureProbeUsesTheURLItIsGiven(t *testing.T) {
 		mcpTunnelPrivate.Store(false)
 	})
 
-	probeTunnelExposure(context.Background(), mcpProbeTarget("https://corgi.example"))
+	probeTunnelExposure(context.Background(), mcpProbeTarget("https://corgi.example"), noWait)
 
 	if probed != "https://corgi.example/mcp" {
 		t.Errorf("probed %q, want the gated route", probed)
@@ -172,3 +173,7 @@ func TestCorgisOwn401DoesNotMarkTheEndpointPrivate(t *testing.T) {
 		t.Errorf("corgi's own 401 must never count as an identity proxy (detail: %s)", got.Detail)
 	}
 }
+
+// noWait skips the DNS-propagation delay: these tests point at a live server
+// whose name already resolves.
+func noWait(context.Context, time.Duration) bool { return true }

--- a/cmd/mcp_pairing_test.go
+++ b/cmd/mcp_pairing_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,8 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"andriiklymiuk/corgi/utils/agent/pairing"
+	"andriiklymiuk/corgi/utils/tunnel"
 )
 
 func pairingFixture(t *testing.T) (*pairing.Session, string, string) {
@@ -429,5 +432,76 @@ func TestInspectStoreDistinguishesUnreadable(t *testing.T) {
 	}
 	if got := pairing.InspectStore(path); got != pairing.StoreUnreadable {
 		t.Errorf("corrupt store = %v, want StoreUnreadable", got)
+	}
+}
+
+func TestProbeWaitsBeforeAskingDNS(t *testing.T) {
+	origProbe := exposureProbe
+	t.Cleanup(func() { exposureProbe = origProbe })
+
+	var asked int
+	exposureProbe = func(context.Context, string) tunnel.AccessResult {
+		asked++
+		return tunnel.AccessResult{Detail: "probe failed: dial tcp: lookup x: no such host"}
+	}
+	var waited []time.Duration
+	sleep := func(context.Context, time.Duration) bool { return true }
+	record := func(ctx context.Context, d time.Duration) bool {
+		waited = append(waited, d)
+		return sleep(ctx, d)
+	}
+
+	probeTunnelExposure(context.Background(), "https://x.trycloudflare.com/mcp", record)
+
+	if len(waited) == 0 || waited[0] == 0 {
+		t.Fatalf("the first probe must wait for DNS to propagate, waits=%v", waited)
+	}
+	if asked != len(probeDelays) {
+		t.Errorf("an unresolved name must be retried: asked %d times, want %d", asked, len(probeDelays))
+	}
+	if mcpTunnelPrivate.Load() {
+		t.Error("a failed probe must not mark the tunnel private")
+	}
+}
+
+func TestProbeStopsOnceItGetsAnAnswer(t *testing.T) {
+	origProbe := exposureProbe
+	t.Cleanup(func() { exposureProbe = origProbe; mcpTunnelPrivate.Store(false) })
+
+	var asked int
+	exposureProbe = func(context.Context, string) tunnel.AccessResult {
+		asked++
+		return tunnel.AccessResult{Detail: "public endpoint"}
+	}
+	probeTunnelExposure(context.Background(), "https://x.trycloudflare.com/mcp",
+		func(context.Context, time.Duration) bool { return true })
+	if asked != 1 {
+		t.Errorf("a real answer must end the retries, asked %d times", asked)
+	}
+}
+
+func TestProbeGivesUpWhenTheServerStops(t *testing.T) {
+	origProbe := exposureProbe
+	t.Cleanup(func() { exposureProbe = origProbe })
+	var asked int
+	exposureProbe = func(context.Context, string) tunnel.AccessResult {
+		asked++
+		return tunnel.AccessResult{}
+	}
+	probeTunnelExposure(context.Background(), "https://x/mcp",
+		func(context.Context, time.Duration) bool { return false })
+	if asked != 0 {
+		t.Errorf("a cancelled wait must not probe, asked %d times", asked)
+	}
+}
+
+func TestWaitOrDoneRespectsCancellation(t *testing.T) {
+	if !waitOrDone(context.Background(), time.Millisecond) {
+		t.Error("a completed wait must report true")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if waitOrDone(ctx, time.Hour) {
+		t.Error("a cancelled context must not wait out the delay")
 	}
 }


### PR DESCRIPTION
## The bug

`corgi agent up` published a working tunnel that the phone could not open, and the laptop could not either — for about half an hour, at which point it started working on its own.

```
cloudflared prints URL ──▶ corgi probes it immediately
                             ▼
                       DNS has not propagated → NXDOMAIN
                             ▼
                 resolver caches that against the zone SOA
                 (trycloudflare.com: 1800s negative TTL)
                             ▼
              the machine and every device behind that resolver
              cannot reach the URL corgi just printed
```

Measured on a real router: it resolved `google.com`, `github.com` and `trycloudflare.com` itself, and returned NXDOMAIN for the new subdomain with `SOA … 1800`. Fetching the same URL through `--resolve` against 1.1.1.1 returned 200 the whole time — the tunnel was never the problem. corgi's own log showed it: `exposure: public — probe failed: … no such host`.

That log line was the tell: the probe that reported the failure is the query that caused it.

## The fix

The probe waits before asking, and retries only while the name is unresolved (`no such host` / `server misbehaving`). Any real answer — public or protected — ends it immediately, so the exposure gate is unchanged for every endpoint that resolves.

## Verified

- `gofmt`, `go vet`, native + Windows builds clean
- `go test -race ./cmd/` green, with new tests for the wait, the retry-only-on-unresolved rule, stopping on a real answer, and cancellation