### PR TITLE
docs: how the phone should reach the machine, and ngrok's dev domain

### DIFF
--- a/cmd/agent_tunnel.go
+++ b/cmd/agent_tunnel.go
@@ -27,8 +27,9 @@ tunnel when it does not exist, routes the DNS name to it, and saves both flags
 so a plain ` + "`corgi agent restart`" + ` keeps the same URL — and the phone
 stays paired, because the origin never changes.
 
-For ngrok it checks the authtoken and saves the domain; claiming the free
-static domain itself is a dashboard step with no CLI equivalent.`,
+For ngrok it checks the authtoken and saves the domain. Every free account
+already has one static ` + "`*.ngrok-free.dev`" + ` dev domain — copy it from
+dashboard.ngrok.com/domains; its name cannot be chosen on the free tier.`,
 	Args: cobra.ExactArgs(1),
 	Run:  runAgentTunnelSetup,
 }
@@ -172,7 +173,7 @@ https://dashboard.ngrok.com/get-started/your-authtoken then run:
     ngrok config add-authtoken <token>`)
 	}
 	utils.Infof("using ngrok domain %s\n", host)
-	utils.Info("if that domain is not claimed yet: dashboard.ngrok.com → Domains → claim your free static domain")
+	utils.Info("free tier: this is the `dev domain` row on dashboard.ngrok.com/domains — its name is assigned, not chosen")
 	return nil
 }
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -92,14 +92,15 @@ phone stays paired across restarts.
 `corgi agent restart` keeps the named tunnel. Pass the flags again to change
 them; `--tunnel-hostname ""` goes back to a quick tunnel.
 
-No domain on Cloudflare? ngrok's free tier includes one static domain and needs
-no DNS work:
+No domain on Cloudflare? ngrok's free tier already gave your account one static
+`*.ngrok-free.dev` **dev domain** and needs no DNS work. You cannot choose its
+name — picking one is a paid feature — but the assigned one never changes:
 
 ```bash
 brew install ngrok
-ngrok config add-authtoken <token>        # dashboard.ngrok.com → Your Authtoken
-# dashboard.ngrok.com → Domains → claim your free *.ngrok-free.app domain, then:
-corgi agent up --provider ngrok --tunnel-hostname <yours>.ngrok-free.app
+ngrok config add-authtoken <token>   # dashboard.ngrok.com → Your Authtoken
+# dashboard.ngrok.com → Domains → copy the row tagged `dev domain`, then:
+corgi agent up --provider ngrok --tunnel-hostname <yours>.ngrok-free.dev
 ```
 
 The first time the phone opens the page, ngrok's free tier shows its own
@@ -111,7 +112,7 @@ phone's home screen once. One command does the whole setup and remembers it:
 
 ```bash
 corgi agent tunnel setup corgi.yourdomain.com                  # cloudflared
-corgi agent tunnel setup <yours>.ngrok-free.app --provider ngrok
+corgi agent tunnel setup <yours>.ngrok-free.dev --provider ngrok
 ```
 
 Per-service stable tunnels: [docs/tunnel.md](tunnel.md#stable-urls-named-mode).

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -67,6 +67,23 @@ corgi agent install              # start at login (launchd / systemd)
 corgi agent status               # what is running, and under which account
 ```
 
+### Which path the phone should use
+
+Pick by where the phone will be, not by which tunnel sounds best:
+
+| where the phone is | run this | URL to save on the phone |
+|---|---|---|
+| on the same Wi-Fi | `corgi agent up --http 0.0.0.0:8765` | `http://<lan-ip>:8765/app` |
+| anywhere, domain on Cloudflare | `corgi agent tunnel setup corgi.yourdomain.com` | `https://corgi.yourdomain.com/app` |
+| anywhere, no domain | `corgi agent tunnel setup <yours>.ngrok-free.dev --provider ngrok` | that host + `/app` |
+| one-off, re-pairing is fine | `corgi agent up` | changes on every restart |
+
+The Wi-Fi row uses no tunnel, no DNS and no provider, so it is the fastest and
+the least breakable — reach for it first when you are at home. The launcher is
+token-protected either way, so serving it on the local network is not serving it
+to the internet. The middle two rows keep a fixed origin, which is what keeps
+the phone paired across restarts; the quick tunnel does not.
+
 ### A launcher URL that never changes
 
 The default is a Cloudflare **quick tunnel**: free, no signup — and a **new random
@@ -250,6 +267,22 @@ corgi agent up --http 0.0.0.0:8765     # prints http://<lan-ip>:8765/app too
 That path has no DNS, no provider and no public exposure — it is the one to
 reach for first when you are at home, and the fallback when a tunnel misbehaves.
 Back to loopback with `corgi agent restart --http 127.0.0.1:8765`.
+
+When it is unclear whether corgi or the tunnel is at fault, two requests settle
+it. Run both on the machine:
+
+```bash
+curl -so /dev/null -w '%{http_code} %{time_total}s\n' http://127.0.0.1:8765/app
+curl -so /dev/null -w '%{http_code} %{time_total}s\n' https://<public-host>/app
+```
+
+A slow or failing loopback request means corgi itself — `corgi agent status`,
+then `corgi agent restart`. A fast loopback and a failing public one means the
+tunnel is not delivering; switch provider, or use the Wi-Fi path above. Both
+fast means the machine's side is healthy and the phone's network is the
+problem, so test the public URL again from something that is not on this
+network — the machine shares its own DNS and route with that second request,
+so a `200` there does not prove a phone on cellular can resolve the name.
 
 ### When a session needs you
 

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -255,8 +255,9 @@ daemon AND the detached MCP + tunnel (`agent stop` stops only the daemon).
 corgi upgrade so the daemon and launcher run the new binary. `up` remembers
 the tunnel flags it last ran with, so a bare `restart` keeps the named tunnel;
 `--tunnel-hostname ""` is the way back to a quick tunnel. ngrok works too:
