### PR TITLE
Agent: explain why the phone cannot reach it, and offer the tunnel-free path

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -399,6 +399,9 @@ func runAgentStatus(_ *cobra.Command, _ []string) {
 	if !status.WakeLockable {
 		fmt.Println("wake lock: unsupported on this platform")
 	}
+	if risk := supervisor.CheckSleepRisk(); risk.AtRisk() {
+		fmt.Printf("⚠ %s\n  fix: %s\n", risk.Reason, risk.Fix)
+	}
 	for _, w := range status.Workspaces {
 		printWorkspaceState(w)
 	}

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -502,6 +502,9 @@ func checkWakeLockSupport() agentCheck {
 			Fix:    "install " + argv[0] + ", or set wakeLock: off",
 		}
 	}
+	if risk := supervisor.CheckSleepRisk(); risk.AtRisk() {
+		return agentCheck{Name: checkWakeLock, Detail: risk.Reason, Fix: risk.Fix}
+	}
 	detail := argv[0]
 	if runtime.GOOS == "darwin" {
 		detail += " — note: " + supervisor.ClamshellWarning

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -627,11 +627,6 @@ func printAgentUp(res agentUpResult) {
 	fmt.Println("  or from any MCP client: corgi_session_start {\"workspace\":\"" + orDefault(res.Workspace, "<name>") + "\"}")
 }
 
-// sharedTunnelHint warns about the failure that looks like corgi being broken
-// but is not: a free tunnel provider's shared domain is on enough blocklists
-// that mobile carriers and filtering resolvers refuse to resolve it, so the
-// page never loads on cellular while the same link works on Wi-Fi. Only for
-// those shared domains — a hostname the user owns is not on any list.
 func lanLauncherURL(addr, code string) string {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil || (host != "0.0.0.0" && host != "::" && host != "") {
@@ -649,18 +644,41 @@ func lanLauncherURL(addr, code string) string {
 	return out + "    launcher: " + base + "/app\n"
 }
 
-// No packet is sent: a UDP socket only records the route.
 func outboundIP() string {
-	conn, err := net.Dial("udp", "1.1.1.1:80")
+	ifaces, err := net.Interfaces()
 	if err != nil {
 		return ""
 	}
-	defer conn.Close()
-	host, _, err := net.SplitHostPort(conn.LocalAddr().String())
-	if err != nil {
-		return ""
+	return lanAddressOf(ifaces)
+}
+
+// A phone reaches this machine over the real network, so a docker bridge or a
+// VPN tunnel is the wrong answer even though both carry a private address.
+func lanAddressOf(ifaces []net.Interface) string {
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 ||
+			iface.Flags&net.FlagLoopback != 0 ||
+			iface.Flags&net.FlagPointToPoint != 0 ||
+			strings.HasPrefix(iface.Name, "docker") ||
+			strings.HasPrefix(iface.Name, "br-") ||
+			strings.HasPrefix(iface.Name, "utun") {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok || ipnet.IP.IsLinkLocalUnicast() {
+				continue
+			}
+			if v4 := ipnet.IP.To4(); v4 != nil && v4.IsPrivate() {
+				return v4.String()
+			}
+		}
 	}
-	return host
+	return ""
 }
 
 func sharedTunnelHint(publicURL string) string {

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -17,6 +17,7 @@ import (
 
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/daemon"
+	"andriiklymiuk/corgi/utils/agent/supervisor"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 	"andriiklymiuk/corgi/utils/tunnel"
 
@@ -595,12 +596,12 @@ func printAgentUp(res agentUpResult) {
 	if res.PairCode != "" {
 		fmt.Println()
 		if res.PairURL != "" {
-			fmt.Println("  📱 scan to pair (single use, 2 minutes):")
+			fmt.Println("  📱 scan to pair (single use, 10 minutes):")
 			fmt.Println()
 			printTerminalQR(res.PairURL)
 			fmt.Printf("    or open: %s\n", res.PairURL)
 		} else {
-			fmt.Println("  pair a device (single use, 2 minutes):")
+			fmt.Println("  pair a device (single use, 10 minutes):")
 			fmt.Printf("    code: %s — POST http://%s/pair {\"code\":\"%s\",\"device\":\"my-phone\"}\n",
 				res.PairCode, res.MCPAddr, res.PairCode)
 		}
@@ -609,10 +610,79 @@ func printAgentUp(res agentUpResult) {
 		fmt.Printf("  %s\n", res.Hint)
 	}
 	fmt.Println()
+	if risk := supervisor.CheckSleepRisk(); risk.AtRisk() {
+		fmt.Printf("  ⚠ %s\n    fix: %s\n", risk.Reason, risk.Fix)
+	}
+	if lan := lanLauncherURL(res.MCPAddr, res.PairCode); lan != "" {
+		fmt.Println()
+		fmt.Print(lan)
+	}
 	if res.PublicURL != "" {
 		fmt.Printf("  after scanning, the phone opens the launcher — tap a repo to start:\n    %s/app\n", res.PublicURL)
+		if hint := sharedTunnelHint(res.PublicURL); hint != "" {
+			fmt.Println()
+			fmt.Print(hint)
+		}
 	}
 	fmt.Println("  or from any MCP client: corgi_session_start {\"workspace\":\"" + orDefault(res.Workspace, "<name>") + "\"}")
+}
+
+// sharedTunnelHint warns about the failure that looks like corgi being broken
+// but is not: a free tunnel provider's shared domain is on enough blocklists
+// that mobile carriers and filtering resolvers refuse to resolve it, so the
+// page never loads on cellular while the same link works on Wi-Fi. Only for
+// those shared domains — a hostname the user owns is not on any list.
+func lanLauncherURL(addr, code string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || (host != "0.0.0.0" && host != "::" && host != "") {
+		return ""
+	}
+	ip := outboundIP()
+	if ip == "" {
+		return ""
+	}
+	base := "http://" + net.JoinHostPort(ip, port)
+	out := "  🏠 on the same Wi-Fi, skip the tunnel entirely:\n"
+	if code != "" {
+		out += "    pair:     " + base + "/pair#" + code + "\n"
+	}
+	return out + "    launcher: " + base + "/app\n"
+}
+
+// No packet is sent: a UDP socket only records the route.
+func outboundIP() string {
+	conn, err := net.Dial("udp", "1.1.1.1:80")
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+	host, _, err := net.SplitHostPort(conn.LocalAddr().String())
+	if err != nil {
+		return ""
+	}
+	return host
+}
+
+func sharedTunnelHint(publicURL string) string {
+	shared := []string{".trycloudflare.com", ".loca.lt", ".ngrok-free.app", ".ngrok-free.dev", ".ngrok.io"}
+	matched := false
+	for _, d := range shared {
+		if strings.Contains(publicURL, d) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return ""
+	}
+	return "  \u26a0 if the page never loads on the phone:\n" +
+		"    \u2022 open the link in the real browser, not an app's built-in one\n" +
+		"      (in Safari's in-app view, tap the compass icon) \u2014 scanning the QR\n" +
+		"      with the camera already does this\n" +
+		"    \u2022 this is a free shared tunnel domain; some carriers and filtering\n" +
+		"      DNS refuse to resolve these, so it can work on Wi-Fi and not on\n" +
+		"      cellular. A hostname you own is on no blocklist:\n" +
+		"          corgi agent tunnel setup corgi.yourdomain.com\n"
 }
 
 // printTerminalQR renders a scannable QR in the terminal, indented to match
@@ -747,7 +817,7 @@ func readAgentPidFile(path string) (int, bool) {
 }
 
 func addAgentUpFlags(c *cobra.Command) {
-	c.Flags().String("http", defaultMCPAddr, "Local MCP address")
+	c.Flags().String("http", defaultMCPAddr, "Local MCP address. Use 0.0.0.0:8765 to also serve phones on the same Wi-Fi, which needs no tunnel at all")
 	c.Flags().String("provider", "", "Tunnel provider (cloudflared|ngrok|localtunnel)")
 	c.Flags().String("tunnel-name", "", "cloudflared named-tunnel name — a stable public URL you can bookmark, and a phone that stays paired (needs a one-time `cloudflared tunnel create` and --tunnel-hostname; see docs/agent.md)")
 	c.Flags().String("tunnel-hostname", "", "Public hostname of the named tunnel, e.g. corgi.yourdomain.com (the DNS name routed to it; ngrok: your free static domain). Remembered for the next up/restart; pass \"\" to go back to a quick tunnel")

--- a/cmd/agent_up_test.go
+++ b/cmd/agent_up_test.go
@@ -347,3 +347,38 @@ func TestAwaitMCPLogSurfacesTheTunnelError(t *testing.T) {
 		t.Errorf("the tunnel's own error must be returned at once, got %v", err)
 	}
 }
+
+func TestSharedTunnelHint(t *testing.T) {
+	for _, u := range []string{"https://x.trycloudflare.com", "https://y.loca.lt", "https://z.ngrok-free.app"} {
+		hint := sharedTunnelHint(u)
+		if hint == "" {
+			t.Errorf("%s is a shared domain and must carry the warning", u)
+			continue
+		}
+		if !strings.Contains(hint, "compass") || !strings.Contains(hint, "tunnel setup") {
+			t.Errorf("the hint must name both fixes, got %q", hint)
+		}
+	}
+	if got := sharedTunnelHint("https://corgi.example.com"); got != "" {
+		t.Errorf("a hostname the user owns needs no warning, got %q", got)
+	}
+}
+
+func TestLANLauncherURL(t *testing.T) {
+	if got := lanLauncherURL("127.0.0.1:8765", "CODE"); got != "" {
+		t.Errorf("a loopback-only listener is not reachable from a phone, got %q", got)
+	}
+	got := lanLauncherURL("0.0.0.0:8765", "CODE")
+	if got == "" {
+		t.Skip("no outbound route on this machine")
+	}
+	if !strings.Contains(got, ":8765/app") || !strings.Contains(got, "/pair#CODE") {
+		t.Errorf("both links must be printed, got %q", got)
+	}
+	if strings.Contains(got, "0.0.0.0") {
+		t.Errorf("the printed host must be the LAN address, not the bind address: %q", got)
+	}
+	if noCode := lanLauncherURL("0.0.0.0:8765", ""); strings.Contains(noCode, "/pair#") {
+		t.Errorf("with no pairing code there is no pair link to print: %q", noCode)
+	}
+}

--- a/cmd/agent_up_test.go
+++ b/cmd/agent_up_test.go
@@ -382,3 +382,35 @@ func TestLANLauncherURL(t *testing.T) {
 		t.Errorf("with no pairing code there is no pair link to print: %q", noCode)
 	}
 }
+
+func TestLANAddressSkipsVirtualInterfaces(t *testing.T) {
+	// A docker bridge and a VPN tunnel both carry private addresses, and both
+	// are the wrong answer for a phone on the real network.
+	docker := net.Interface{Name: "docker0", Flags: net.FlagUp}
+	vpn := net.Interface{Name: "utun4", Flags: net.FlagUp | net.FlagPointToPoint}
+	loop := net.Interface{Name: "lo0", Flags: net.FlagUp | net.FlagLoopback}
+	down := net.Interface{Name: "en1", Flags: 0}
+	if got := lanAddressOf([]net.Interface{docker, vpn, loop, down}); got != "" {
+		t.Errorf("no usable interface must yield nothing, got %q", got)
+	}
+	if got := lanAddressOf(nil); got != "" {
+		t.Errorf("no interfaces at all must yield nothing, got %q", got)
+	}
+}
+
+func TestOutboundIPIsPrivateAndRoutable(t *testing.T) {
+	ip := outboundIP()
+	if ip == "" {
+		t.Skip("no LAN interface on this machine")
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil || parsed.To4() == nil {
+		t.Fatalf("not an IPv4 address: %q", ip)
+	}
+	if !parsed.IsPrivate() {
+		t.Errorf("a LAN link must use a private address, got %q", ip)
+	}
+	if parsed.IsLoopback() {
+		t.Errorf("loopback is not reachable from a phone, got %q", ip)
+	}
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -339,7 +339,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 
 	// /pair is deliberately NOT behind the bearer check: its whole purpose is
 	// to serve a client that has no token yet. It is guarded by the pairing
-	// code — single-use, two minutes, attempt-capped — and the route is only
+	// code — single-use, ten minutes, attempt-capped — and the route is only
 	// mounted while a window is open.
 	var pairSession *pairing.Session
 	if opts.pair {

--- a/cmd/mcp_pairing.go
+++ b/cmd/mcp_pairing.go
@@ -133,7 +133,7 @@ const pairClosedHTML = `<!doctype html>
 </style>
 <main>
   <h1>🐕 This pairing link is closed</h1>
-  <p id="msg">Pairing links work once and expire after two minutes.</p>
+  <p id="msg">Pairing links work once and expire after ten minutes.</p>
   <p id="paired" hidden>This phone is already paired with this machine.</p>
   <a id="app" class="open" href="/app" hidden>Open the launcher</a>
   <p id="fresh">Not paired yet? On the laptop run <code>corgi agent up --fresh</code> and scan the new QR.</p>

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -225,6 +225,31 @@ button. It is stored in that browser only and changes nothing on the machine —
 it exists for the moment someone else is looking at your screen. To actually
 stop supervising a workspace, set `autostart: false` for it instead.
 
+### If the phone cannot reach it
+
+The tunnel is the fragile part, and three things break it in ways that look
+like corgi being down:
+
+- **The Mac sleeps.** On battery, macOS honours the wake lock's `-s` only on AC
+  power, so a laptop with `sleep 1` sleeps anyway and every request stalls.
+  `corgi agent status`, `doctor` and `up` now say so, with the fix: plug in, or
+  `sudo pmset -b sleep 0`.
+- **A free shared tunnel domain.** `*.trycloudflare.com`, `*.loca.lt` and
+  ngrok's free domains sit on enough blocklists that some carriers and
+  filtering resolvers refuse them — the same link then works on Wi-Fi and does
+  nothing on cellular. A hostname you own is on no list:
+  `corgi agent tunnel setup corgi.yourdomain.com`.
+- **Nothing at all, if the phone is on your Wi-Fi.** Serve on the local network
+  and skip tunnels entirely:
+
+```bash
+corgi agent up --http 0.0.0.0:8765     # prints http://<lan-ip>:8765/app too
+```
+
+That path has no DNS, no provider and no public exposure — it is the one to
+reach for first when you are at home, and the fallback when a tunnel misbehaves.
+Back to loopback with `corgi agent restart --http 127.0.0.1:8765`.
+
 ### When a session needs you
 
 A session waiting on a permission prompt is invisible from the phone. Opt in
@@ -641,7 +666,7 @@ server's own bearer token — that token reaches `corgi_exec` and `corgi_db_quer
 corgi mcp --http 127.0.0.1:8765 --pair
 ```
 
-prints a single-use code, valid two minutes, which a client exchanges once for
+prints a single-use code, valid ten minutes, which a client exchanges once for
 its own revocable token. `corgi mcp devices revoke <name>` kills exactly one
 device without disturbing the others — which is the whole reason not to share
 one token. Full detail: [docs/mcp.md](mcp.md).

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -173,6 +173,19 @@ doctor. Two things worth telling a user unprompted:
   transcripts (`corgi agent status` prints the same). Cache reads are included,
   so the numbers are large by design — do not report them as an anomaly.
 
+### If the phone cannot open the launcher
+
+Check these before suspecting corgi — all three have been real:
+
+| symptom | cause | say |
+|---|---|---|
+| requests stall ~15s, Safari says "server stopped responding" | the Mac sleeps on battery; the wake lock is AC-only | plug in, or `sudo pmset -b sleep 0` |
+| works on Wi-Fi, dead on cellular | free shared tunnel domain refused by carrier/filtering DNS | `corgi agent tunnel setup <host you own>` |
+| any tunnel flakiness, phone at home | no need for a tunnel | `corgi agent up --http 0.0.0.0:8765`, then `http://<lan-ip>:8765/app` |
+
+`corgi agent status` and `doctor` report the sleep risk directly; relay it
+rather than re-deriving.
+
 ### If a session died
 
 `corgi agent status` shows `lastReason`, and `corgi agent logs <workspace>`

--- a/utils/agent/pairing/pairing.go
+++ b/utils/agent/pairing/pairing.go
@@ -35,9 +35,12 @@ import (
 // unauthenticated pairing endpoint; anything else names local paths.
 var ErrBadRequest = errors.New("pairing request rejected")
 
-// CodeTTL is how long a pairing code stays valid. Long enough to walk to your
-// phone, short enough that a code left on screen is not a standing invitation.
-const CodeTTL = 2 * time.Minute
+// CodeTTL is how long a pairing code stays valid. Two minutes was too short in
+// practice: the code has to survive being read off a terminal, sent to a phone
+// and opened there, and a window that closes mid-flow costs a whole restart.
+// Ten still keeps a code left on screen from being a standing invitation, and
+// the attempt cap is what actually bounds guessing.
+const CodeTTL = 10 * time.Minute
 
 // MaxAttempts is how many wrong codes are tolerated before pairing closes.
 // The code is high-entropy, so this is about shutting down noise, not about

--- a/utils/agent/pairing/pairing.go
+++ b/utils/agent/pairing/pairing.go
@@ -35,11 +35,8 @@ import (
 // unauthenticated pairing endpoint; anything else names local paths.
 var ErrBadRequest = errors.New("pairing request rejected")
 
-// CodeTTL is how long a pairing code stays valid. Two minutes was too short in
-// practice: the code has to survive being read off a terminal, sent to a phone
-// and opened there, and a window that closes mid-flow costs a whole restart.
-// Ten still keeps a code left on screen from being a standing invitation, and
-// the attempt cap is what actually bounds guessing.
+// CodeTTL has to survive a code being read off a terminal, sent to a phone and
+// opened there; the single-use rule and MaxAttempts are what bound guessing.
 const CodeTTL = 10 * time.Minute
 
 // MaxAttempts is how many wrong codes are tolerated before pairing closes.

--- a/utils/agent/supervisor/sleepguard.go
+++ b/utils/agent/supervisor/sleepguard.go
@@ -1,0 +1,83 @@
+package supervisor
+
+import (
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// macOS honours `caffeinate -s` on AC power only, so a laptop on battery
+// sleeps with the wake lock held and every remote request stalls or fails.
+type SleepRisk struct {
+	OnBattery bool
+	// SleepMinutes is 0 for never, negative when it could not be read.
+	SleepMinutes int
+	Reason       string
+	Fix          string
+}
+
+func (s SleepRisk) AtRisk() bool { return s.Reason != "" }
+
+// Best-effort: anything unreadable is reported as no risk, because a false
+// warning on every status is worse than a missing one.
+func CheckSleepRisk() SleepRisk {
+	if runtime.GOOS != "darwin" {
+		return SleepRisk{SleepMinutes: -1}
+	}
+	return sleepRiskFrom(runCommand("pmset", "-g", "batt"), runCommand("pmset", "-g", "custom"))
+}
+
+func runCommand(name string, args ...string) string {
+	out, err := exec.Command(name, args...).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+var sleepSettingPattern = regexp.MustCompile(`(?m)^\s*sleep\s+(\d+)`)
+
+func sleepRiskFrom(battOutput, customOutput string) SleepRisk {
+	risk := SleepRisk{SleepMinutes: -1}
+	if battOutput == "" && customOutput == "" {
+		return risk
+	}
+	risk.OnBattery = strings.Contains(battOutput, "'Battery Power'")
+
+	section := customOutput
+	if risk.OnBattery {
+		// Only the active power source's block decides what happens now.
+		if i := strings.Index(customOutput, "Battery Power:"); i >= 0 {
+			section = customOutput[i:]
+			if j := strings.Index(section, "AC Power:"); j > 0 {
+				section = section[:j]
+			}
+		}
+	} else if i := strings.Index(customOutput, "AC Power:"); i >= 0 {
+		section = customOutput[i:]
+	}
+
+	if m := sleepSettingPattern.FindStringSubmatch(section); m != nil {
+		if v, err := strconv.Atoi(m[1]); err == nil {
+			risk.SleepMinutes = v
+		}
+	}
+	if !risk.OnBattery || risk.SleepMinutes <= 0 {
+		return risk
+	}
+
+	risk.Reason = "on battery, this Mac sleeps after " + plural(risk.SleepMinutes, "minute") +
+		" — the wake lock cannot stop that (macOS honours it on AC power only), so remote sessions stall or fail"
+	risk.Fix = "plug in, or `sudo pmset -b sleep 0`"
+	return risk
+}
+
+func plural(n int, unit string) string {
+	s := strconv.Itoa(n) + " " + unit
+	if n != 1 {
+		s += "s"
+	}
+	return s
+}

--- a/utils/agent/supervisor/sleepguard.go
+++ b/utils/agent/supervisor/sleepguard.go
@@ -1,11 +1,13 @@
 package supervisor
 
 import (
+	"context"
 	"os/exec"
 	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // macOS honours `caffeinate -s` on AC power only, so a laptop on battery
@@ -29,8 +31,11 @@ func CheckSleepRisk() SleepRisk {
 	return sleepRiskFrom(runCommand("pmset", "-g", "batt"), runCommand("pmset", "-g", "custom"))
 }
 
+// Bounded: a hung pmset must not hang `corgi agent status`.
 func runCommand(name string, args ...string) string {
-	out, err := exec.Command(name, args...).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, name, args...).Output()
 	if err != nil {
 		return ""
 	}

--- a/utils/agent/supervisor/sleepguard_test.go
+++ b/utils/agent/supervisor/sleepguard_test.go
@@ -1,0 +1,81 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+)
+
+const customOutput = `Battery Power:
+ standby              1
+ sleep                1
+ displaysleep         60
+AC Power:
+ standby              1
+ sleep                0
+ displaysleep         10
+`
+
+func TestSleepRiskOnBatteryWithSleepEnabled(t *testing.T) {
+	risk := sleepRiskFrom("Now drawing from 'Battery Power'\n", customOutput)
+	if !risk.AtRisk() {
+		t.Fatal("a Mac that sleeps in a minute on battery is exactly the risk to report")
+	}
+	if !risk.OnBattery || risk.SleepMinutes != 1 {
+		t.Errorf("risk = %+v", risk)
+	}
+	if !strings.Contains(risk.Reason, "1 minute") || strings.Contains(risk.Reason, "1 minutes") {
+		t.Errorf("reason must read naturally: %q", risk.Reason)
+	}
+	if !strings.Contains(risk.Fix, "pmset -b sleep 0") {
+		t.Errorf("fix must be the command that removes it: %q", risk.Fix)
+	}
+}
+
+func TestNoRiskOnACPower(t *testing.T) {
+	risk := sleepRiskFrom("Now drawing from 'AC Power'\n", customOutput)
+	if risk.AtRisk() {
+		t.Errorf("the AC block has sleep 0, so there is nothing to warn about: %+v", risk)
+	}
+	if risk.OnBattery {
+		t.Error("AC power must not read as battery")
+	}
+}
+
+func TestNoRiskWhenBatterySleepIsDisabled(t *testing.T) {
+	custom := "Battery Power:\n sleep                0\nAC Power:\n sleep                0\n"
+	if risk := sleepRiskFrom("Now drawing from 'Battery Power'\n", custom); risk.AtRisk() {
+		t.Errorf("sleep 0 on battery is the fixed state, not a risk: %+v", risk)
+	}
+}
+
+func TestUnreadablePowerStateIsNotARisk(t *testing.T) {
+	risk := sleepRiskFrom("", "")
+	if risk.AtRisk() {
+		t.Error("a warning on every status is worse than a missing one")
+	}
+	if risk.SleepMinutes != -1 {
+		t.Errorf("an unread setting is -1, got %d", risk.SleepMinutes)
+	}
+}
+
+func TestBatteryReadsItsOwnBlockNotTheACOne(t *testing.T) {
+	// The AC block says 0; the battery block says 5. Reading the wrong one
+	// would silently clear the warning on the machine that needs it.
+	custom := "Battery Power:\n sleep                5\nAC Power:\n sleep                0\n"
+	risk := sleepRiskFrom("Now drawing from 'Battery Power'\n", custom)
+	if risk.SleepMinutes != 5 || !risk.AtRisk() {
+		t.Errorf("risk = %+v", risk)
+	}
+	if !strings.Contains(risk.Reason, "5 minutes") {
+		t.Errorf("reason = %q", risk.Reason)
+	}
+}
+
+func TestPlural(t *testing.T) {
+	if got := plural(1, "minute"); got != "1 minute" {
+		t.Errorf("got %q", got)
+	}
+	if got := plural(3, "minute"); got != "3 minutes" {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
Three separate failures, one afternoon, all of which looked like corgi being broken. None of them were reported by corgi.

## 1. The Mac sleeps and the wake lock does not stop it

macOS honours `caffeinate -s` **on AC power only**. On battery with `sleep 1`, the machine sleeps with the lock held; requests then stall ~15s or fail outright, while `corgi agent status` cheerfully prints `wakeLock=true`.

Measured on the machine that hit this:

| | time |
|---|---|
| corgi, directly | 0.0006s |
| 19-byte 404 through the tunnel | 15.0s |
| 30KB page through the tunnel | 13.0s |

A 19-byte response taking 15 seconds is not bandwidth and not corgi.

`status`, `doctor` and `up` now read `pmset` and say it:

```
⚠ on battery, this Mac sleeps after 1 minute — the wake lock cannot stop that
  (macOS honours it on AC power only), so remote sessions stall or fail
  fix: plug in, or `sudo pmset -b sleep 0`
```

## 2. Free shared tunnel domains get refused

`*.trycloudflare.com`, `*.loca.lt` and ngrok's free domains are on enough blocklists that some carriers and filtering resolvers will not resolve them — so the same link opens on Wi-Fi and does nothing on cellular. `up` now warns when the published host is one of those, and points at the fix (a hostname you own, via `corgi agent tunnel setup`).

## 3. A phone on the same Wi-Fi needs no tunnel at all

With `--http 0.0.0.0:8765` the summary now prints the LAN links:

```
🏠 on the same Wi-Fi, skip the tunnel entirely:
  pair:     http://192.168.0.67:8765/pair#CODE
  launcher: http://192.168.0.67:8765/app
```

No DNS, no provider, no public exposure — 5ms instead of 15s. It is the right first move at home and the fallback whenever a tunnel misbehaves.

## Also: pairing window 2 → 10 minutes

Two minutes did not survive reading a code off a terminal, sending it to a phone and opening it there; a window that closes mid-flow costs a whole restart. The single-use rule and the attempt cap — which are what actually bound guessing — are unchanged.

## Verified

- `gofmt`, `go vet`, native + Windows builds clean
- `go test -race ./cmd/ ./utils/agent/...` green, with new tests for the pmset parsing (battery vs AC block, sleep 0, unreadable output), the shared-domain hint, and the LAN URL
- The sleep warning was confirmed firing on a real machine with `sleep 1` on battery