-`--provider ngrok --tunnel-hostname <yours>.ngrok-free.app` (free static
-domain, no DNS) — its free tier shows an interstitial once on first open.
+`--provider ngrok --tunnel-hostname <yours>.ngrok-free.dev` (the static dev
+domain every free account already has, no DNS; its name cannot be chosen on the
+free tier) — ngrok shows an interstitial once on first open.
 
 The user scans the QR (or opens the printed URL) on their phone, names the
 device, and gets a per-device token. After pairing, the same page offers **Open

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -173,6 +173,25 @@ doctor. Two things worth telling a user unprompted:
   transcripts (`corgi agent status` prints the same). Cache reads are included,
   so the numbers are large by design — do not report them as an anomaly.
 
+### Choosing how the phone reaches the machine
+
+Ask where the phone will be, then pick the row — do not default to a tunnel:
+
+| where the phone is | what to run | URL they save |
+|---|---|---|
+| same Wi-Fi as the machine | `corgi agent up --http 0.0.0.0:8765` | `http://<lan-ip>:8765/app` |
+| anywhere, domain on Cloudflare | `corgi agent tunnel setup corgi.<their-domain>` | `https://corgi.<their-domain>/app` |
+| anywhere, no domain | `corgi agent tunnel setup <yours>.ngrok-free.dev --provider ngrok` | that host + `/app` |
+| one-off, re-pairing is fine | `corgi agent up` | changes on every restart |
+
+The Wi-Fi row has no tunnel, no DNS and no provider, so it is the one to
+suggest first when the phone is in the same building. The launcher is
+token-protected either way — serving it on the local network is not serving it
+to the internet. The middle two rows hold a fixed origin, which is what keeps
+the phone paired across restarts. ngrok's free plan cannot choose a name;
+every account already has one static `*.ngrok-free.dev` dev domain, and that is
+the one to use.
+
 ### If the phone cannot open the launcher
 
 Check these before suspecting corgi — all three have been real:
@@ -185,6 +204,21 @@ Check these before suspecting corgi — all three have been real:
 
 `corgi agent status` and `doctor` report the sleep risk directly; relay it
 rather than re-deriving.
+
+When it is unclear whether corgi or the tunnel is at fault, run both of these on
+the machine before changing anything:
+
+```bash
+curl -so /dev/null -w '%{http_code} %{time_total}s\n' http://127.0.0.1:8765/app
+curl -so /dev/null -w '%{http_code} %{time_total}s\n' https://<public-host>/app
+```
+
+Loopback slow or failing is corgi — `corgi agent status`, then restart. Loopback
+fast and public failing is the tunnel — switch provider or move to the Wi-Fi
+path. Both fast means the machine is healthy and the phone's network is the
+problem; say so instead of restarting things. That second request shares this
+machine's DNS and route, so a `200` does not prove a phone on cellular can
+resolve the name — confirm from an off-network vantage before concluding it.
 
 ### If a session died
 


### PR DESCRIPTION
Two documentation gaps that both cost real debugging time this week.

### 1. The ngrok instructions described a flow that no longer exists

`corgi agent tunnel setup <host> --provider ngrok` told people to go and claim a
free `*.ngrok-free.app` domain. On the free plan every name you type now comes
back **Requires Upgrade** — choosing a name is a paid feature.

What free accounts get instead is one auto-named static `*.ngrok-free.dev` **dev
domain**, already provisioned, listed on dashboard.ngrok.com/domains with a
`dev domain` tag. It is permanent, which is all the launcher needs for the phone
to stay paired across restarts. Corrected in `docs/agent.md`,
`plugins/corgi/skills/agent/SKILL.md` and the `Long` help plus success hint in
`cmd/agent_tunnel.go`.

### 2. Nothing said which path to set up in the first place

The connectivity docs were purely reactive — a table of things that had already
broken. Adds the decision table to both the doc and the skill:

| where the phone is | what to run |
|---|---|
| same Wi-Fi | `corgi agent up --http 0.0.0.0:8765` |
| anywhere, domain on Cloudflare | `corgi agent tunnel setup corgi.yourdomain.com` |
| anywhere, no domain | `corgi agent tunnel setup <yours>.ngrok-free.dev --provider ngrok` |
| one-off | `corgi agent up` (quick tunnel, new URL each restart) |

The Wi-Fi row involves no tunnel, no DNS and no provider, and the launcher is
token-protected either way — it should be the first suggestion when the phone is
in the same building, not the last resort.

### 3. A way to tell corgi and the tunnel apart

Also adds the two curl requests that separate "corgi is down" from "the tunnel is
not delivering", and the caveat that a `200` from the machine shares that
machine's DNS and route, so it does not prove a phone on cellular can resolve the
name. That caveat is the one that kept sending this debugging in the wrong
direction.

Docs, skill and help text only; no behaviour change.