### PR TITLE
Optimize the code: dead code, resource leaks, comment trimming

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -102,8 +102,6 @@ func warnStrandedAgentData() {
 func agentUserConfigPath(dir string) string { return filepath.Join(dir, "config.yml") }
 func agentRegistryPath(dir string) string   { return filepath.Join(dir, "registry.json") }
 
-// ---------------------------------------------------------------- serve
-
 var agentServeCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Supervise Remote Control for every enabled workspace",
@@ -364,8 +362,6 @@ func printStartupDiagnostics(configs []supervisor.SpawnConfig) {
 	}
 }
 
-// ---------------------------------------------------------------- status
-
 var agentStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show what agent mode is running, and under which account",
@@ -478,8 +474,6 @@ func printWorkspaceDiagnostic(d daemon.WorkspaceDiagnostic) {
 	}
 }
 
-// ---------------------------------------------------------------- stop
-
 var agentStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the agent daemon",
@@ -532,8 +526,6 @@ func waitForDaemonExit(dir string, timeout time.Duration) bool {
 	info, err := daemon.ReadInfo(dir)
 	return err != nil || info == nil
 }
-
-// ---------------------------------------------------------------- workspaces
 
 var agentWorkspacesCmd = &cobra.Command{
 	Use:     "workspaces",
@@ -620,8 +612,6 @@ var agentWorkspacesRelocateCmd = &cobra.Command{
 	},
 }
 
-// ---------------------------------------------------------------- session
-
 var agentSessionCmd = &cobra.Command{
 	Use:   "session",
 	Short: "Start or stop a supervised session in a workspace, on demand",
@@ -663,7 +653,7 @@ func enqueueSessionCommand(action string, args []string, profile, name string) {
 				fmt.Printf("  %-20s %s\n", c.Workspace.ID, c.Workspace.AbsPath)
 			}
 		}
-		os.Exit(2)
+		exitProcess(2)
 	}
 
 	dir, err := agentDir()
@@ -715,7 +705,7 @@ var agentResolveCmd = &cobra.Command{
 			// Same exit code as the human path: a script must not read an
 			// ambiguous answer as a resolved one.
 			if !res.Resolved() {
-				os.Exit(2)
+				exitProcess(2)
 			}
 			return
 		}
@@ -729,7 +719,7 @@ var agentResolveCmd = &cobra.Command{
 		}
 		// Ambiguity is a question for a person, not a failure of the machine,
 		// but it must not read as success to a script.
-		os.Exit(2)
+		exitProcess(2)
 	},
 }
 

--- a/cmd/agent_brief.go
+++ b/cmd/agent_brief.go
@@ -146,8 +146,6 @@ func loadComposeAtDir(dir string) (*utils.CorgiCompose, error) {
 	return nil, fmt.Errorf("no compose file in %s", dir)
 }
 
-// ---------------------------------------------------------------- brief
-
 var agentBriefCmd = &cobra.Command{
 	Use:   "brief [workspace]",
 	Short: "What the last supervised session was working on before it restarted",

--- a/cmd/agent_brief_test.go
+++ b/cmd/agent_brief_test.go
@@ -283,14 +283,10 @@ func briefCmdWithJSON(t *testing.T) *cobra.Command {
 }
 
 func TestProbeWorkspaceReposNamesServicesFromTheComposeFile(t *testing.T) {
-	// End to end over the bug this file's naming logic exists for: worktree
-	// directories are named from the git repository ROOT, so a map keyed on the
-	// service path silently never matches and every worktree gets labelled with
-	// the repository basename instead of its service name.
-	//
-	// The service therefore lives in a SUBDIRECTORY of its repository — a
-	// monorepo, which is exactly the layout where the two paths diverge. With
-	// the service path as the key this test reports "mono" instead of "api".
+	// Worktree dirs are named from the git repository ROOT, so a map keyed on
+	// the service path never matches and every worktree gets the repo basename.
+	// The service lives in a subdirectory here — the monorepo layout where the
+	// two paths diverge — so a regression reports "mono" instead of "api".
 	dir := t.TempDir()
 	repo := gitRepo(t, filepath.Join(dir, "mono"), "main")
 	servicePath := filepath.Join(repo, "services", "api")

--- a/cmd/agent_install.go
+++ b/cmd/agent_install.go
@@ -90,22 +90,12 @@ func runAgentInstall(_ *cobra.Command, _ []string) {
 	}
 }
 
-// servicePATH is the PATH the supervised daemon runs with.
-//
-// launchd and systemd start services with a minimal PATH that does not include
-// Homebrew or ~/.local/bin, so `claude` would not be found: five startup
-// failures, the workspace disabled, and `corgi agent doctor` in the user's own
-// shell passing all the while. The installing shell's PATH is captured, since
-// that is the one where the user verified their setup, with the usual locations
-// added in case corgi was invoked from somewhere unusual.
-// serviceEnv is the environment the supervised daemon needs to resolve the same
-// state the installing shell did.
-//
-// PATH alone is not enough: the agent dir resolves through NativeDataDir, which
-// keys on CORGI_DATA_DIR, HOME and XDG_DATA_HOME. Capturing them keeps the
-// daemon reading the same agent dir as the shell that ran `corgi agent init` —
-// the same skew capturing PATH exists to prevent. HOMEBREW_PREFIX is kept for
-// the legacy exec-path registry (CorgiDataDir), which the daemon can still touch.
+// servicePATH is the PATH the supervised daemon runs with. launchd and systemd
+// start services with a minimal PATH that would not find `claude`, so the
+// installing shell's PATH is captured plus the usual locations.
+// serviceEnv keeps the daemon reading the same agent dir as the installing
+// shell. NativeDataDir keys on CORGI_DATA_DIR, HOME and XDG_DATA_HOME, so PATH
+// alone is not enough. HOMEBREW_PREFIX is for the legacy exec-path registry.
 func serviceEnv() map[string]string {
 	env := map[string]string{"PATH": servicePATH()}
 	// HOME is normally injected by launchd/systemd, but the daemon's data-dir

--- a/cmd/agent_logs.go
+++ b/cmd/agent_logs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"andriiklymiuk/corgi/utils"
@@ -32,7 +31,7 @@ func runAgentLogs(cmd *cobra.Command, args []string) {
 				fmt.Printf("  %-20s %s\n", c.Workspace.ID, c.Workspace.AbsPath)
 			}
 		}
-		os.Exit(2)
+		exitProcess(2)
 	}
 
 	dir, err := agentDir()

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -21,8 +21,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ---------------------------------------------------------------- init
-
 var agentInitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Opt this stack into agent mode",
@@ -161,13 +159,10 @@ func composeFileName(dir string) string {
 	return "corgi-compose.yml"
 }
 
-// claudeTrustsDir reports whether Claude's own config records an accepted
-// workspace-trust dialog for dir under the given account. remote-control
-// refuses an untrusted directory, and only a human running `claude` there can
-// accept the dialog — so init/up warn up front instead of letting the phone
-// discover a card that can never start. Best-effort: an unparseable config
-// reports trusted, so a format change never produces false warnings; a missing
-// file means Claude never ran under that account, which IS untrusted.
+// claudeTrustsDir reports whether Claude's config records an accepted
+// workspace-trust dialog for dir. remote-control refuses an untrusted directory
+// and only a human at `claude` can accept, so init/up warn up front. An
+// unparseable config reports trusted; a missing one means Claude never ran.
 func claudeTrustsDir(configDir, dir string) bool {
 	base := expandTilde(configDir)
 	if base == "" {
@@ -272,8 +267,6 @@ func enableWorkspace(id, configDir string, skipPerms bool) error {
 	return writeUserConfig(path, user)
 }
 
-// ---------------------------------------------------------------- scan
-
 var agentScanCmd = &cobra.Command{
 	Use:   "scan <dir>",
 	Short: "Find corgi stacks under a directory and register them",
@@ -369,8 +362,6 @@ func findComposeDirs(root string) []string {
 	return out
 }
 
-// ---------------------------------------------------------------- doctor
-
 var agentDoctorCmd = &cobra.Command{
 	Use:   "doctor",
 	Short: "Check whether agent mode can actually work here",
@@ -397,7 +388,7 @@ func runAgentDoctor(_ *cobra.Command, _ []string) {
 	if utils.JSONOutput {
 		utils.PrintJSON(checks)
 		if anyCheckFailed(checks) {
-			os.Exit(1)
+			exitProcess(1)
 		}
 		return
 	}
@@ -413,7 +404,7 @@ func runAgentDoctor(_ *cobra.Command, _ []string) {
 		}
 	}
 	if anyCheckFailed(checks) {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -438,12 +438,9 @@ func upLockIsStale(path string) bool {
 }
 
 // corgiListenerPIDs returns the pids of corgi processes listening on addr's
-// port. This is the recovery path for an MCP left over by an older `agent up`
-// (started before mcp.pid existed, or whose pid file was lost): without it the
-// port stays held, every `up` refuses, and pairing can never reopen. Only pids
-// whose command name contains "corgi" are returned — an unidentified listener
-// is never touched. Unix-only (lsof); on Windows or without lsof it returns
-// nothing and callers fall back to the manual hint.
+// port — the recovery path for an MCP whose pid file was lost, which would
+// otherwise hold the port against every `up`. Only pids whose command name
+// contains "corgi". Unix-only (lsof); elsewhere callers fall back to a hint.
 func corgiListenerPIDs(addr string) []int {
 	if runtime.GOOS == "windows" {
 		return nil
@@ -723,8 +720,6 @@ func orDefault(s, def string) string {
 	return s
 }
 
-// ---------------------------------------------------------------- down
-
 var agentDownCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Stop everything `corgi agent up` started — the daemon and the detached MCP + tunnel",
@@ -751,14 +746,10 @@ func runAgentDown(_ *cobra.Command, _ []string) {
 		}
 	}
 
-	// The detached MCP + tunnel that `agent up` recorded. Stopping it is what
-	// takes the public URL down; `agent stop` alone leaves it serving.
-	//
-	// PidAlive guards against a recycled pid: mcp.pid can outlive its process (an
-	// MCP crash, a reboot, an `agent stop` all leave it on disk), and the OS may
-	// hand that number to an unrelated process. PidAlive confirms the pid is still
-	// its own process-group leader — which the detached MCP is and a recycled pid
-	// almost never is — so a stale file cannot make `down` kill your editor.
+	// The detached MCP + tunnel `agent up` recorded; stopping it is what takes
+	// the public URL down. mcp.pid outlives its process on a crash or reboot, so
+	// PidAlive checks the pid is still its own group leader — a stale file must
+	// not make `down` kill an unrelated process.
 	pidPath := filepath.Join(dir, mcpPidName)
 	mcpStopped := false
 	if pid, ok := readAgentPidFile(pidPath); ok {
@@ -797,8 +788,6 @@ func runAgentDown(_ *cobra.Command, _ []string) {
 		utils.Info("corgi agent is not running")
 	}
 }
-
-// ---------------------------------------------------------------- restart
 
 var agentRestartCmd = &cobra.Command{
 	Use:   "restart",

--- a/cmd/autopilot.go
+++ b/cmd/autopilot.go
@@ -27,7 +27,7 @@ func failAutopilot(humanMsg string, err error) {
 	} else {
 		utils.Infof("%s: %s\n", humanMsg, err)
 	}
-	os.Exit(1)
+	exitProcess(1)
 }
 
 // autopilotStateDir resolves the compose dir the same way sibling commands do
@@ -68,7 +68,7 @@ var autopilotStatusCmd = &cobra.Command{
 			} else {
 				utils.Infof("couldn't read autopilot state: %s\n", err)
 			}
-			os.Exit(1)
+			exitProcess(1)
 		}
 		if utils.JSONOutput {
 			utils.PrintJSON(st)
@@ -109,7 +109,7 @@ func newAutopilotModeCmd(use, short string, mode utils.AutopilotMode) *cobra.Com
 				} else {
 					utils.Infof("couldn't write autopilot state: %s\n", err)
 				}
-				os.Exit(1)
+				exitProcess(1)
 			}
 			if utils.JSONOutput {
 				utils.PrintJSON(st)
@@ -153,7 +153,7 @@ var autopilotHeartbeatCmd = &cobra.Command{
 			} else {
 				utils.Infof("couldn't record heartbeat: %s\n", err)
 			}
-			os.Exit(1)
+			exitProcess(1)
 		}
 		if utils.JSONOutput {
 			utils.PrintJSON(st)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -83,7 +83,7 @@ func runBuild(cmd *cobra.Command, _ []string) {
 		utils.PrintJSON(results)
 	}
 	if failed > 0 {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,7 +4,6 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/art"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ var configPathCmd = &cobra.Command{
 			} else {
 				fmt.Println(err)
 			}
-			os.Exit(1)
+			exitProcess(1)
 		}
 		path := filepath.Join(dir, "config.yml")
 		if utils.JSONOutput {
@@ -63,7 +62,7 @@ func runConfigShow(cmd *cobra.Command, _ []string) {
 		} else {
 			fmt.Printf("%s❌ Failed to read user config: %v%s\n", art.RedColor, err, art.WhiteColor)
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 	dir, _ := utils.GetUserConfigDir()
 	path := filepath.Join(dir, "config.yml")

--- a/cmd/coverage_extra_test.go
+++ b/cmd/coverage_extra_test.go
@@ -35,8 +35,6 @@ func runRoot(t *testing.T, args ...string) {
 	}
 }
 
-// --- autopilot.go: pure renderers + the cobra command paths ---
-
 func TestPrintAutopilotStatus(t *testing.T) {
 	// No heartbeat yet.
 	out := captureStdout(t, func() {
@@ -102,8 +100,6 @@ func TestAutopilotCommandsViaCobra(t *testing.T) {
 		t.Fatalf("expected an autopilot state file: %v", err)
 	}
 }
-
-// --- memory.go: human + json branches (no os.Exit paths) ---
 
 func TestMemoryListHumanAndTypeFilter(t *testing.T) {
 	dir := t.TempDir()
@@ -174,8 +170,6 @@ func TestMemoryLintWarnsOnDanglingLink(t *testing.T) {
 	}
 }
 
-// --- suggest_history.go: human output, config, --workspace, cooldown default ---
-
 func TestSuggestHistoryHumanFlows(t *testing.T) {
 	withTempHome(t)
 	dir := t.TempDir()
@@ -231,8 +225,6 @@ func TestSuggestHistoryWorkspaceFlag(t *testing.T) {
 		t.Fatalf("--workspace state file not written under %s: %v", ws, err)
 	}
 }
-
-// --- missioncontrol.go: label parsing, the agent-work prober, command path ---
 
 func TestLabelToNameKind(t *testing.T) {
 	cases := []struct {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -217,7 +217,7 @@ func runCreate(cmd *cobra.Command, _ []string) {
 			} else {
 				fmt.Fprintln(os.Stderr, err)
 			}
-			os.Exit(2)
+			exitProcess(2)
 		}
 		createNonInteractive(cmd, createOpts)
 		return

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -34,13 +34,13 @@ func runUpAll(cmd *cobra.Command, dbs []utils.DatabaseService) {
 			} else {
 				fmt.Fprintln(os.Stderr, "❌", err)
 			}
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 
 	if once, _ := cmd.Root().Flags().GetBool("runOnce"); once {
 		utils.PrintFinalMessage()
-		os.Exit(0)
+		exitProcess(0)
 	}
 }
 
@@ -513,14 +513,14 @@ func runDbShellQuery(dbService utils.DatabaseService, query string) {
 		out, qerr := utils.ExecDBQueryCapture(dbService, query)
 		if qerr != nil {
 			utils.JSONError(utils.ErrExecFailed, qerr.Error())
-			os.Exit(1)
+			exitProcess(1)
 		}
 		utils.PrintJSON(dbQueryResult{Service: dbService.ServiceName, Output: out})
 		return
 	}
 	if err := utils.ExecDBQuery(dbService, query); err != nil {
 		fmt.Printf("%s❌ Query failed: %v%s\n", art.RedColor, err, art.WhiteColor)
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/db_snapshot.go
+++ b/cmd/db_snapshot.go
@@ -76,7 +76,7 @@ func runDbSnapshot(cmd *cobra.Command, args []string) {
 	corgi, err := utils.GetCorgiServices(cmd)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	// --list / --rm manage existing snapshots; then the lone positional is the
@@ -92,7 +92,7 @@ func resolvePostgresServiceOrExit(serviceArg string, dbs []utils.DatabaseService
 	svc, err := resolvePostgresService(serviceArg, dbs)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	return svc
 }
@@ -127,12 +127,12 @@ func createSnapshot(args []string, dbs []utils.DatabaseService) {
 	name, err := utils.SanitizeSnapshotName(name)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if utils.IsStackSupervised(utils.CorgiComposePathDir) {
 		utils.Info("a detached `corgi run` is managing this stack — run `corgi stop` first")
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	container := utils.ContainerName(svc.Driver, svc.ServiceName)
@@ -145,7 +145,7 @@ func createSnapshot(args []string, dbs []utils.DatabaseService) {
 	}, time.Now())
 	if err != nil {
 		utils.Info("snapshot failed:", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	utils.Infof("📦 snapshot %q saved (%s, pg%s/%s, %d bytes)\n",
 		name, meta.Image, meta.PgVersionMajor, meta.Arch, meta.SizeBytes)
@@ -155,7 +155,7 @@ func runDbRestore(cmd *cobra.Command, args []string) {
 	corgi, err := utils.GetCorgiServices(cmd)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	nameOrPath, serviceArg := "", ""
@@ -167,24 +167,24 @@ func runDbRestore(cmd *cobra.Command, args []string) {
 	}
 	if nameOrPath == "" {
 		utils.Info("usage: corgi db restore [name|path] [service]")
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	svc, err := resolvePostgresService(serviceArg, corgi.DatabaseServices)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if utils.IsStackSupervised(utils.CorgiComposePathDir) {
 		utils.Info("a detached `corgi run` is managing this stack — run `corgi stop` first")
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	archive, metaPath, fromPath, err := resolveRestoreSource(svc.ServiceName, nameOrPath)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if !restoreYes {
@@ -204,7 +204,7 @@ func runDbRestore(cmd *cobra.Command, args []string) {
 		FromPath: fromPath, Force: restoreForce,
 	}); err != nil {
 		utils.Info("restore failed:", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	utils.Infof("✅ restored %q from %s\n", svc.ServiceName, filepath.Base(archive))
 }
@@ -213,7 +213,7 @@ func listSnapshots(service string) {
 	items, err := utils.ListSnapshots(service)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	if utils.JSONOutput {
 		utils.PrintJSON(items)
@@ -255,7 +255,7 @@ func removeSnapshot(service, name string) {
 	archive, metaPath, err := snapshotRemovePaths(service, name)
 	if err != nil {
 		utils.Info(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	_ = os.Remove(archive)
 	_ = os.Remove(metaPath)

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -407,16 +407,16 @@ func generateCobraDocs(cmd *cobra.Command) {
 	)
 	if err != nil {
 		fmt.Println("Cobra docs are not regenerated: ", err)
-		os.Exit(0)
+		exitProcess(0)
 	}
 
 	if err := makeCommandDocsMDXSafe(commandsDocsDir); err != nil {
 		fmt.Println("Cobra docs generated, but MDX escaping failed: ", err)
-		os.Exit(0)
+		exitProcess(0)
 	}
 
 	fmt.Println("Cobra docs are generated, exiting ..")
-	os.Exit(0)
+	exitProcess(0)
 }
 
 const commandsDocsDir = "./resources/readme/commands"

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,7 +4,6 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/art"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -200,7 +199,7 @@ func runDoctor(cmd *cobra.Command, _ []string) {
 		} else {
 			fmt.Printf("couldn't get services config, error: %s\n", err)
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if fix, _ := cmd.Flags().GetBool("fix"); fix {
@@ -225,7 +224,7 @@ func runDoctor(cmd *cobra.Command, _ []string) {
 	}
 
 	fmt.Println(art.RedColor, "❌ Doctor: one or more checks failed", art.WhiteColor)
-	os.Exit(1)
+	exitProcess(1)
 }
 
 func runDoctorFix(cmd *cobra.Command, corgi *utils.CorgiCompose) {
@@ -254,7 +253,7 @@ func runDoctorFix(cmd *cobra.Command, corgi *utils.CorgiCompose) {
 		}
 	}
 	if !out.OK {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 
@@ -262,7 +261,7 @@ func runDoctorJSON(corgi *utils.CorgiCompose) {
 	res := buildDoctorResult(corgi)
 	utils.PrintJSON(res)
 	if !res.OK {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -73,7 +73,7 @@ func emitExecError(code, msg string, exitCode int) {
 	} else {
 		fmt.Fprintln(os.Stderr, msg)
 	}
-	os.Exit(exitCode)
+	exitProcess(exitCode)
 }
 
 func runExec(cmd *cobra.Command, args []string) {
@@ -94,7 +94,7 @@ func runExec(cmd *cobra.Command, args []string) {
 	}
 
 	if !utils.AbortOnValidationErrors(corgi) {
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if err := utils.MaterializeServiceWorktrees(cmd, corgi); err != nil {
@@ -120,7 +120,7 @@ func runExec(cmd *cobra.Command, args []string) {
 		emitExecError(utils.ErrExecFailed, err.Error(), 1)
 	}
 	// Propagate the child's exit code (failure cases already emitted their message).
-	os.Exit(code)
+	exitProcess(code)
 }
 
 // readyTimeoutFlag reads --ready-timeout, falling back to the default.

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"andriiklymiuk/corgi/utils"
 )
 
@@ -32,4 +34,18 @@ func exitWithErrorPrefix(jsonCode, stderrPrefix string, err error, exitCode int)
 func exitProcess(code int) {
 	utils.CloseSessionLog()
 	osExit(code)
+}
+
+// mustLoadCorgiServices loads the compose file or exits 1 reporting why.
+func mustLoadCorgiServices(cmd *cobra.Command) *utils.CorgiCompose {
+	corgi, err := utils.GetCorgiServices(cmd)
+	if err != nil {
+		if utils.JSONOutput {
+			utils.JSONError(utils.ErrConfig, err.Error())
+		} else {
+			utils.Infof("couldn't get services config: %s\n", err)
+		}
+		exitProcess(1)
+	}
+	return corgi
 }

--- a/cmd/exit_paths_test.go
+++ b/cmd/exit_paths_test.go
@@ -1,0 +1,540 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+
+	"github.com/spf13/cobra"
+)
+
+type exitPanic struct{ code int }
+
+// expectExit reports the code fn exits with. The osExit stub panics so fn stops
+// where a real exit would; without that it would run on past the exit with the
+// zero values it was about to abandon.
+func expectExit(t *testing.T, fn func()) int {
+	t.Helper()
+	orig := osExit
+	osExit = func(c int) { panic(exitPanic{c}) }
+	t.Cleanup(func() { osExit = orig })
+
+	code := -1
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				return
+			}
+			ep, ok := r.(exitPanic)
+			if !ok {
+				panic(r)
+			}
+			code = ep.code
+		}()
+		fn()
+	}()
+	return code
+}
+
+func jsonMode(t *testing.T, on bool) {
+	t.Helper()
+	prev := utils.JSONOutput
+	utils.JSONOutput = on
+	t.Cleanup(func() { utils.JSONOutput = prev })
+}
+
+func TestFailHelpersExit(t *testing.T) {
+	err := errors.New("boom")
+	cases := []struct {
+		name string
+		want int
+		fn   func()
+	}{
+		{"failMemory", 1, func() { failMemory(err) }},
+		{"failAutopilot", 1, func() { failAutopilot("autopilot", err) }},
+		{"failSuggestHistory", 1, func() { failSuggestHistory(err) }},
+		{"failUsage", 2, func() { failUsage("bad usage") }},
+		{"failE2E", 1, func() { failE2E("suite failed") }},
+		{"emitExecError", 3, func() { emitExecError(utils.ErrUsage, "nope", 3) }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := expectExit(t, c.fn); got != c.want {
+				t.Errorf("exit code = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// The same helpers must exit with the same code on the JSON path, which is a
+// separate branch that writes a JSONError instead of a stderr line.
+func TestFailHelpersExitInJSONMode(t *testing.T) {
+	jsonMode(t, true)
+	err := errors.New("boom")
+	cases := []struct {
+		name string
+		want int
+		fn   func()
+	}{
+		{"failMemory", 1, func() { failMemory(err) }},
+		{"failAutopilot", 1, func() { failAutopilot("autopilot", err) }},
+		{"failSuggestHistory", 1, func() { failSuggestHistory(err) }},
+		{"failUsage", 2, func() { failUsage("bad usage") }},
+		{"failE2E", 1, func() { failE2E("suite failed") }},
+		{"emitExecError", 4, func() { emitExecError(utils.ErrUsage, "nope", 4) }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := expectExit(t, c.fn); got != c.want {
+				t.Errorf("exit code = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolvePostgresServiceOrExitOnUnknownService(t *testing.T) {
+	dbs := []utils.DatabaseService{{ServiceName: "main", Driver: "postgres"}}
+	if got := expectExit(t, func() { resolvePostgresServiceOrExit("nope", dbs) }); got != 1 {
+		t.Errorf("exit code = %d, want 1", got)
+	}
+}
+
+func TestRemoveSnapshotExitsOnUnresolvablePaths(t *testing.T) {
+	if got := expectExit(t, func() { removeSnapshot("svc", "../escape") }); got != 1 {
+		t.Errorf("exit code = %d, want 1", got)
+	}
+}
+
+// Every command that loads the compose file must exit 1 rather than run on with
+// a nil config when there is no corgi-compose.yml to load.
+func TestComposeLoadFailuresExit(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func(c *cobra.Command)
+	}{
+		{"mustLoadCorgiServices", func(c *cobra.Command) { mustLoadCorgiServices(c) }},
+		{"loadCorgiForStop", func(c *cobra.Command) { loadCorgiForStop(c) }},
+		{"runPs", func(c *cobra.Command) { runPs(c, nil) }},
+		{"runOpen", func(c *cobra.Command) { runOpen(c, nil) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := noComposeCmd(t)
+			if got := expectExit(t, func() { tc.fn(c) }); got != 1 {
+				t.Errorf("exit code = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// composeCmd points the process at a dir holding body as corgi-compose.yml and
+// returns a command carrying the flags the run functions read.
+func composeCmd(t *testing.T, body string) *cobra.Command {
+	t.Helper()
+	chdirToTempCompose(t, body)
+	return cmdWithRunFlags()
+}
+
+// cmdWithRunFlags carries the flags the run functions under test read.
+func cmdWithRunFlags() *cobra.Command {
+	c := newRootedCmd()
+	c.Flags().Bool("strict", false, "")
+	c.Flags().Bool("docker", false, "")
+	c.Flags().Bool("ensure-deps", false, "")
+	c.Flags().String("host", "", "")
+	c.Flags().StringSlice("service", nil, "")
+	return c
+}
+
+// noComposeCmd chdirs somewhere with no corgi-compose.yml at all.
+func noComposeCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = filepath.Join(dir, "absent")
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	return cmdWithRunFlags()
+}
+
+// A command with no compose file to load must exit rather than continue with a
+// nil config. These are the paths the exitProcess sweep touched.
+func TestCommandsExitWhenComposeIsMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		want int
+		fn   func(c *cobra.Command)
+	}{
+		{"runValidate", 2, func(c *cobra.Command) { runValidate(c, nil) }},
+		{"runDbSnapshot", 1, func(c *cobra.Command) { runDbSnapshot(c, nil) }},
+		{"runDbRestore", 1, func(c *cobra.Command) { runDbRestore(c, nil) }},
+		{"resolveStatusRows", 1, func(c *cobra.Command) { resolveStatusRows(c) }},
+		{"restartSingleService", 1, func(c *cobra.Command) { restartSingleService(c) }},
+		{"worktreeList", 1, func(c *cobra.Command) { worktreeListCmd.Run(c, nil) }},
+		{"worktreePrune", 1, func(c *cobra.Command) { worktreePruneCmd.Run(c, nil) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := noComposeCmd(t)
+			if got := expectExit(t, func() { tc.fn(c) }); got != tc.want {
+				t.Errorf("exit code = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// `corgi db restore` with no snapshot name is a usage error, not a crash.
+func TestRunDbRestoreWithoutNameExits(t *testing.T) {
+	c := composeCmd(t, "name: stack\ndb_services:\n  main:\n    driver: postgres\n")
+	if got := expectExit(t, func() { runDbRestore(c, nil) }); got != 1 {
+		t.Errorf("exit code = %d, want 1", got)
+	}
+}
+
+// A compose file that parses but fails validation exits 1, on both output paths.
+func TestRunValidateExitsOnValidationErrors(t *testing.T) {
+	const broken = "name: stack\nservices:\n  api:\n    service_name: api\n    port: 3000\n    depends_on_db:\n      - name: missing\n"
+	t.Run("human", func(t *testing.T) {
+		c := composeCmd(t, broken)
+		if got := expectExit(t, func() { runValidate(c, nil) }); got != 1 {
+			t.Errorf("exit code = %d, want 1", got)
+		}
+	})
+	t.Run("json", func(t *testing.T) {
+		jsonMode(t, true)
+		c := composeCmd(t, broken)
+		if got := expectExit(t, func() { runValidate(c, nil) }); got != 1 {
+			t.Errorf("exit code = %d, want 1", got)
+		}
+	})
+}
+
+func TestWriteMergedLineJSONMode(t *testing.T) {
+	jsonMode(t, true)
+	var buf bytes.Buffer
+	out := bufio.NewWriter(&buf)
+	writeMergedLine(out, "api", "2026-01-01T00:00:00.000Z", "hello")
+	out.Flush()
+	if !strings.Contains(buf.String(), `"api"`) || !strings.Contains(buf.String(), "hello") {
+		t.Errorf("json log line = %q", buf.String())
+	}
+}
+
+func TestWriteMergedLineHumanModeWithAndWithoutTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	out := bufio.NewWriter(&buf)
+	writeMergedLine(out, "api", "2026-01-01T00:00:00.000Z", "with ts")
+	writeMergedLine(out, "web", "", "no ts")
+	out.Flush()
+	got := buf.String()
+	for _, want := range []string{"api", "with ts", "web", "no ts"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output %q missing %q", got, want)
+		}
+	}
+}
+
+const brokenCompose = "name: stack\nservices:\n  api:\n    service_name: api\n    port: 3000\n    depends_on_db:\n      - name: missing\n"
+
+// A snapshot name builds a path, so one carrying a separator or ".." must exit
+// rather than resolve outside the snapshots directory.
+func TestSnapshotNameRejectionExits(t *testing.T) {
+	dbs := []utils.DatabaseService{{ServiceName: "main", Driver: "postgres"}}
+	if got := expectExit(t, func() { createSnapshot([]string{"../escape"}, dbs) }); got != 1 {
+		t.Errorf("createSnapshot exit = %d, want 1", got)
+	}
+}
+
+// `db restore <name> <service>` naming a non-postgres service must exit.
+func TestRunDbRestoreRefusesNonPostgresService(t *testing.T) {
+	c := composeCmd(t, "name: stack\ndb_services:\n  cache:\n    driver: redis\n")
+	if got := expectExit(t, func() { runDbRestore(c, []string{"snap", "cache"}) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// A --service filter matching nothing is an error, not an empty success.
+func TestResolveStatusRowsExitsWhenFilterMatchesNothing(t *testing.T) {
+	c := composeCmd(t, "name: stack\nservices:\n  api:\n    service_name: api\n    port: 3000\n    start_command: echo hi\n")
+	if err := c.Flags().Set("service", "nope"); err != nil {
+		t.Fatal(err)
+	}
+	if got := expectExit(t, func() { resolveStatusRows(c) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// mustLoadCorgiServices reports the failure as JSON when --json is set, and
+// still exits 1.
+func TestMustLoadCorgiServicesExitsInJSONMode(t *testing.T) {
+	jsonMode(t, true)
+	c := noComposeCmd(t)
+	if got := expectExit(t, func() { mustLoadCorgiServices(c) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// A compose that parses but fails validation stops exec before it runs anything.
+func TestRunExecExitsOnValidationErrors(t *testing.T) {
+	c := composeCmd(t, brokenCompose)
+	if got := expectExit(t, func() { runExec(c, []string{"api"}) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// `memory add` without the required flags is a usage error.
+func TestMemoryAddWithoutRequiredFlagsExits(t *testing.T) {
+	noComposeCmd(t)
+	// The cobra command is a package var, so a sibling test's flag values
+	// outlive it.
+	for _, name := range []string{"type", "name", "desc", "service", "pattern"} {
+		if err := memoryAddCmd.Flags().Set(name, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := expectExit(t, func() { memoryAddCmd.Run(memoryAddCmd, nil) }); got != 2 {
+		t.Errorf("exit = %d, want 2", got)
+	}
+}
+
+// `memory lint` exits 1 when the store has errors, on both output paths.
+func TestMemoryLintExitsOnStoreErrors(t *testing.T) {
+	write := func(t *testing.T) {
+		t.Helper()
+		noComposeCmd(t)
+		wd, _ := os.Getwd()
+		// Facts are read from the typed subdirs, so a loose file at the root
+		// would not be linted at all.
+		dir := filepath.Join(wd, utils.MemoryDirName, "decisions")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// No frontmatter at all — the lint's first requirement.
+		if err := os.WriteFile(filepath.Join(dir, "broken.md"), []byte("no frontmatter here\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Run("human", func(t *testing.T) {
+		write(t)
+		if got := expectExit(t, func() { memoryLintCmd.Run(memoryLintCmd, nil) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+	t.Run("json", func(t *testing.T) {
+		jsonMode(t, true)
+		write(t)
+		if got := expectExit(t, func() { memoryLintCmd.Run(memoryLintCmd, nil) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+}
+
+// A non-interactive create with no --kind/--name cannot prompt, so it exits.
+func TestRunCreateNonInteractiveWithoutFlagsExits(t *testing.T) {
+	prev := utils.NonInteractive
+	utils.NonInteractive = true
+	t.Cleanup(func() { utils.NonInteractive = prev })
+	prevOpts := createOpts
+	createOpts = createFlags{}
+	t.Cleanup(func() { createOpts = prevOpts })
+
+	c := noComposeCmd(t)
+	if got := expectExit(t, func() { runCreate(c, nil) }); got != 2 {
+		t.Errorf("exit = %d, want 2", got)
+	}
+}
+
+// A corrupt autopilot state file is an error, unlike an absent one.
+func TestAutopilotStatusExitsOnCorruptState(t *testing.T) {
+	dir := chdirToTempCompose(t, "name: stack\n")
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	path := utils.AutopilotStatePath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := expectExit(t, func() { autopilotStatusCmd.Run(newRootedCmd(), nil) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// Restarting a service that no run-state knows about must exit, not relaunch it.
+func TestRestartSingleServiceExitsWithoutRunState(t *testing.T) {
+	c := composeCmd(t, "name: stack\nservices:\n  api:\n    service_name: api\n    port: 3000\n    start_command: echo hi\n")
+	prev := restartService
+	restartService = "api"
+	t.Cleanup(func() { restartService = prev })
+
+	if got := expectExit(t, func() { restartSingleService(c) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// A closed port is a down service, and `corgi status` exits 1 for it on both
+// output paths rather than reporting success.
+func TestRunStatusOnceExitsWhenAServiceIsDown(t *testing.T) {
+	// Port 1 needs privileges to bind, so nothing local answers on it.
+	rows := []statusRow{{Label: "api", Port: 1, Kind: "service", URL: "http://localhost:1"}}
+	t.Run("human", func(t *testing.T) {
+		if got := expectExit(t, func() { runStatusOnce(rows, statusFlags{quiet: true}) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+	t.Run("json", func(t *testing.T) {
+		if got := expectExit(t, func() { runStatusOnce(rows, statusFlags{jsonOut: true, quiet: true}) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+}
+
+// `corgi logs --dump` into a workspace that never logged is an error.
+func TestRunLogsDumpExitsWithNoLogs(t *testing.T) {
+	dir := chdirToTempCompose(t, "name: stack\n")
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	prevDump := logsDumpFlag
+	logsDumpFlag = filepath.Join(dir, "out")
+	t.Cleanup(func() { logsDumpFlag = prevDump })
+
+	if got := expectExit(t, func() { runLogs(newRootedCmd(), nil) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// Autopilot state that cannot be written is an error, not a silent no-op.
+func TestAutopilotModeExitsWhenStateIsUnwritable(t *testing.T) {
+	dir := chdirToTempCompose(t, "name: stack\n")
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	// A regular file where the state directory has to go makes the write fail.
+	if err := os.WriteFile(filepath.Join(dir, "corgi_services"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modeCmd := newAutopilotModeCmd("stop", "stop", utils.AutopilotStopped)
+	if got := expectExit(t, func() { modeCmd.Run(newRootedCmd(), nil) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// With no resolvable home directory the user config cannot be located, and both
+// config commands must say so rather than print a nonsense path.
+func TestConfigCommandsExitWithoutAHome(t *testing.T) {
+	t.Run("path", func(t *testing.T) {
+		t.Setenv("HOME", "")
+		if got := expectExit(t, func() { configPathCmd.Run(newRootedCmd(), nil) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+	t.Run("show", func(t *testing.T) {
+		// A directory where config.yml belongs is a read error, which is not
+		// the same as the file simply being absent.
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		if err := os.MkdirAll(filepath.Join(home, ".corgi", "config.yml"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := expectExit(t, func() { runConfigShow(newRootedCmd(), nil) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+}
+
+// An unreadable snapshots directory is an error, unlike an absent one.
+func TestListSnapshotsExitsOnUnreadableDir(t *testing.T) {
+	dir := chdirToTempCompose(t, "name: stack\n")
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	snapDir, err := utils.SnapshotsDir("main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(snapDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A regular file where the directory belongs makes ReadDir fail.
+	if err := os.WriteFile(snapDir, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := expectExit(t, func() { listSnapshots("main") }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// A heartbeat that cannot be persisted is an error, like any other state write.
+func TestAutopilotHeartbeatExitsWhenStateIsUnwritable(t *testing.T) {
+	dir := chdirToTempCompose(t, "name: stack\n")
+	prev := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+	if err := os.WriteFile(filepath.Join(dir, "corgi_services"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := expectExit(t, func() { autopilotHeartbeatCmd.Run(newRootedCmd(), nil) }); got != 1 {
+		t.Errorf("exit = %d, want 1", got)
+	}
+}
+
+// Snapshot and restore both stop the container, so they refuse to run while a
+// detached `corgi run` is supervising the stack.
+func TestSnapshotCommandsRefuseASupervisedStack(t *testing.T) {
+	setup := func(t *testing.T) *cobra.Command {
+		t.Helper()
+		dir := chdirToTempCompose(t, "name: stack\ndb_services:\n  main:\n    driver: postgres\n")
+		prev := utils.CorgiComposePathDir
+		utils.CorgiComposePathDir = dir
+		t.Cleanup(func() { utils.CorgiComposePathDir = prev })
+
+		// A pid of 0 marks a container-managed service, which reconciliation
+		// leaves alone — so this stays "running" without probing anything.
+		st := utils.RunState{Services: []utils.RunStateEntry{
+			{Name: "api", Kind: "service", PID: 0, Status: "running"},
+		}}
+		if err := utils.WriteRunState(utils.RunStatePath(dir), st); err != nil {
+			t.Fatal(err)
+		}
+		c := newRootedCmd()
+		c.Flags().Bool("docker", false, "")
+		return c
+	}
+	dbs := []utils.DatabaseService{{ServiceName: "main", Driver: "postgres"}}
+
+	t.Run("snapshot", func(t *testing.T) {
+		setup(t)
+		if got := expectExit(t, func() { createSnapshot([]string{"snap"}, dbs) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+	t.Run("restore", func(t *testing.T) {
+		c := setup(t)
+		if got := expectExit(t, func() { runDbRestore(c, []string{"snap"}) }); got != 1 {
+			t.Errorf("exit = %d, want 1", got)
+		}
+	})
+}

--- a/cmd/exit_sessionlog_test.go
+++ b/cmd/exit_sessionlog_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+// A command that exits on an error path must still close the session log.
+// logWriter holds a trailing line that has no newline yet, and only Close
+// flushes it — so a bare os.Exit dropped whatever was written last.
+func TestExitProcessFlushesSessionLog(t *testing.T) {
+	dir := t.TempDir()
+	origPath := utils.CorgiComposePathDir
+	utils.CorgiComposePathDir = dir
+	t.Cleanup(func() {
+		utils.CorgiComposePathDir = origPath
+		utils.CloseSessionLog()
+	})
+
+	utils.StartSessionLog()
+	logDir := filepath.Join(dir, "corgi_services", ".logs", utils.SessionLogDir)
+	if _, err := os.Stat(logDir); err != nil {
+		t.Skipf("session log not started: %v", err)
+	}
+
+	utils.Infof("partial line with no newline")
+
+	code := -1
+	orig := osExit
+	osExit = func(c int) { code = c }
+	t.Cleanup(func() { osExit = orig })
+
+	exitProcess(1)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	entries, err := os.ReadDir(logDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("no session log written: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(logDir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "partial line with no newline") {
+		t.Errorf("session log lost the trailing line, got %q", body)
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -106,7 +106,7 @@ func runInit(cmd *cobra.Command, _ []string) {
 		} else {
 			fmt.Fprintln(os.Stderr, "❌", msg)
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -4,7 +4,6 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/art"
 	"bufio"
-	"container/heap"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -90,7 +89,7 @@ func runLogs(cmd *cobra.Command, _ []string) {
 	if logsDumpFlag != "" {
 		if err := dumpNewestLogs(base, logsDumpFlag); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		return
 	}
@@ -372,12 +371,9 @@ func hasTimestampShape(b []byte) bool {
 }
 
 // mergeStream is one input to the k-way merge — a service's log file read line
-// by line, with the current head buffered for heap compare.
-//
-// Deliberately a Reader rather than a Scanner: a Scanner stops for good at EOF,
-// but a log being written to reaches EOF constantly and gains more later. The
-// handle keeps its offset, and a trailing line without a newline is held back
-// until the rest of it arrives.
+// by line, head buffered for heap compare. A Reader rather than a Scanner
+// because a Scanner stops for good at EOF and a live log hits EOF constantly.
+// A trailing line without a newline is held back until the rest arrives.
 type mergeStream struct {
 	service string
 	reader  *bufio.Reader
@@ -385,7 +381,6 @@ type mergeStream struct {
 	headTS  string
 	headBuf string
 	partial string
-	eof     bool
 }
 
 // readLine returns the next complete line. An incomplete trailing line is kept
@@ -406,45 +401,6 @@ func (s *mergeStream) close() {
 		s.f.Close()
 		s.f = nil
 	}
-}
-
-func (s *mergeStream) advance() bool {
-	if s.eof {
-		return false
-	}
-	line, ok := s.readLine()
-	if !ok {
-		s.eof = true
-		s.close()
-		return false
-	}
-	if hasTimestampShape([]byte(line)) {
-		s.headTS = line[:utils.LogTimestampLen-1]
-		s.headBuf = line[utils.LogTimestampLen:]
-	} else {
-		s.headTS = ""
-		s.headBuf = line
-	}
-	return true
-}
-
-type mergeHeap []*mergeStream
-
-func (h mergeHeap) Len() int { return len(h) }
-func (h mergeHeap) Less(i, j int) bool {
-	if h[i].headTS == h[j].headTS {
-		return h[i].service < h[j].service
-	}
-	return h[i].headTS < h[j].headTS
-}
-func (h mergeHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h *mergeHeap) Push(x interface{}) { *h = append(*h, x.(*mergeStream)) }
-func (h *mergeHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[:n-1]
-	return x
 }
 
 // followAllLogs merges the newest run of every logged service into one
@@ -530,26 +486,9 @@ func drainStreams(out *bufio.Writer, streams map[string]*mergeStream) int {
 	}
 	sort.SliceStable(batch, func(i, j int) bool { return batch[i].ts < batch[j].ts })
 	for _, e := range batch {
-		writeMergedLine(out, &mergeStream{service: e.service, headTS: e.ts, headBuf: e.line})
+		writeMergedLine(out, e.service, e.ts, e.line)
 	}
 	return len(batch)
-}
-
-func buildMergeHeap(base string, services []string) *mergeHeap {
-	h := &mergeHeap{}
-	heap.Init(h)
-	for _, svc := range services {
-		s := openMergeStream(base, svc)
-		if s == nil {
-			continue
-		}
-		if s.advance() {
-			heap.Push(h, s)
-		} else {
-			s.f.Close()
-		}
-	}
-	return h
 }
 
 // advanceTail is advance for a file still being written: EOF means "nothing
@@ -585,16 +524,16 @@ func openMergeStream(base, svc string) *mergeStream {
 	return &mergeStream{service: svc, reader: bufio.NewReader(f), f: f}
 }
 
-func writeMergedLine(out *bufio.Writer, s *mergeStream) {
+func writeMergedLine(out *bufio.Writer, service, ts, line string) {
 	if utils.JSONOutput {
-		fmt.Fprintln(out, logJSONLine(s.service, s.headTS, detectLevel(s.headBuf), s.headBuf))
+		fmt.Fprintln(out, logJSONLine(service, ts, detectLevel(line), line))
 		return
 	}
-	if s.headTS != "" {
-		fmt.Fprintf(out, "%s %s[%s]%s %s\n", s.headTS, art.CyanColor, s.service, art.WhiteColor, s.headBuf)
+	if ts != "" {
+		fmt.Fprintf(out, "%s %s[%s]%s %s\n", ts, art.CyanColor, service, art.WhiteColor, line)
 		return
 	}
-	fmt.Fprintf(out, "%s[%s]%s %s\n", art.CyanColor, s.service, art.WhiteColor, s.headBuf)
+	fmt.Fprintf(out, "%s[%s]%s %s\n", art.CyanColor, service, art.WhiteColor, line)
 }
 
 // isLogFileActive returns true when the log file was modified in the last 2s.

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -95,13 +95,9 @@ func mcpExposure() tunnel.Exposure {
 }
 
 // dangerousTunnelToolsAllowed reports whether corgi_exec / corgi_db_query may
-// run.
-//
-// Always allowed over stdio or a plain (non-tunneled) HTTP endpoint. Over a
-// tunnel it depends on who can reach it: a tunnel behind an identity proxy is
-// not open to the internet, so the tools stay usable from a phone that has
-// signed in. A tunnel anyone holding the URL can reach still requires the
-// explicit opt-in, because that is arbitrary command and DB execution.
+// run. Always over stdio or a plain HTTP endpoint, and over a tunnel behind an
+// identity proxy. A tunnel anyone with the URL can reach needs the explicit
+// opt-in — this is arbitrary command and DB execution.
 func dangerousTunnelToolsAllowed(publicTunnel bool) bool {
 	if !publicTunnel {
 		return true
@@ -127,11 +123,11 @@ func runMCP(cmd *cobra.Command, _ []string) {
 	opts := mcpHTTPOptsFromFlags(cmd)
 	if opts.pair && httpAddr == "" {
 		fmt.Fprintln(os.Stderr, "corgi mcp --pair requires --http (the addr a device connects to).")
-		os.Exit(2)
+		exitProcess(2)
 	}
 	if opts.tunnel && httpAddr == "" {
 		fmt.Fprintln(os.Stderr, "corgi mcp --tunnel requires --http (the local addr to expose).")
-		os.Exit(2)
+		exitProcess(2)
 	}
 	if httpAddr != "" {
 		serveMCPHTTP(s, httpAddr, resolveMCPToken(opts), opts)
@@ -182,7 +178,7 @@ func generateMCPToken() string {
 	if _, err := rand.Read(b); err != nil {
 		// crypto/rand failure is fatal: a weak token would defeat the auth.
 		fmt.Fprintln(os.Stderr, "could not generate token:", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	return "corgi_mcp_" + base64.RawURLEncoding.EncodeToString(b)
 }
@@ -258,7 +254,7 @@ func serveMCPStdio(s *server.MCPServer) {
 	// WithWorkerPoolSize(1) is defense-in-depth; mcpHandlerMu is the real guard.
 	if err := server.ServeStdio(s, server.WithWorkerPoolSize(1)); err != nil {
 		fmt.Fprintln(os.Stderr, "mcp server error:", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 
@@ -284,7 +280,7 @@ func resolveDeviceStore(opts mcpHTTPOpts) string {
 		fmt.Fprintf(os.Stderr,
 			"corgi mcp: cannot read the paired-device store at %s.\n"+
 				"Fix its permissions (chmod 600) or remove it to start over; refusing to serve in the meantime.\n", path)
-		os.Exit(1)
+		exitProcess(1)
 	case pairing.StoreEmpty:
 		if opts.pair {
 			return path
@@ -348,12 +344,12 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 			// single-use code, fail to save, and leave a stray .tmp holding the
 			// token hash wherever corgi happened to be running.
 			fmt.Fprintln(os.Stderr, "corgi mcp --pair cannot be combined with --insecure, and needs a writable corgi data directory.")
-			os.Exit(2)
+			exitProcess(2)
 		}
 		session, _, err := pairing.NewSession()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "could not start pairing:", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		pairSession = session
 		mux.Handle("/pair", pairingHandler(session, deviceStore))
@@ -400,7 +396,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 	}
 	if err != nil && err != http.ErrServerClosed {
 		fmt.Fprintln(os.Stderr, "mcp server error:", err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 
@@ -412,12 +408,12 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 	provider, named, err := buildMCPTunnelConfig(opts.tunnelProvider, opts.tunnelHostname, opts.tunnelName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "tunnel:", err)
-		os.Exit(2)
+		exitProcess(2)
 	}
 	port, err := mcpAddrPort(addr)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "tunnel:", err)
-		os.Exit(2)
+		exitProcess(2)
 	}
 	if token == "" {
 		fmt.Fprintln(os.Stderr, "⚠️⚠️⚠️  --tunnel --insecure exposes corgi control (corgi_up ⇒ arbitrary command execution) to ANYONE with the URL. Do not use on untrusted networks.")
@@ -455,27 +451,15 @@ func startMCPTunnel(ctx context.Context, addr, token string, opts mcpHTTPOpts) <
 	return done
 }
 
-// probeTunnelExposure checks whether the published tunnel is behind an identity
-// proxy, and says so either way.
-//
-// The url must be the endpoint the tools are served on (`/mcp`), never the
-// tunnel root. Making a non-browser MCP client work behind Cloudflare Access
-// means giving `/mcp` a service-token or bypass policy while `/` keeps
-// redirecting to the login page — so probing the root would see that redirect,
-// call the whole tunnel private, and re-enable corgi_exec on a route anyone
-// with the URL can reach. The gate has to be measured where it applies.
-//
-// Runs in the background: nothing may wait on it, because the endpoint is
-// already serving by the time the URL is printed, and a gate that starts closed
-// and opens on evidence is the safe direction to be wrong in.
-// probeDelays waits out DNS propagation before asking. A quick tunnel's
-// hostname does not resolve for a few seconds after cloudflared prints it, and
-// a query made in that window is answered NXDOMAIN — which resolvers cache
-// against the negative TTL on the zone's SOA, half an hour for trycloudflare.
-// Probing immediately therefore poisons the very hostname corgi just published,
-// for the machine and every device sharing its resolver.
+// probeDelays waits out DNS propagation. A quick tunnel's hostname is NXDOMAIN
+// for a few seconds after cloudflared prints it, and resolvers cache that
+// against the zone's negative TTL — half an hour for trycloudflare.
 var probeDelays = []time.Duration{8 * time.Second, 20 * time.Second, 45 * time.Second}
 
+// probeTunnelExposure reports whether the tunnel is behind an identity proxy.
+// url must be the endpoint the tools are served on (`/mcp`), not the tunnel
+// root: `/` may still redirect to a login page and that would read as private.
+// Runs in the background — the gate starts closed and only opens on evidence.
 func probeTunnelExposure(ctx context.Context, url string, sleep func(context.Context, time.Duration) bool) {
 	if sleep == nil {
 		sleep = waitOrDone
@@ -620,8 +604,6 @@ func loadComposeForMCP(composePath string) (*utils.CorgiCompose, error) {
 	ctx.cleanup()
 	return ctx.corgi, nil
 }
-
-// --- typed handler cores (testable without a JSON-RPC pipe) ---
 
 type validateArgs struct {
 	ComposePath string `json:"composePath"`
@@ -1161,8 +1143,6 @@ func withStdoutToStderr(fn func()) {
 	fn()
 }
 
-// --- MCP tool registration (thin wrappers over the cores above) ---
-
 const profileDesc = "Only these profiles (comma-separated union, e.g. backend,worker)"
 const serviceBranchDesc = `Run service(s) on a git branch via an isolated reused worktree, without editing path: in corgi-compose.yml. Format "svc=branch[,svc2=branch2]". Non-destructive — the main checkout is untouched.`
 const serviceDirDesc = `Run service(s) from an existing directory, e.g. a git worktree. Format "svc=/path[,svc2=/path2]".`
@@ -1347,8 +1327,6 @@ func jsonHandler(core func(mcp.CallToolRequest) (any, error)) server.ToolHandler
 		return mcp.NewToolResultText(string(b)), nil
 	}
 }
-
-// --- MCP resources ---
 
 func registerMCPResources(s *server.MCPServer) {
 	s.AddResource(

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -18,17 +18,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-// These are the tools a Remote Control session calls from a phone to do what
-// Remote Control cannot: find the right stack among many, materialize a branch
-// across every repository in it, and read the whole change at once.
+// Tools a Remote Control session calls from a phone: find the right stack,
+// materialize a branch across every repository, read the whole change at once.
 //
-// Two rules hold for all of them:
-//
-//   - Nothing blocks. cmd/mcp.go serializes every handler behind one global
-//     mutex (handlers swap os.Stdout and mutate rootCmd flags), so a handler
-//     that waited on slow work would freeze the server for every client.
-//   - Anything that mutates joins the existing dangerous-tool tunnel gate, the
-//     same one that already covers corgi_exec and corgi_db_query.
+// Nothing here may block — cmd/mcp.go serializes handlers behind one global
+// mutex. Anything that mutates joins the dangerous-tool tunnel gate.
 
 const agentDangerousBlockedMsg = "corgi_worktrees_* are disabled over a public tunnel; set CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1 to allow"
 
@@ -75,19 +69,11 @@ func registerAgentMCPTools(s *server.MCPServer) {
 		return mcpWorkspaceResolve(r.GetString("query", ""))
 	}))
 
-	// corgi_session_start/_stop are NOT behind the dangerous-tunnel gate, for
-	// the same reason corgi_up/corgi_down are not: they are the point of a
-	// phone-driven endpoint. What bounds them instead:
-	//   - the endpoint is per-device-token authenticated (pairing), and a lost
-	//     device is revoked, not tolerated — treat its token as the machine key;
-	//   - starts are registry-scoped: a caller picks an existing workspace, it
-	//     cannot define what runs or where;
-	//   - a workspace marked `sensitive` refuses remote start (remoteResolver);
-	//   - the started session's conversation still needs the owner's claude.ai
-	//     account — the sessionUrl reaches paired devices, so status.json is
-	//     0600 and the URL is not otherwise logged.
-	// A stolen token can still stop the owner's sessions (a nuisance, not a
-	// breach); revocation is the answer, as with every tool the token reaches.
+	// Not behind the dangerous-tunnel gate — a phone-driven endpoint is the
+	// point. Bounded instead by per-device-token auth, registry-scoped starts
+	// (no caller-defined command), `sensitive` workspaces refusing remote start,
+	// and 0600 status.json for the sessionUrl. A stolen token can stop sessions;
+	// revocation is the answer, as for every tool the token reaches.
 	s.AddTool(mcp.NewTool("corgi_session_start",
 		mcp.WithDescription(
 			"Start a supervised Claude Code Remote Control session in a registered workspace, by name. "+
@@ -256,8 +242,6 @@ func registerAgentMCPTools(s *server.MCPServer) {
 		)
 	}))
 }
-
-// --- handlers ---
 
 func mcpAgentStatus() (any, error) {
 	dir, err := agentDir()
@@ -627,8 +611,6 @@ func workspaceIsSensitive(dir string) bool {
 	repo, err := config.LoadRepo(dir)
 	return err == nil && repo != nil && repo.Workspace.Sensitive
 }
-
-// --- shared helpers ---
 
 // agentRegistry loads the workspace registry the CLI and MCP both read, so
 // every surface agrees on what exists.

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -23,18 +23,14 @@ import (
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
-// The launcher is corgi's own phone UI: after pairing, the same browser page
-// lists the machine's workspaces and starts a session in one tap, then hands
-// back the claude.ai link. It needs no claude.ai custom connector — the page
-// holds the device token and calls these endpoints directly:
+// corgi's own phone UI: after pairing the browser page lists workspaces and
+// starts a session in one tap, no claude.ai connector needed.
 //
 //   GET  /app                 the launcher page (static; uses the stored token)
 //   GET  /launch/workspaces   list workspaces with running state + sessionUrl
 //   POST /launch/start        {workspace, profile?} → start a session
 //
-// /launch/* sit behind the same bearer/device-token auth as /mcp, and start is
-// the same capability as corgi_session_start — no new power, just a browser
-// transport. /app is static and carries no secret.
+// /launch/* sits behind the same auth as /mcp and grants no new capability.
 
 // launchWorkspace is one row in the launcher list.
 type launchWorkspace struct {

--- a/cmd/mcp_pairing.go
+++ b/cmd/mcp_pairing.go
@@ -241,8 +241,6 @@ func announcePairing(code, addr string) {
 	fmt.Fprintln(os.Stderr, "")
 }
 
-// ---------------------------------------------------------------- devices CLI
-
 var mcpDevicesCmd = &cobra.Command{
 	Use:   "devices",
 	Short: "List and revoke devices paired with corgi mcp",

--- a/cmd/mcp_pairing_test.go
+++ b/cmd/mcp_pairing_test.go
@@ -198,8 +198,6 @@ func TestPairEndpointRefusedWhenTheWindowIsClosed(t *testing.T) {
 	}
 }
 
-// --- device-token auth ---
-
 func pairedToken(t *testing.T, storeDir, device string) string {
 	t.Helper()
 	store := pairing.StorePath(storeDir)

--- a/cmd/mcp_serving_test.go
+++ b/cmd/mcp_serving_test.go
@@ -142,8 +142,6 @@ func TestServeMCPStdioEndToEnd(t *testing.T) {
 	}
 }
 
-// --- jsonHandler (marshals result, converts error to tool error) ---
-
 func TestJSONHandler_MarshalsResult(t *testing.T) {
 	h := jsonHandler(func(mcp.CallToolRequest) (any, error) {
 		return map[string]string{"hello": "world"}, nil
@@ -181,8 +179,6 @@ type errString string
 
 func (e errString) Error() string { return string(e) }
 
-// --- isAlreadyRunning ---
-
 func TestIsAlreadyRunning_NoStateFile(t *testing.T) {
 	dir := t.TempDir()
 	if isAlreadyRunning(utils.RunStatePath(dir)) {
@@ -204,8 +200,6 @@ func TestIsAlreadyRunning_StoppedState(t *testing.T) {
 	}
 }
 
-// --- printMCPClientConfig (header only when token set) ---
-
 func TestPrintMCPClientConfig(t *testing.T) {
 	var noTok bytes.Buffer
 	printMCPClientConfig(&noTok, "http://127.0.0.1:8765/mcp", "")
@@ -226,8 +220,6 @@ func TestPrintMCPClientConfig(t *testing.T) {
 		t.Errorf("token config must include the bearer header: %s", withTok.String())
 	}
 }
-
-// --- tailLogFile ---
 
 func TestTailLogFile(t *testing.T) {
 	dir := t.TempDir()
@@ -258,8 +250,6 @@ func TestTailLogFile(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
-
-// --- mcpUp already-running guard (no real spawn) ---
 
 func TestMCPUp_BlockedWhenAlreadyRunning(t *testing.T) {
 	chdirToTempCompose(t, mcpComposeFixture)

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -83,7 +83,7 @@ var memoryAddCmd = &cobra.Command{
 		pattern, _ := cmd.Flags().GetString("pattern")
 		if t == "" || name == "" || desc == "" {
 			fmt.Fprintln(os.Stderr, "memory add requires --type, --name and --desc")
-			os.Exit(2)
+			exitProcess(2)
 		}
 		path, err := utils.AddFact(memoryRoot(), utils.Fact{
 			Name: name, Description: desc, Type: t, Service: svc, Pattern: pattern,
@@ -141,7 +141,7 @@ var memoryLintCmd = &cobra.Command{
 		if utils.JSONOutput {
 			utils.PrintJSON(map[string]any{"ok": len(errs) == 0, "errors": errs, "warnings": warns})
 			if len(errs) > 0 {
-				os.Exit(1)
+				exitProcess(1)
 			}
 			return
 		}
@@ -155,7 +155,7 @@ var memoryLintCmd = &cobra.Command{
 			utils.Infof("memory ok — %d warning(s)\n", len(warns))
 			return
 		}
-		os.Exit(1)
+		exitProcess(1)
 	},
 }
 
@@ -166,7 +166,7 @@ func failMemory(err error) {
 	} else {
 		fmt.Fprintf(os.Stderr, "memory: %s\n", err)
 	}
-	os.Exit(1)
+	exitProcess(1)
 }
 
 func init() {

--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -47,7 +47,7 @@ func runNotifications(cmd *cobra.Command, args []string) {
 		fmt.Println("Test notification dispatched. Nothing shown? Check OS notification permissions for your terminal app.")
 	default:
 		fmt.Fprintf(os.Stderr, "unknown action %q — use one of: on, off, test\n", args[0])
-		os.Exit(2)
+		exitProcess(2)
 	}
 }
 
@@ -55,7 +55,7 @@ func showNotificationsStatus() {
 	cfg, err := utils.LoadUserConfig()
 	if err != nil {
 		fmt.Printf("%s❌ Failed to read user config: %v%s\n", art.RedColor, err, art.WhiteColor)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	state := "off"
 	if cfg.Notifications {
@@ -69,12 +69,12 @@ func writeNotificationsPref(enabled bool) {
 	cfg, err := utils.LoadUserConfig()
 	if err != nil {
 		fmt.Printf("%s❌ Failed to read user config: %v%s\n", art.RedColor, err, art.WhiteColor)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	cfg.Notifications = enabled
 	if err := utils.SaveUserConfig(cfg); err != nil {
 		fmt.Printf("%s❌ Failed to save user config: %v%s\n", art.RedColor, err, art.WhiteColor)
-		os.Exit(1)
+		exitProcess(1)
 	}
 	utils.ResetNotifyCache()
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 
@@ -85,15 +84,7 @@ func launchBrowser(url, browser string) error {
 }
 
 func runOpen(cmd *cobra.Command, args []string) {
-	corgi, err := utils.GetCorgiServices(cmd)
-	if err != nil {
-		if utils.JSONOutput {
-			utils.JSONError(utils.ErrConfig, err.Error())
-		} else {
-			utils.Infof("couldn't get services config: %s\n", err)
-		}
-		os.Exit(1)
-	}
+	corgi := mustLoadCorgiServices(cmd)
 
 	targets := openTargets(corgi, args)
 

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -83,13 +83,10 @@ func psRowFromEntry(e utils.RunStateEntry) psRow {
 // may still be booting. Don't demote it to "stopped" within this window of start.
 const dockerRunnerBootGrace = 15 * time.Second
 
-// probeDockerRunnerServices confirms pid==0 (container-backed / docker-runner)
-// service entries by a port probe. Reconcile can't pid-track them, so without this a
-// service whose container has died lingers as a stale "running". A not-yet-listening
-// container within dockerRunnerBootGrace of start is left as-is (still booting);
-// after that a closed port marks it "stopped". On a real status change StatusChangedAt
-// is advanced (same invariant as ReconcileRunState). db_services keep their own
-// container-state reconciliation.
+// probeDockerRunnerServices confirms pid==0 (container-backed) entries by a port
+// probe, since Reconcile cannot pid-track them and a dead container would linger
+// as "running". Within dockerRunnerBootGrace of start it is left booting; after
+// that a closed port marks it stopped and advances StatusChangedAt.
 func probeDockerRunnerServices(st utils.RunState, probe func(port int) bool, now time.Time) utils.RunState {
 	for i := range st.Services {
 		e := &st.Services[i]
@@ -136,15 +133,7 @@ func makePsRow(name, kind string, port int, probe func(port int) bool) psRow {
 }
 
 func runPs(cmd *cobra.Command, _ []string) {
-	corgi, err := utils.GetCorgiServices(cmd)
-	if err != nil {
-		if utils.JSONOutput {
-			utils.JSONError(utils.ErrConfig, err.Error())
-		} else {
-			utils.Infof("couldn't get services config: %s\n", err)
-		}
-		os.Exit(1)
-	}
+	corgi := mustLoadCorgiServices(cmd)
 
 	var rows []psRow
 	statePath := utils.RunStatePath(utils.CorgiComposePathDir)

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -116,13 +116,13 @@ func resolveRestartTarget(statePath string, corgi *utils.CorgiCompose, service s
 func restartSingleService(cmd *cobra.Command) {
 	if herr := resolveHostFlag(cmd); herr != nil {
 		emitRestartError(utils.ErrConfig, herr.Error())
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	corgi, cerr := utils.GetCorgiServices(cmd)
 	if cerr != nil {
 		emitRestartError(utils.ErrConfig, cerr.Error())
-		os.Exit(1)
+		exitProcess(1)
 	}
 	// Same re-derivation as stop: the relaunch branch keys off Runner.Name.
 	dockerFlag, _ := cmd.Flags().GetBool("docker")
@@ -138,13 +138,13 @@ func restartSingleService(cmd *cobra.Command) {
 	st, entry, svc, code, err := resolveRestartTarget(statePath, corgi, restartService)
 	if err != nil {
 		emitRestartError(code, err.Error())
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	// bakes --host override + cross-service exports into the .env
 	if eerr := utils.GenerateEnvForServices(corgi); eerr != nil {
 		emitRestartError(utils.ErrConfig, eerr.Error())
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	_ = stopProcessGroup(entry)
@@ -154,7 +154,7 @@ func restartSingleService(cmd *cobra.Command) {
 	pid, command, serr := relaunchDetachedService(*svc)
 	if serr != nil {
 		emitRestartError(utils.ErrExecFailed, serr.Error())
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	updated := updateServiceEntry(st, restartService, pid, command, svc.Port)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"andriiklymiuk/corgi/utils"
 
 	"github.com/spf13/cobra"
@@ -52,7 +50,7 @@ func Execute() string {
 	err := rootCmd.Execute()
 
 	if err != nil {
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	return rootCmd.CalledAs()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -367,7 +367,7 @@ func handleRunSignal(cmd *cobra.Command, s os.Signal) {
 	utils.KillAllStoredProcesses()
 	cleanup(corgiLatestVersion)
 	utils.PrintFinalMessage()
-	os.Exit(0)
+	exitProcess(0)
 }
 
 func installSignalHandler(cmd *cobra.Command) func() {
@@ -553,7 +553,7 @@ func runRun(cmd *cobra.Command, _ []string) {
 	// --dry-run branches before any side effect: plan only, then exit.
 	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
 		dockerFlag, _ := cmd.Flags().GetBool("docker")
-		os.Exit(emitDryRunPlan(computeDryRunPlan(corgi, dockerFlag)))
+		exitProcess(emitDryRunPlan(computeDryRunPlan(corgi, dockerFlag)))
 	}
 
 	runPortPreflightOrExit(cmd, corgi)
@@ -596,7 +596,7 @@ func runRun(cmd *cobra.Command, _ []string) {
 
 	if err := startDatabasePhase(cmd, corgi); err != nil {
 		fmt.Println(art.RedColor, "aborting corgi run:", err, art.WhiteColor)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if detach {
@@ -646,7 +646,7 @@ func loadRunCompose(cmd *cobra.Command) *utils.CorgiCompose {
 		if runReloading.Load() {
 			return nil
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	utils.StartSessionLog()
@@ -655,7 +655,7 @@ func loadRunCompose(cmd *cobra.Command) *utils.CorgiCompose {
 		if runReloading.Load() {
 			return nil
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 	return corgi
 }
@@ -755,7 +755,7 @@ func runDetached(cmd *cobra.Command, corgi *utils.CorgiCompose) {
 		} else {
 			fmt.Fprintln(os.Stderr, msg)
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	// --wait gates the return on the whole stack becoming reachable. The state
@@ -787,7 +787,7 @@ func waitDetachedReadyOrExit(cmd *cobra.Command, corgi *utils.CorgiCompose) func
 		} else {
 			fmt.Fprintln(os.Stderr, "❌", msg)
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), remaining)
 	defer cancel()
@@ -811,7 +811,7 @@ func waitDetachedReadyOrExit(cmd *cobra.Command, corgi *utils.CorgiCompose) func
 		if dump, _ := cmd.Flags().GetBool("dump-on-failure"); dump {
 			printFailureLogs()
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 	return stopFollow
 }
@@ -886,7 +886,7 @@ func exitIfDetachedStillRunning(prev utils.RunState) {
 			} else {
 				fmt.Fprintln(os.Stderr, msg)
 			}
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 }
@@ -1284,12 +1284,9 @@ func closedGate() chan struct{} {
 }
 
 // startDatabasePhase brings the databases up and writes each service's env.
-//
-// With every service on the default gate this is exactly the old sequence:
-// databases, then env. When a service opted out, the phase moves to the
-// background so that service can start against the databases still coming up.
-// Env is written first either way — corgi derives it from corgi-compose.yml and
-// each driver's config, never from a running container.
+// On the default gate that is the old sequence: databases, then env. A service
+// that opted out moves the phase to the background so it can start against
+// databases still coming up. Env is derived from the compose file either way.
 func startDatabasePhase(cmd *cobra.Command, corgi *utils.CorgiCompose) error {
 	if !utils.AnyServiceStartsWithDatabases(corgi) {
 		runDatabaseServices(cmd, corgi.DatabaseServices)

--- a/cmd/run_lifecycle_test.go
+++ b/cmd/run_lifecycle_test.go
@@ -10,8 +10,6 @@ import (
 	"andriiklymiuk/corgi/utils"
 )
 
-// --- spawnDetachedServices (seam-injected, no real processes) ---
-
 func TestSpawnDetachedServices_StartsServiceViaSeam(t *testing.T) {
 	os, ds := startDetachedFn, dockerRunnerUp
 	t.Cleanup(func() { startDetachedFn, dockerRunnerUp = os, ds })
@@ -87,8 +85,6 @@ func TestSpawnDetachedServices_StartErrorIsSkipped(t *testing.T) {
 	}
 }
 
-// --- runDetachedBeforeStart / runServiceAfterStop (omit-flag behavior) ---
-
 func TestRunDetachedBeforeStart_NilBeforeStartIsNoop(t *testing.T) {
 	// No BeforeStart → returns without touching the filesystem or shelling out.
 	runDetachedBeforeStart(utils.Service{ServiceName: "api"})
@@ -101,8 +97,6 @@ func TestRunServiceAfterStop_MissingServiceIsNoop(t *testing.T) {
 	// Known service with no AfterStart → also a no-op.
 	runServiceAfterStop(corgi, "api")
 }
-
-// --- settleDetached (status classification) ---
 
 func TestSettleDetached_EmptyIsNoop(t *testing.T) {
 	settleDetached(nil) // must not sleep or panic on empty input
@@ -117,14 +111,10 @@ func TestSettleDetached_SkipsPidZero(t *testing.T) {
 	}
 }
 
-// --- killDetached (only kills real process groups) ---
-
 func TestKillDetached_SkipsPgidZero(t *testing.T) {
 	// pgid<=0 must be skipped; with no positive pgids this is a safe no-op.
 	killDetached([]detachedProc{{name: "dbx", pgid: 0}})
 }
-
-// --- markStarted / markReady (idempotent channel close) ---
 
 func TestReadySignal_MarkIsIdempotent(t *testing.T) {
 	s := &readySignal{started: make(chan struct{}), ready: make(chan struct{})}
@@ -144,8 +134,6 @@ func TestReadySignal_MarkIsIdempotent(t *testing.T) {
 	}
 }
 
-// --- emitDepReady / emitDepTimeout (JSON vs human output) ---
-
 func TestEmitDepReady_HumanAndJSON(t *testing.T) {
 	orig := utils.JSONOutput
 	t.Cleanup(func() { utils.JSONOutput = orig })
@@ -159,8 +147,6 @@ func TestEmitDepReady_HumanAndJSON(t *testing.T) {
 	emitDepTimeout("api", "pg")
 }
 
-// --- runPreflight / runBeforeStart (no-side-effect branches) ---
-
 func TestRunPreflight_NoDockerNoVPNIsNoop(t *testing.T) {
 	c := newRootedCmd()
 	// Neither UseAwsVpn nor docker runners → neither init path is taken.
@@ -170,8 +156,6 @@ func TestRunPreflight_NoDockerNoVPNIsNoop(t *testing.T) {
 func TestRunBeforeStart_EmptyIsNoop(t *testing.T) {
 	runBeforeStart(&utils.CorgiCompose{}) // empty BeforeStart → no commands run
 }
-
-// --- runDetached: already-running guard returns without writing state ---
 
 func TestRunDetached_BlockedWhenAlreadyRunning(t *testing.T) {
 	dir := chdirToTempCompose(t, "name: x\n")

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -7,7 +7,6 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/art"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -137,7 +136,7 @@ func runScript(cmd *cobra.Command, _ []string) {
 		}
 		if failed > 0 {
 			utils.Infof("✗ %d of %d failed\n", failed, len(results))
-			os.Exit(1)
+			exitProcess(1)
 		}
 		utils.Infof("✓ all %d passed\n", len(results))
 	}

--- a/cmd/snapshot_e2e_test.go
+++ b/cmd/snapshot_e2e_test.go
@@ -54,14 +54,10 @@ func composeDownVolumes(t *testing.T, dir string) {
 	}
 }
 
-// waitReady blocks until Postgres in the container is the FINAL server and
-// stably accepting connections. A single successful query is not enough on first
-// boot: the official entrypoint runs a temporary server (to set the password /
-// run init), logs "ready to accept connections", then shuts it down and restarts
-// the real server. A query can slip into that transient window and the next one
-// then hits "shutting down". So we require a sustained streak of successes —
-// long enough to outlast that init/restart blip — which also holds for the plain
-// `start` (post-snapshot) and restore boots, where no init phase runs at all.
+// waitReady blocks until Postgres is the FINAL server and stably accepting
+// connections. One successful query is not enough on first boot: the entrypoint
+// runs a temporary server, says "ready", then restarts the real one — so a
+// sustained streak of successes is required to outlast that blip.
 func waitReady(t *testing.T, container, user, db string) {
 	t.Helper()
 	deadline := time.Now().Add(180 * time.Second)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -100,7 +100,7 @@ func resolveStatusRows(cmd *cobra.Command) []statusRow {
 		} else {
 			fmt.Fprintf(os.Stderr, "couldn't get services config: %s\n", err)
 		}
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	rows := collectStatusRows(corgi)
@@ -116,7 +116,7 @@ func resolveStatusRows(cmd *cobra.Command) []statusRow {
 		rows = filterRows(rows, serviceFilter)
 		if len(rows) == 0 {
 			emitNoMatch(serviceFilter)
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 	return rows
@@ -139,7 +139,7 @@ func runStatusOnce(rows []statusRow, f statusFlags) {
 	if f.jsonOut {
 		emitJSON(up, down)
 		if anyDown(up, down) {
-			os.Exit(1)
+			exitProcess(1)
 		}
 		return
 	}
@@ -156,7 +156,7 @@ func runStatusOnce(rows []statusRow, f statusFlags) {
 		fmt.Printf("%s%d down, %d up%s — check `corgi run` logs for the failing services.\n",
 			art.RedColor, len(down), len(up), art.WhiteColor)
 	}
-	os.Exit(1)
+	exitProcess(1)
 }
 
 func runStatus(cmd *cobra.Command, _ []string) {
@@ -273,7 +273,7 @@ func runStatusWatchTTY(rows []statusRow, interval time.Duration) {
 	go func() {
 		<-sigCh
 		restore()
-		os.Exit(0)
+		exitProcess(0)
 	}()
 
 	results := probeAllParallel(rows)
@@ -426,7 +426,7 @@ func runStatusUntilHealthy(rows []statusRow, interval, timeout time.Duration, js
 		}
 		if time.Now().After(deadline) {
 			finalize(rows, jsonOut, quiet, false)
-			os.Exit(1)
+			exitProcess(1)
 		}
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -101,20 +101,12 @@ func runStop(cmd *cobra.Command, _ []string) {
 
 	emitStopSummary(summary)
 	if len(summary.Failed) > 0 {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 
 func loadCorgiForStop(cmd *cobra.Command) *utils.CorgiCompose {
-	corgi, err := utils.GetCorgiServices(cmd)
-	if err != nil {
-		if utils.JSONOutput {
-			utils.JSONError(utils.ErrConfig, err.Error())
-		} else {
-			utils.Infof("couldn't get services config: %s\n", err)
-		}
-		os.Exit(1)
-	}
+	corgi := mustLoadCorgiServices(cmd)
 	// Re-derive docker mode: run resolved it in another process, and cleanup's
 	// container teardown keys off Runner.Name. Detection errors don't block stop.
 	if resolved, rerr := utils.ResolveRunnerModes(corgi.Services, false, false); rerr == nil {

--- a/cmd/suggest_history.go
+++ b/cmd/suggest_history.go
@@ -34,7 +34,7 @@ func failSuggestHistory(err error) {
 	} else {
 		fmt.Fprintf(os.Stderr, "suggest-history: %s\n", err)
 	}
-	os.Exit(1)
+	exitProcess(1)
 }
 
 // failUsage reports a bad-usage error (JSON via JSONError, else stderr) and exits 2.
@@ -44,7 +44,7 @@ func failUsage(msg string) {
 	} else {
 		fmt.Fprintln(os.Stderr, msg)
 	}
-	os.Exit(2)
+	exitProcess(2)
 }
 
 var suggestHistoryCmd = &cobra.Command{

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -108,7 +108,7 @@ func runTestCmd(cmd *cobra.Command, args []string) {
 	reportTestResults(results, allPassed)
 
 	if !allPassed {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/test_e2e.go
+++ b/cmd/test_e2e.go
@@ -60,7 +60,7 @@ func failE2E(msg string) {
 	} else {
 		fmt.Fprintln(os.Stderr, "❌", msg)
 	}
-	os.Exit(1)
+	exitProcess(1)
 }
 
 // collectE2EArtifacts copies the paths declared in the suite's `artifacts:` into

--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -223,7 +223,7 @@ func runTunnelCmd(cmd *cobra.Command, args []string) {
 		names := tunnel.Names()
 		sort.Strings(names)
 		fmt.Printf("Unknown provider %q. Available: %s\n", tunnelProvider, strings.Join(names, ", "))
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	flagProvider, flagSet := provider, cmd.Flags().Changed("provider")
@@ -235,19 +235,19 @@ func runTunnelCmd(cmd *cobra.Command, args []string) {
 		built, err := buildTargetsFromCompose(cmd, args, flagProvider, flagSet)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		targets = built
 	}
 
 	if len(targets) == 0 {
 		fmt.Println("No services with port: matched. Nothing to tunnel.")
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	if err := preflightTargets(targets, provider); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		exitProcess(1)
 	}
 
 	printTunnelSummary(targets, provider)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -55,7 +55,7 @@ func runValidate(cmd *cobra.Command, _ []string) {
 		} else {
 			fmt.Fprintf(os.Stderr, "couldn't load corgi-compose.yml: %s\n", err)
 		}
-		os.Exit(2)
+		exitProcess(2)
 	}
 
 	errs, warns := utils.ValidateCompose(corgi)
@@ -71,14 +71,14 @@ func runValidate(cmd *cobra.Command, _ []string) {
 	if jsonOut {
 		utils.PrintJSON(validateReport{Ok: !failed, Errors: errs, Warnings: warns})
 		if failed {
-			os.Exit(1)
+			exitProcess(1)
 		}
 		return
 	}
 
 	printValidateHuman(errs, warns, strict)
 	if failed {
-		os.Exit(1)
+		exitProcess(1)
 	}
 }
 

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -22,7 +22,7 @@ var worktreeListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		if _, err := utils.GetCorgiServices(cmd); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		base := filepath.Join(utils.CorgiComposePathDir, "corgi_services", ".worktrees")
 		entries, err := os.ReadDir(base)
@@ -45,12 +45,12 @@ var worktreePruneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		if _, err := utils.GetCorgiServices(cmd); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		skipped, err := utils.CleanCorgiWorktrees(worktreePruneForce)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "couldn't prune worktrees:", err)
-			os.Exit(1)
+			exitProcess(1)
 		}
 		fmt.Println("🗑️ pruned corgi worktrees")
 		if len(skipped) > 0 {

--- a/utils/agent/brief/brief.go
+++ b/utils/agent/brief/brief.go
@@ -1,18 +1,13 @@
 // Package brief records what a supervised session was working on, so the one
 // that replaces it can be told.
 //
-// The supervisor restarts a session after a network timeout, a crash, or a
-// reboot. What comes back is a NEW session: the conversation, and everything it
-// had worked out, is gone. corgi cannot restore that — but it does know the
-// part that survives on disk, which is the part worth having. Which branch was
-// checked out in each repository, which of them hold uncommitted work, and
-// which worktrees a cross-repo branch left behind.
-//
-// That is the difference between "your session restarted" and "your session
-// restarted, and here is where it was".
+// A restart gives a NEW session with none of the conversation. corgi cannot
+// restore that, but it does know what survives on disk: the branch in each
+// repository, which hold uncommitted work, and any leftover worktrees.
 package brief
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -160,11 +155,7 @@ func Write(agentDir string, b Brief) error {
 	}
 	// Write-then-rename, so a daemon killed mid-write cannot leave a truncated
 	// brief that fails to parse for the session that needed it.
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o600)
 }
 
 // Read returns a workspace's brief, or nil when there is none — which is the
@@ -221,21 +212,11 @@ func Clear(agentDir, workspaceID string) error {
 	return err
 }
 
-// sanitize turns a workspace id into a filename that is safe, collision-free,
-// and case-insensitive.
-//
-// Three things it has to get right, each of which serves the wrong workspace's
-// branches to someone if it does not:
-//
-//   - It must not escape the briefs directory. Ids come from a registry corgi
-//     writes, but this builds a filename from a name, and that pattern is worth
-//     closing wherever it appears.
-//   - Distinct ids must not collapse together. Replacing unsafe runes alone
-//     maps "acme/stack" and "acme-stack" onto one file, so a short hash of the
-//     original is appended whenever the mapping actually changed anything.
-//   - It must match the registry's own comparison, which is case-insensitive
-//     (workspace.Registry.Forget uses EqualFold). Without lowercasing here,
-//     `workspaces forget ACME` drops the row and leaves briefs/acme.json behind.
+// sanitize turns a workspace id into a filename. Getting any of this wrong
+// serves the wrong workspace's branches to someone: it must not escape the
+// briefs directory, distinct ids must not collide (hence the hash suffix when
+// the mapping changed anything), and it lowercases to match the registry's own
+// case-insensitive comparison, or `workspaces forget ACME` orphans the file.
 func sanitize(id string) string {
 	lower := strings.ToLower(id)
 	replaced := strings.Map(func(r rune) rune {

--- a/utils/agent/command/command.go
+++ b/utils/agent/command/command.go
@@ -5,6 +5,7 @@
 package command
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -77,11 +78,7 @@ func Write(agentDir string, c Command) (Command, error) {
 		return c, err
 	}
 	path := filepath.Join(dir, c.ID+".json")
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return c, err
-	}
-	return c, os.Rename(tmp, path)
+	return c, atomicfile.Write(path, data, 0o600)
 }
 
 // Drain reads and removes every pending command, oldest first. Corrupt and

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -1,17 +1,9 @@
 // Package config resolves agent-mode settings from two files with different
-// trust levels.
+// trust levels: `.corgi/agent.yml` is committed and written by whoever wrote
+// the repo, so it is UNTRUSTED; the user-level file in the corgi data directory
+// is written by the machine's owner and is TRUSTED.
 //
-// `.corgi/agent.yml` lives in the repository and is committed, so it travels
-// with a clone and is written by whoever wrote the repo — which may not be the
-// person running the daemon. It is therefore UNTRUSTED.
-//
-// The user-level file lives in the corgi data directory, is never committed,
-// and is written by the machine's owner. It is TRUSTED.
-//
-// The rule that keeps this safe: **untrusted config may restrict, never
-// relax.** A cloned repository can mark itself sensitive, which only ever
-// removes capability. It cannot choose which binary runs, which credentials
-// are used, or which permission mode applies.
+// The rule that keeps this safe: untrusted config may restrict, never relax.
 package config
 
 import (
@@ -84,13 +76,10 @@ type WorkspaceConfig struct {
 	// subscription.
 	InheritAPIKey     bool `yaml:"inheritApiKey"`
 	InheritOAuthToken bool `yaml:"inheritOauthToken"`
-	// DangerouslySkipPermissions runs this workspace's session with permission
-	// prompts turned off (emitted as --permission-mode bypassPermissions). It
-	// removes the gate a person answers from their phone — the main defence
-	// against a session acting on instructions injected into a file it read.
-	// Trusted config only, and by construction: RepoConfig has no such field, so
-	// a cloned repository can never turn it on. Off unless the machine's owner
-	// sets it, per-workspace or in a profile.
+	// DangerouslySkipPermissions runs the session with permission prompts off,
+	// removing the main defence against it acting on instructions injected into
+	// a file it read. Trusted config only by construction — RepoConfig has no
+	// such field, so a cloned repository can never turn it on.
 	DangerouslySkipPermissions bool `yaml:"dangerouslySkipPermissions"`
 }
 
@@ -171,16 +160,12 @@ type Resolved struct {
 
 // Resolve merges the two files under the restrict-never-relax rule.
 //
-// id comes from the local registry and is the TRUSTED identity. The repo file
-// may not change it, because the id is the lookup key into the trusted
-// per-workspace settings: a cloned repository declaring `id: work` would
-// otherwise inherit that workspace's configDir, bin, and permissionMode —
-// the exact escalation this split exists to prevent. RepoDeclaredID is
-// reported separately so `corgi agent init` can adopt it as a deliberate local
-// act, which is the only moment a repo's own name should matter.
+// id comes from the local registry and the repo file may not change it: the id
+// keys into the trusted per-workspace settings, so a clone declaring `id: work`
+// would inherit that workspace's configDir, bin and permissionMode.
+// RepoDeclaredID is reported separately for `corgi agent init` to adopt.
 //
-// repo may be nil (no committed config). Capability-granting fields come only
-// from user, whose per-workspace entry overrides its defaults.
+// repo may be nil. Capability-granting fields come only from user.
 func Resolve(id string, repo *RepoConfig, user *UserConfig) Resolved {
 	out := Resolved{ID: id}
 
@@ -269,13 +254,10 @@ func ApplyProfile(r Resolved, user *UserConfig, name string) (Resolved, error) {
 	return r, nil
 }
 
-// AutostartEnabled reports whether the workspace should be supervised.
-//
-// Opt-in, not opt-out. `corgi agent scan ~/projects` can register a dozen
-// stacks, and defaulting to on would spawn a remote-control process for every
-// one of them the next time the daemon started — a surprise measured in
-// gigabytes. A workspace runs when the trusted user config says so, which
-// `corgi agent init` writes and `scan` deliberately does not.
+// AutostartEnabled reports whether the workspace should be supervised. Opt-in:
+// `agent scan ~/projects` can register a dozen stacks, and defaulting to on
+// would spawn a process for each on the next daemon start. `agent init` writes
+// the trusted config that enables it; `scan` deliberately does not.
 func (r Resolved) AutostartEnabled() bool {
 	return r.Autostart != nil && *r.Autostart
 }

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -4,6 +4,7 @@
 package daemon
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -134,13 +135,10 @@ func (d *Daemon) Nudge() {
 	}
 }
 
-// Nudge pokes a running daemon in another process so it drains the spool now
-// rather than on the next tick. Best-effort: the tick still wins without it.
-//
-// It signals ONLY a daemon that advertised command support. A daemon from
-// before this feature has no handler for SIGUSR1, whose default disposition is
-// to terminate — so nudging one would kill it. Such a daemon cannot drain the
-// spool anyway; the caller should tell the user to restart it.
+// Nudge pokes a running daemon so it drains the spool now rather than on the
+// next tick. Best-effort. Signals ONLY a daemon that advertised command
+// support: an older one has no SIGUSR1 handler and would be killed by the
+// nudge, and cannot drain the spool anyway — tell the user to restart it.
 func Nudge(info *Info) {
 	if info == nil || info.PID <= 0 || !info.Commands {
 		return
@@ -214,23 +212,17 @@ func ReadStatus(dir string) (*Status, error) {
 	return &s, nil
 }
 
-// Run supervises every config until ctx is cancelled.
+// Run supervises every config until ctx is cancelled. One goroutine per
+// workspace, so one disabling itself does not take the others down. Returns
+// only once every supervisor has finished — "nothing of mine is still up".
 //
-// Each workspace gets its own goroutine; one workspace disabling itself does
-// not take the others down. Run returns only when every supervisor has
-// finished, so a caller can rely on it meaning "nothing of mine is still up".
-//
-// With ResolveWorkspace set, Run also drains the command spool and can start
-// and stop workspaces at runtime; without it, the fixed-set lifecycle below is
-// unchanged.
+// With ResolveWorkspace set it also drains the command spool and can start and
+// stop workspaces at runtime.
 func (d *Daemon) Run(ctx context.Context, configs []supervisor.SpawnConfig) error {
-	// Catch SIGUSR1 for the daemon's ENTIRE lifetime, before writeInfo makes
-	// this pid discoverable to a nudge and until after cleanup. Go's default
-	// disposition for SIGUSR1 is to terminate the process, so a nudge landing
-	// in the window before the handler was installed — a phone start racing a
-	// launchd restart, exactly what this feature invites — would kill the
-	// daemon outright. Installed on the fixed path too, where nothing reads the
-	// channel, purely so the signal is never fatal.
+	// Catch SIGUSR1 for the daemon's ENTIRE lifetime — before writeInfo makes
+	// this pid nudgeable, until after cleanup. Go terminates on an unhandled
+	// SIGUSR1, so a nudge racing a launchd restart would kill the daemon.
+	// Installed on the fixed path too, where nothing reads it, for that reason.
 	stopSignals := notifyNudge(d.nudge)
 	defer stopSignals()
 
@@ -704,13 +696,9 @@ func ReadInfo(dir string) (*Info, error) {
 	return &info, nil
 }
 
-// processMatchesRecord checks that the pid is still running the binary that
-// wrote the record.
-//
-// Pids are recycled. Without this, a daemon.json left behind by an unclean exit
-// would make `corgi agent stop` SIGTERM whatever now holds that number, and
-// `corgi agent serve` would refuse to start because it believes a daemon is
-// already running.
+// processMatchesRecord checks the pid is still running the binary that wrote
+// the record. Pids are recycled, so without this a stale daemon.json makes
+// `agent stop` SIGTERM an unrelated process and `agent serve` refuse to start.
 func processMatchesRecord(info Info) bool {
 	name, ok := processName(info.PID)
 	if !ok {
@@ -747,9 +735,5 @@ func writeJSONAtomic(path string, v any) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o600)
 }

--- a/utils/agent/daemon/daemon_test.go
+++ b/utils/agent/daemon/daemon_test.go
@@ -365,15 +365,10 @@ func TestDaemonWithoutABriefProbeStillRuns(t *testing.T) {
 }
 
 func TestRunWaitsForTheStatusPublisherBeforeReturning(t *testing.T) {
-	// Run's contract is "nothing of mine is still up". The status publisher runs
-	// in its own goroutine, so without an explicit wait Run can return — and its
-	// deferred cleanup delete status.json — while the publisher is still
-	// mid-write, resurrecting the file and racing anything clearing the
-	// directory behind it. Under `go test -race` that surfaced in CI as a
-	// TempDir cleanup failure in whichever test happened to run next.
-	//
-	// The delay makes the ordering deterministic: without the wait Run returns
-	// long before the publisher is finished.
+	// Without an explicit wait, Run's deferred delete of status.json races the
+	// status publisher goroutine still mid-write, resurrecting the file. That
+	// surfaced under -race as a TempDir cleanup failure in the next test.
+	// The delay makes the ordering deterministic.
 	d := testDaemon(t)
 	var publisherFinished atomic.Bool
 	d.publishStopped = func() {

--- a/utils/agent/daemon/signal_windows.go
+++ b/utils/agent/daemon/signal_windows.go
@@ -7,13 +7,10 @@ import "os"
 // syscallZero is unused on Windows; see processAliveOS.
 var syscallZero os.Signal = nil
 
-// processAliveOS reports whether pid is a live process.
-//
-// Windows has no signal 0, and os.Process.Signal(nil) returns EWINDOWS for a
-// live process — so probing by signal reports every daemon as dead, which made
-// ReadInfo delete daemon.json and defeated the already-running guard.
-// os.FindProcess opens a handle on Windows and fails for a pid that is gone,
-// which is the check we actually want.
+// processAliveOS reports whether pid is a live process. Windows has no signal
+// 0 and Signal(nil) returns EWINDOWS even when alive, so probing by signal
+// reported every daemon dead and made ReadInfo delete daemon.json.
+// os.FindProcess opens a handle and fails only for a pid that is gone.
 func processAliveOS(pid int) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil {

--- a/utils/agent/events/events.go
+++ b/utils/agent/events/events.go
@@ -3,6 +3,7 @@
 package events
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -73,11 +74,7 @@ func (l *Log) trimLocked(path string) {
 	if len(lines) > maxKeep {
 		lines = lines[len(lines)-maxKeep:]
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
-		return
-	}
-	_ = os.Rename(tmp, path)
+	_ = atomicfile.Write(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
 }
 
 func (l *Log) Read(workspaceID string, limit int) []Event {

--- a/utils/agent/pairing/pairing.go
+++ b/utils/agent/pairing/pairing.go
@@ -1,17 +1,13 @@
 // Package pairing issues per-device tokens for corgi's MCP HTTP endpoint.
 //
-// The obvious design — show a QR containing the server's bearer token — is
-// unsafe. That endpoint can run shell (corgi_exec) and query databases
-// (corgi_db_query), so the QR is a credential for the whole machine: anyone who
-// sees the screen, a photo of it, or a screen-share frame has it, and there is
-// no way to revoke one device without re-pairing every other.
-//
-// Instead a short-lived, single-use code is exchanged for a token that belongs
-// to one device and can be revoked on its own. Tokens are stored hashed, so a
-// readable store still does not yield a working credential.
+// A QR holding the server's bearer token would be a credential for the whole
+// machine (the endpoint runs shell and queries databases), visible to anyone
+// who sees the screen and unrevocable per device. Instead a short-lived,
+// single-use code buys a per-device token, stored hashed and revocable alone.
 package pairing
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -56,13 +52,9 @@ const codeAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 // hand-typing it is only the fallback when a camera fails.
 const codeLength = 20
 
-// Device is one paired client.
-//
-// There is deliberately no "last seen" field. Recording it would mean a
-// read-modify-write of this store on every authenticated request, and a
-// concurrent `corgi mcp devices revoke` could then be undone by a touch that
-// loaded before it — resurrecting a revoked device. Knowing when a phone last
-// called is not worth a revocation that silently fails.
+// Device is one paired client. Deliberately no "last seen": recording it means
+// a read-modify-write on every authenticated request, and a concurrent
+// `devices revoke` could then be undone by a touch that loaded before it.
 type Device struct {
 	Name      string    `json:"name"`
 	TokenHash string    `json:"tokenHash"`
@@ -161,11 +153,7 @@ func Save(path string, s *Store) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o600)
 }
 
 // Find returns the device with the given name.

--- a/utils/agent/supervisor/kind.go
+++ b/utils/agent/supervisor/kind.go
@@ -7,16 +7,12 @@ import (
 	"strings"
 )
 
-// A Kind is one agent CLI the supervisor knows how to keep alive.
+// A Kind is one agent CLI the supervisor knows how to keep alive. Only launch
+// details differ between agents, so they live here and the rest of the package
+// never asks which agent it has.
 //
-// Everything the supervisor actually does — restart after the ways a session
-// dies, hold a wake lock, scope credentials and config directory per workspace
-// — is identical whichever agent is running. Only the launch details differ, so
-// they live here and the rest of the package never asks which agent it has.
-//
-// Adding one is a map entry. Deliberately not exported as a registration hook:
-// a kind decides the argv of a process the daemon runs unattended, so the set
-// is fixed at compile time rather than being something config can extend.
+// Adding one is a map entry, deliberately not a registration hook: a kind
+// decides the argv of an unattended process, so the set is fixed at compile time.
 type Kind struct {
 	// Name is what `kind:` in the trusted user config selects.
 	Name string
@@ -40,12 +36,9 @@ type Kind struct {
 	SupportsSpawn          bool
 	SupportsPermissionMode bool
 	// BuildsArgvFromSettings is true for a kind that assembles its own command
-	// line out of the typed settings (spawn, capacity, permissionMode, name),
-	// and false for one handed a complete argv.
-	//
-	// It decides which half of the config is meaningful, so the other half can
-	// be rejected rather than silently dropped: a `capacity: 4` that quietly
-	// does nothing reads as a configured limit that is not being applied.
+	// line from the typed settings, false for one handed a complete argv. It
+	// decides which half of the config is meaningful so the other is rejected,
+	// not silently dropped — a `capacity: 4` that does nothing reads as applied.
 	BuildsArgvFromSettings bool
 }
 
@@ -166,12 +159,9 @@ func customArgs(c SpawnConfig) ([]string, error) {
 }
 
 // forbiddenArgPrefixes never reach a supervised process, whoever wrote them.
-//
-// The permission prompts are what a person answers from their phone, and they
-// are the main defence against a session acting on instructions it read out of
-// a repository. A daemon running unattended must not be able to skip them —
-// which is the same rule that rejects permissionMode: bypassPermissions,
-// applied to the one place a custom kind could otherwise route around it.
+// Permission prompts are the main defence against a session acting on
+// instructions it read out of a repository, so an unattended daemon must not
+// skip them — the same rule that rejects permissionMode: bypassPermissions.
 var forbiddenArgPrefixes = []string{
 	"--dangerously",
 	"--yolo",

--- a/utils/agent/supervisor/runner.go
+++ b/utils/agent/supervisor/runner.go
@@ -66,12 +66,9 @@ type Runner struct {
 	// Notify reports a restart or a shutdown to the user. Optional.
 	Notify func(title, body string)
 	// OnSessionEnd runs after a supervised process exits and before its
-	// replacement starts, while whatever the session left on disk is still
-	// there. It returns a line to append to the restart notification, or "" when
-	// there is nothing worth adding. Optional.
-	//
-	// This is the only moment the state is both final and current, which is why
-	// it is a hook here rather than something the daemon polls for.
+	// replacement starts, while what the session left on disk is still there —
+	// the only moment that state is both final and current, hence a hook rather
+	// than polling. Returns a line for the restart notification, or "". Optional.
 	OnSessionEnd func(Decision) string
 	// Sleep is the delay between restarts. Injected so tests do not wait.
 	Sleep func(ctx context.Context, d time.Duration)

--- a/utils/agent/supervisor/runner_test.go
+++ b/utils/agent/supervisor/runner_test.go
@@ -268,6 +268,24 @@ func TestWakeLockModeDefaultsToSession(t *testing.T) {
 	}
 }
 
+// waitForActive is waitFor for a session that is working, so it keeps recording
+// activity while it polls. One stamp is not enough: the monitor ticks on its own
+// schedule, and a tick delayed past the idle window reads a single stamp as
+// stale — then never looks again, because nothing re-stamps it. A real session
+// emits output repeatedly, which is what this reproduces.
+func waitForActive(t *testing.T, r *Runner, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r.recordActivity()
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}
+
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -596,9 +614,8 @@ func TestIdleWakeLockReleasesWhenQuietAndReacquiresOnActivity(t *testing.T) {
 	waitFor(t, func() bool { return lock.Held() })
 	// It goes quiet with no further output — the machine may sleep.
 	waitFor(t, func() bool { return !lock.Held() })
-	// Work resumes (output arrives) — awake again.
-	r.recordActivity()
-	waitFor(t, func() bool { return lock.Held() })
+	// Work resumes — awake again.
+	waitForActive(t, r, func() bool { return lock.Held() })
 
 	r.Stop()
 	<-done

--- a/utils/agent/supervisor/spawn.go
+++ b/utils/agent/supervisor/spawn.go
@@ -313,26 +313,17 @@ func BuildArgs(c SpawnConfig) ([]string, error) {
 	return kind.Args(c)
 }
 
-// BuildEnv constructs the child environment explicitly rather than handing over
-// the daemon's own.
-//
-// This exists because launchd and systemd never source a shell rc file, so the
-// CLAUDE_CONFIG_DIR aliases people use to separate accounts are simply absent.
-// Without setting it here every workspace would silently run under the default
-// account — no error, correct-looking output, wrong account.
-//
-// parentEnv is the environment to derive from, in "KEY=value" form.
+// BuildEnv constructs the child environment explicitly from parentEnv
+// ("KEY=value" form) rather than handing over the daemon's own. launchd and
+// systemd never source a shell rc file, so without this every workspace runs
+// under the default Claude account — no error, correct-looking output.
 func BuildEnv(c SpawnConfig, parentEnv []string) []string {
 	kind, err := KindFor(c)
 	if err != nil {
-		// Unreachable through the daemon, which validates first. Returning the
-		// parent unchanged would hand the child every ambient credential, so
-		// return an empty environment instead: a process with none fails loudly.
-		//
-		// Non-nil deliberately. exec.Cmd treats a nil Env as "inherit the whole
-		// parent environment", which is the exact opposite of what this line is
-		// for, so returning nil here would turn the safe fallback into total
-		// credential inheritance.
+		// Unreachable via the daemon, which validates first. Empty rather than
+		// the parent env so a misconfigured child fails loudly instead of
+		// inheriting every ambient credential — and non-nil, because exec.Cmd
+		// reads a nil Env as "inherit everything".
 		return []string{}
 	}
 	configVar := kind.ConfigDirEnv
@@ -358,12 +349,9 @@ func BuildEnv(c SpawnConfig, parentEnv []string) []string {
 }
 
 // isStrippedCredential reports whether a variable is one of the kind's ambient
-// credentials and the workspace has not opted in to keeping it.
-//
-// The two opt-ins are split because they fail differently: an API key bills the
-// API instead of a subscription, while an OAuth token points at another
-// account. A name containing OAUTH is treated as the token case, which is the
-// convention every CLI here follows.
+// credentials the workspace has not opted in to keeping. The two opt-ins are
+// split because they fail differently: an API key bills the API instead of a
+// subscription, an OAuth token points at another account.
 func isStrippedCredential(kind Kind, key string, c SpawnConfig) bool {
 	for _, name := range kind.CredentialEnv {
 		if key != name {

--- a/utils/agent/supervisor/wakelock_test.go
+++ b/utils/agent/supervisor/wakelock_test.go
@@ -22,7 +22,11 @@ func fakeLock(t *testing.T, mode WakeLockMode) (*WakeLock, *int) {
 		starts++
 		cmd := exec.Command("sleep", "30")
 		if err := cmd.Start(); err != nil {
-			t.Fatalf("could not start stand-in process: %v", err)
+			// The idle monitor calls this from its own goroutine, where
+			// t.Fatal would stop only that goroutine and leave the test to
+			// time out on a lock nothing re-acquires. Acquire propagates the
+			// error instead, so the test fails on its real assertion.
+			return nil, err
 		}
 		return cmd, nil
 	}

--- a/utils/agent/workspace/migrate.go
+++ b/utils/agent/workspace/migrate.go
@@ -5,13 +5,9 @@ import (
 	"strings"
 )
 
-// LegacyEntry is one row of the pre-existing `corgi_exec_paths.txt` registry:
-// a name, a description, and the path to a corgi-compose file.
-//
-// That file is pipe-separated with no quoting and is rewritten by truncating
-// first, so a name containing "|" corrupts a row and a crash mid-write loses
-// everything. Migration is one-way and lossy only in the sense that already
-// corrupt rows are skipped.
+// LegacyEntry is one row of the pre-existing `corgi_exec_paths.txt` registry.
+// That file is pipe-separated with no quoting and rewritten by truncating, so a
+// name containing "|" corrupts a row. Migration is one-way and skips those.
 type LegacyEntry struct {
 	Name        string
 	Description string
@@ -60,13 +56,9 @@ func legacyID(e LegacyEntry, path string) string {
 }
 
 // MergeLegacy folds legacy rows into an existing registry without overwriting
-// anything already recorded. Migration must never clobber a workspace that has
-// since been configured with aliases or a config dir.
-//
-// pathExists filters out rows whose directory is gone. The legacy file was
-// append-only with no pruning, so it accumulates temp directories and deleted
-// projects; importing those would fill the workspace list with noise on the
-// very first run.
+// anything already recorded — a workspace since given aliases or a config dir
+// must survive. pathExists prunes rows whose directory is gone; the legacy file
+// was append-only and accumulated temp dirs and deleted projects.
 func MergeLegacy(r *Registry, entries []LegacyEntry, pathExists func(string) bool) (added int) {
 	for _, w := range FromLegacy(entries) {
 		if _, exists := r.Find(w.ID); exists {

--- a/utils/agent/workspace/registry.go
+++ b/utils/agent/workspace/registry.go
@@ -3,6 +3,7 @@
 package workspace
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -162,9 +163,5 @@ func Save(path string, r *Registry) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o644)
 }

--- a/utils/agentdiff.go
+++ b/utils/agentdiff.go
@@ -405,6 +405,3 @@ func WorktreeDirs(set *WorktreeSet) map[string]string {
 	}
 	return dirs
 }
-
-// ShortRepoName is the last path segment, for compact output.
-func ShortRepoName(repo string) string { return filepath.Base(repo) }

--- a/utils/agentpreview.go
+++ b/utils/agentpreview.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,14 +13,12 @@ import (
 	"time"
 )
 
-// A live preview is a public URL onto a service the agent is editing, so the
-// user can watch it change from a phone. corgi does not need a refresh
-// mechanism — the dev server already hot reloads. corgi needs to keep one
-// tunnel open and be honest about what state the build is in.
+// A live preview is a public URL onto a service the agent is editing. The dev
+// server already hot reloads, so corgi only keeps one tunnel open and reports
+// the build state honestly.
 //
-// The tunnel runs as a DETACHED process writing to a log file, the same shape
-// corgi already uses for detached services. That way a preview outlives the
-// session that started it, and a later corgi run can still find and reap it.
+// The tunnel is a DETACHED process writing to a log file, like corgi's detached
+// services, so a preview outlives its session and a later run can reap it.
 
 // PreviewState is what to show over the webview. A visible banner beats a
 // white screen, so "broken" is a first-class state rather than an absence.
@@ -110,11 +109,7 @@ func SavePreviews(composeDir string, s *PreviewStore) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o644)
 }
 
 // PreviewOptions configures a new preview.

--- a/utils/agentwork.go
+++ b/utils/agentwork.go
@@ -56,16 +56,11 @@ type RepoState struct {
 }
 
 // ProbeRepoState reads a checkout's branch and whether it holds uncommitted
-// work. Returns false when dir is not a git repository.
+// work. Returns false when dir is not a git repository. Detached HEAD reports
+// an empty branch.
 //
-// Separate from ProbeAgentWork, which additionally shells out to `gh` / `glab`
-// to find the branch's PR. Those calls hit the network with no timeout, which
-// is fine for a snapshot someone asked for and wrong anywhere on a restart
-// path — a session that died *because* the network went away must not then wait
-// on GitHub, once per repository, before it can come back.
-//
-// A detached HEAD reports an empty branch rather than the literal "HEAD", since
-// a name there would be a lie.
+// Separate from ProbeAgentWork, which also shells out to `gh`/`glab` with no
+// timeout — wrong on a restart path, where the network may be why it died.
 func ProbeRepoState(dir string) (RepoState, bool) {
 	if dir == "" || !isGitRepo(dir) {
 		return RepoState{}, false

--- a/utils/agentworktrees.go
+++ b/utils/agentworktrees.go
@@ -223,12 +223,9 @@ func ExistingBranchWorktrees(corgi *CorgiCompose, composeDir, branch string) (*W
 }
 
 // ReleaseBranchWorktrees removes the worktrees a branch materialized, leaving
-// the branches themselves alone — the work is usually the point.
-//
-// A worktree with uncommitted changes is kept and reported instead of removed:
-// the tool promises only that branches and commits survive, and `git worktree
-// remove --force` would silently throw away work nobody asked it to. Pass
-// force to remove them anyway.
+// the branches alone — the work is usually the point. A worktree with
+// uncommitted changes is kept and reported rather than removed, since
+// `--force` would discard work nobody asked it to. Pass force to override.
 func ReleaseBranchWorktrees(composeDir, branch string) ([]string, error) {
 	removed, _, err := releaseBranchWorktrees(composeDir, branch, false)
 	return removed, err
@@ -318,36 +315,26 @@ func removeWorktree(dest string) bool {
 }
 
 // HasUncommittedWork reports whether a checkout holds anything not committed,
-// including untracked files.
-//
-// isTreeDirty deliberately ignores untracked files, which is right for asking
-// "has this checkout diverged" — but wrong here. An agent's work is usually a
-// set of brand-new files, and those are the ones it would hurt most to discard,
-// which is equally true when releasing a worktree and when writing a handover
-// brief. .gitignore still applies, so build output does not count.
+// untracked files included — unlike isTreeDirty, which ignores them. An agent's
+// work is usually brand-new files, the ones it would hurt most to discard.
+// .gitignore still applies, so build output does not count.
 func HasUncommittedWork(dir string) bool {
 	out, err := gitOut(dir, "status", "--porcelain")
 	return err == nil && strings.TrimSpace(out) != ""
 }
 
 // worktreeDirName keeps repo and branch in the directory name so a release can
-// find exactly the worktrees a branch created.
-//
-// The repo's basename alone is not unique — a stack can contain ~/work/api and
-// ~/oss/api — so a short hash of the full path is appended. Without it both
-// services would resolve to the same destination and the second would silently
-// be pointed at the first repository's worktree.
+// find exactly the worktrees a branch created. The basename alone is not unique
+// — a stack can hold ~/work/api and ~/oss/api — so a hash of the full path is
+// appended, or the second service silently gets the first's worktree.
 func worktreeDirName(repo, branch string) string {
 	return fmt.Sprintf("%s@%s", WorktreeDirPrefix(repo), branchDirSegment(branch))
 }
 
 // WorktreeDirPrefix is the part of a worktree directory name before the "@",
-// derived only from the repository path.
-//
-// Exported so a caller holding a compose file can map an existing worktree
-// directory back to the service that owns it. Parsing the name by hand does not
-// work: the prefix is "<basename>-<hash>", so splitting on "@" yields
-// "api-3f2a1b" rather than "api".
+// derived only from the repository path. Exported because parsing the name by
+// hand does not work: the prefix is "<basename>-<hash>", so splitting on "@"
+// yields "api-3f2a1b" rather than "api".
 func WorktreeDirPrefix(repo string) string {
 	sum := sha256.Sum256([]byte(repo))
 	return fmt.Sprintf("%s-%x", filepath.Base(repo), sum[:3])

--- a/utils/atomicfile/atomicfile.go
+++ b/utils/atomicfile/atomicfile.go
@@ -1,0 +1,20 @@
+// Package atomicfile replaces a file's contents in one step, so a crash
+// mid-write cannot leave a half-written file behind.
+package atomicfile
+
+import "os"
+
+// Write puts data in a sibling ".tmp" file and renames it over path. The temp
+// file is removed when the rename fails, which would otherwise leave it behind
+// for good — nothing else ever cleans it up.
+func Write(path string, data []byte, perm os.FileMode) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/utils/atomicfile/atomicfile_test.go
+++ b/utils/atomicfile/atomicfile_test.go
@@ -1,0 +1,77 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReplacesContentAndLeavesNoTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Write(path, []byte("new"), 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "new" {
+		t.Errorf("content = %q, want new", body)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("temp file survived a successful write")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("perm = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteCreatesAMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.json")
+	if err := Write(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "hello" {
+		t.Errorf("content = %q, want hello", body)
+	}
+}
+
+// The bug this package exists for: a failed rename used to leave the temp file
+// on disk, and nothing else ever cleans it up.
+func TestWriteRemovesTempWhenRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	// A directory at the destination makes the rename fail while the temp
+	// write itself succeeds.
+	path := filepath.Join(dir, "target")
+	if err := os.MkdirAll(filepath.Join(path, "child"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Write(path, []byte("data"), 0o644); err == nil {
+		t.Fatal("Write succeeded, want a rename error")
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("temp file left behind after a failed rename")
+	}
+}
+
+func TestWriteReportsAnUnwritableDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-such-dir", "state.json")
+	if err := Write(path, []byte("data"), 0o644); err == nil {
+		t.Fatal("Write succeeded into a missing directory, want an error")
+	}
+}

--- a/utils/autopilotstate.go
+++ b/utils/autopilotstate.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -59,11 +60,7 @@ func WriteAutopilotState(path string, s AutopilotState) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o644)
 }
 
 func ReadAutopilotState(path string) (AutopilotState, error) {

--- a/utils/cipreflight.go
+++ b/utils/cipreflight.go
@@ -13,12 +13,9 @@ var (
 )
 
 // InContainer reports whether this process is running inside a container.
-//
-// It matters because corgi's databases run as containers that publish to
-// localhost, and every generated connection string assumes the services share
-// that localhost. A CI job running inside its own container does not, so the
-// stack boots and then every service fails to reach its database — which reads
-// as "postgres is down" rather than "wrong runner".
+// corgi's generated connection strings assume services share the localhost its
+// database containers publish to; a CI job in its own container does not, and
+// the failure reads as "postgres is down" rather than "wrong runner".
 func InContainer() bool {
 	if _, err := os.Stat(dockerEnvMarkerPath); err == nil {
 		return true

--- a/utils/coverage_extra_test.go
+++ b/utils/coverage_extra_test.go
@@ -15,8 +15,6 @@ func prependPATH(t *testing.T, bin string) {
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-// --- dbdump.go: RunPgDump / RunPgSeed via fake binaries on PATH ---
-
 func TestRunPgDump(t *testing.T) {
 	db := DatabaseService{Host: "h", Port: 5432, User: "u", DatabaseName: "app", Password: "p"}
 
@@ -96,8 +94,6 @@ func TestMergeEnv(t *testing.T) {
 	}
 }
 
-// --- agentwork.go: GitLab MR probe + CI rollup ---
-
 func TestProbeAgentWork_GitlabMR(t *testing.T) {
 	bin := t.TempDir()
 	writeFakeBin(t, bin, "git", `
@@ -160,8 +156,6 @@ func TestRollupCI(t *testing.T) {
 		}
 	}
 }
-
-// --- validate.go: AbortOnValidationErrors + duplicate-key branch ---
 
 func TestAbortOnValidationErrors_Clean(t *testing.T) {
 	clean := &CorgiCompose{Services: []Service{{ServiceName: "api", Port: 3000, Start: []string{"x"}}}}
@@ -233,8 +227,6 @@ func TestCheckDuplicateNames_DuplicateKeys(t *testing.T) {
 		t.Fatalf("a duplicate decode key must surface E_DUPLICATE_NAME, got %v", codesOf(issues))
 	}
 }
-
-// --- memory.go: error and edge paths ---
 
 func TestMemoryHelperFallbacks(t *testing.T) {
 	if typeForDir("unknown-dir") != "" {
@@ -318,8 +310,6 @@ func TestRenderIndexIncludesService(t *testing.T) {
 	}
 }
 
-// --- autopilotstate.go: write failure when the parent isn't a directory ---
-
 func TestWriteAutopilotStateMkdirFails(t *testing.T) {
 	fileAsParent := filepath.Join(t.TempDir(), "not-a-dir")
 	if err := os.WriteFile(fileAsParent, []byte("x"), 0o644); err != nil {
@@ -332,8 +322,6 @@ func TestWriteAutopilotStateMkdirFails(t *testing.T) {
 	}
 }
 
-// --- output.go: ConsoleOut honors the override ---
-
 func TestConsoleOutUsesOverride(t *testing.T) {
 	var buf bytes.Buffer
 	SetConsoleOverride(&buf)
@@ -345,8 +333,6 @@ func TestConsoleOutUsesOverride(t *testing.T) {
 		t.Fatalf("ConsoleOut did not route to the override: %q", buf.String())
 	}
 }
-
-// --- config.go: small direct-call edges ---
 
 func TestDetectDuplicateComposeKeysEdges(t *testing.T) {
 	// A top-level sequence (not a mapping) yields no duplicates.
@@ -379,8 +365,6 @@ func TestServiceRepoDir(t *testing.T) {
 		t.Errorf("ServiceRepoDir = %q, want %q", got, want)
 	}
 }
-
-// --- suggesthistory.go: parse errors, version default, nil guards ---
 
 func TestLoadSuggestHistory_MalformedJSON(t *testing.T) {
 	root := t.TempDir()

--- a/utils/dbDrivers.go
+++ b/utils/dbDrivers.go
@@ -727,15 +727,10 @@ var DriverConfigs = map[string]DriverConfig{
 		},
 	},
 	"supabase": {
-		// Wraps the supabase CLI rather than running its containers directly —
-		// the CLI manages its own multi-container stack (postgres, gotrue,
-		// postgrest, kong, studio, storage-api, etc.). corgi only emits env
-		// vars and triggers `supabase start/stop` from the project root.
-		//
-		// Defaults below match `supabase status -o env` output for a project
-		// initialized with the stock JWT secret. Customizing the secret in
-		// supabase/config.toml will diverge ANON_KEY / SERVICE_ROLE_KEY /
-		// JWT_SECRET — handle via overrides in v2.
+		// Wraps the supabase CLI, which manages its own multi-container stack;
+		// corgi only emits env vars and runs `supabase start/stop`. Defaults
+		// match `supabase status -o env` with the stock JWT secret — a custom
+		// secret in supabase/config.toml diverges the keys.
 		Prefix: "SUPABASE_",
 		EnvGenerator: func(serviceNameInEnv string, db DatabaseService) string {
 			var out strings.Builder
@@ -803,13 +798,10 @@ var DriverConfigs = map[string]DriverConfig{
 		},
 	},
 	"image": {
-		// Stateless docker-image driver. Use for services shipped as a public
-		// image with no DB / persistent state (gotenberg, mailhog, jaeger,
-		// redis-commander, etc.). Default env emission: <PREFIX>URL/HOST/PORT.
-		// PREFIX is empty by default; consumers usually set `envAlias:` on
-		// their depends_on_db entry. When no alias is set + no driver prefix,
-		// emit uses the uppercased ServiceName as fallback prefix so vars
-		// don't collide.
+		// Stateless docker-image driver for services shipped as a public image
+		// with no persistent state (gotenberg, mailhog, jaeger). Emits
+		// <PREFIX>URL/HOST/PORT; consumers usually set `envAlias:` instead, and
+		// with neither the uppercased ServiceName is the fallback prefix.
 		Prefix: "",
 		EnvGenerator: func(serviceNameInEnv string, db DatabaseService) string {
 			prefix := serviceNameInEnv

--- a/utils/dbshell.go
+++ b/utils/dbshell.go
@@ -59,10 +59,7 @@ func redisArgs(db DatabaseService) []string {
 func redisExecArgs(db DatabaseService, query string) []string {
 	args := redisArgs(db)
 	// redis-cli treats trailing space-separated tokens as the command.
-	for _, tok := range strings.Fields(query) {
-		args = append(args, tok)
-	}
-	return args
+	return append(args, strings.Fields(query)...)
 }
 
 func mongoArgs(db DatabaseService) []string {

--- a/utils/execute.go
+++ b/utils/execute.go
@@ -24,13 +24,10 @@ const (
 	errPathToServiceNotFound = "path to target service is not found: %s"
 )
 
-// withEnvSource prepends a POSIX `set -a; . <envFile>; set +a; ` prefix to a
-// command when an env file exists for the service. Lets a start command like
-// `npx vite --port $PORT` see PORT and other corgi-emitted vars without each
-// service writing its own `source .env` boilerplate.
-//
-// envFile is the absolute path to the file. Empty / missing → command
-// returned untouched. Sourcing uses POSIX `.` so works under /bin/sh.
+// withEnvSource prepends `set -a; . <envFile>; set +a; ` so a start command like
+// `npx vite --port $PORT` sees corgi-emitted vars without its own `source .env`.
+// envFile is absolute; empty or missing returns the command untouched. POSIX `.`
+// keeps it working under /bin/sh.
 func withEnvSource(command, envFile string) string {
 	if envFile == "" {
 		return command

--- a/utils/generateEnv.go
+++ b/utils/generateEnv.go
@@ -158,16 +158,9 @@ func (e *producerSkippedError) Error() string {
 
 var crossServiceRefRe = regexp.MustCompile(`\$\{([A-Za-z0-9_\-/]+)\.([A-Za-z_][A-Za-z0-9_]*)\}`)
 
-// topoSortServices returns services in dependency order (deps first).
-//
-// Only "hard" edges add ordering: a hard edge is created when consumer's
-// environment block contains ${producer.VAR}. depends_on_services entries
-// that are alias-only (e.g. envAlias: BASE_URL) are "soft" — their emitted
-// value is a static localhost:port and needs no ordering. Self-deps are
-// always ignored.
-//
-// Cycles only matter when both sides reference each other's exports. If a
-// cycle is detected, the error names the services involved.
+// Only ${producer.VAR} in an environment block creates an ordering edge.
+// Alias-only depends_on_services entries emit a static localhost:port, so they
+// need none. Self-deps are ignored; a real cycle errors naming the services.
 func collectProducers(s Service) map[string]bool {
 	producers := map[string]bool{}
 	for _, env := range s.Environment {
@@ -345,23 +338,12 @@ func substituteCrossServiceRefs(
 	return out, firstErr
 }
 
-// Adds env variables to each service, including dependent db_services and services.
+// GenerateEnvForServices writes each service's env file, resolving
+// ${producer.VAR} references across services.
 //
-// Resolution is two-phase so that bidirectional ${producer.VAR} references
-// (codependencies) work as long as the actual VAR values don't form a true
-// cycle:
-//
-//  1. Try topo-sort. If it succeeds, process services in dependency order —
-//     each service's exports are fully resolved before any consumer runs.
-//     This is the fast path and matches pre-1.12 behavior.
-//
-//  2. If topo-sort detects a cycle (both sides reference each other's
-//     exports), fall back to fixed-point resolution: build each service's
-//     exports from its local env without cross-ref substitution, then
-//     iteratively expand ${producer.VAR} within the exports map until
-//     stable. Finally, write each service's env file using the resolved
-//     map. A genuine VAR-level cycle (e.g. A.X="${B.Y}" and B.Y="${A.X}")
-//     remains unresolvable and surfaces as an error naming the stuck vars.
+// Two phases so codependent services still resolve: topo-sort first, and on a
+// cycle fall back to expanding the exports maps to a fixed point. A true
+// VAR-level cycle (A.X="${B.Y}", B.Y="${A.X}") errors naming the stuck vars.
 func GenerateEnvForServices(corgiCompose *CorgiCompose) error {
 	ordered, err := topoSortServices(corgiCompose.Services)
 	if err == nil {

--- a/utils/gitlabcache.go
+++ b/utils/gitlabcache.go
@@ -61,13 +61,10 @@ type gitlabEntry struct {
 	paths []string
 }
 
-// GitLabCacheYAML renders the cache plan as a GitLab CI config fragment: a
-// hidden `.corgi-cache` job template that a real job extends.
-//
-// GitHub reads the plan at runtime through the action's outputs. GitLab cannot
-// — its cache config is static YAML — so the fragment is generated and
-// committed, and `corgi cache paths --gitlab --check` fails once it stops
-// matching the compose file.
+// GitLabCacheYAML renders the cache plan as a hidden `.corgi-cache` job
+// template a real job extends. GitLab's cache config is static YAML, so unlike
+// GitHub it cannot read the plan at runtime — the fragment is committed and
+// `corgi cache paths --gitlab --check` fails once it drifts from the compose.
 func GitLabCacheYAML(plan CachePlan, opts GitLabCacheOptions) string {
 	entries := gitlabEntries(plan, opts)
 
@@ -208,7 +205,7 @@ func gitlabVariables(plan CachePlan) []gitlabVariable {
 	seen := map[string]gitlabVariable{}
 	for _, p := range plan.Paths {
 		if mapped, ok := gitlabHomeCaches[p]; ok {
-			seen[mapped.env] = gitlabVariable{mapped.env, mapped.dir}
+			seen[mapped.env] = gitlabVariable(mapped)
 		}
 	}
 	out := make([]gitlabVariable, 0, len(seen))

--- a/utils/liveness_default.go
+++ b/utils/liveness_default.go
@@ -4,15 +4,13 @@ package utils
 
 import "syscall"
 
-// PidAlive reports whether pid is a live process still owned by corgi. The bare
-// kill(pid,0) check isn't enough: after a detached service exits the OS recycles
-// its PID, and signaling that recycled pgid would hit an unrelated process group.
+// PidAlive reports whether pid is a live process still owned by corgi.
 //
-// Detached procs are process-group leaders (Setpgid → pgid==pid), so we confirm
-// pid is still its own group leader. That survives the child exec'ing into
-// another binary (npm→node) yet rejects a recycled pid, which is almost never a
-// group leader. Unreadable pgid → assume alive (safe: at worst we orphan).
-// command is unused here; kept for signature/back-compat.
+// kill(pid,0) alone is not enough: a recycled PID would make corgi signal an
+// unrelated process group. Detached procs are group leaders (Setpgid), so pid
+// must still be its own — that survives npm exec'ing into node but rejects a
+// recycled pid. Unreadable pgid assumes alive; at worst corgi orphans it.
+// command is unused, kept for back-compat.
 func PidAlive(pid int, command string) bool {
 	if pid <= 0 {
 		return false

--- a/utils/output.go
+++ b/utils/output.go
@@ -49,13 +49,9 @@ func withMirror(base io.Writer) io.Writer {
 
 func WithMirror(base io.Writer) io.Writer { return withMirror(base) }
 
-// infoWriter is where human-facing log lines go: the console override when set,
-// else stderr in JSON mode so the JSON payload on stdout stays clean, else
-// stdout.
-// PayloadOnStdout marks a command whose stdout is meant to be read by another
-// program — `corgi cache paths` feeding a CI cache action, say. Human-facing
-// lines then go to stderr, exactly as they do in JSON mode, so a command
-// substitution captures the payload and nothing else.
+// PayloadOnStdout marks a command whose stdout another program reads — `corgi
+// cache paths` feeding a CI cache action. Human lines then go to stderr, as in
+// JSON mode, so a command substitution captures the payload and nothing else.
 var PayloadOnStdout bool
 
 func infoWriter() io.Writer {

--- a/utils/readiness.go
+++ b/utils/readiness.go
@@ -9,13 +9,10 @@ import (
 // readinessPollInterval is how often readiness probes retry while waiting.
 const readinessPollInterval = 500 * time.Millisecond
 
-// readinessProbeTimeout is how long one probe may take before it counts as a
-// failure. Deliberately far longer than the poll interval: a dev server does
-// real work on its first request — Vite pre-bundles dependencies, Metro builds
-// a bundle, Nest warms up — and on a machine busy starting a whole stack that
-// easily takes seconds. Timing out in half a second reports a healthy service
-// as down.
-// ReadinessProbeTimeout is exported so status probes share the same tolerance.
+// ReadinessProbeTimeout is how long one probe may take before it counts as a
+// failure, deliberately far longer than the poll interval: a dev server does
+// real work on its first request (Vite pre-bundling, Metro building), so a short
+// timeout reports a healthy service as down. Exported so status probes match.
 const ReadinessProbeTimeout = 10 * time.Second
 
 // WaitForDBReady blocks until the db is reachable or ctx is done. With no known

--- a/utils/runstate.go
+++ b/utils/runstate.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -81,11 +82,7 @@ func WriteRunState(path string, s RunState) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.Write(path, data, 0o644)
 }
 
 func ReconcileRunState(

--- a/utils/serviceWorktree.go
+++ b/utils/serviceWorktree.go
@@ -56,13 +56,6 @@ func gitRunNoPrompt(dir string, args ...string) error {
 	return c.Run()
 }
 
-func gitOutNoPrompt(dir string, args ...string) (string, error) {
-	c := exec.Command("git", append([]string{"-C", dir}, args...)...)
-	c.Env = noPromptEnv()
-	out, err := c.Output()
-	return strings.TrimSpace(string(out)), err
-}
-
 func isTreeDirty(dir string) (bool, error) {
 	out, err := gitOut(dir, "status", "--porcelain", "--untracked-files=no")
 	if err != nil {

--- a/utils/snapshot_fakedocker_test.go
+++ b/utils/snapshot_fakedocker_test.go
@@ -10,12 +10,9 @@ import (
 	"time"
 )
 
-// The snapshot/restore pipeline shells out to `docker`. The real exercise lives
-// in snapshot_e2e_test.go behind the `e2e` tag and needs a daemon, so it never
-// runs in CI coverage. These tests stub `docker` with a tiny shell script on
-// PATH instead — every docker call returns canned output (tunable per test via
-// FAKE_* env vars), so RunSnapshot, RunRestore and all their helpers run for
-// real with no daemon.
+// snapshot_e2e_test.go needs a real daemon and never runs in CI coverage, so
+// these stub `docker` with a shell script on PATH returning canned output.
+// RunSnapshot, RunRestore and their helpers then run for real with no daemon.
 //
 // Knobs (set after installFakeDocker):
 //

--- a/utils/startCommands.go
+++ b/utils/startCommands.go
@@ -70,13 +70,10 @@ func AwsVpnInit() error {
 	return fmt.Errorf("AWS VPN Client failed to become ready after %d attempts", awsVpnMaxLaunchAttempts)
 }
 
-// connectFirstAwsVpnProfile clicks the first profile's Connect button.
-// AWS VPN Client has no CLI — GUI automation is the only path. State
-// detection runs without activating to avoid focus steal; activates only
-// when clicking Connect.
-//
-// Script uses only generic UI labels (Connect/Disconnect/Cancel) — no
-// profile names. See TestConnectFirstAwsVpnProfile_DoesNotLeakProfileName.
+// connectFirstAwsVpnProfile clicks the first profile's Connect button. AWS VPN
+// Client has no CLI, so GUI automation is the only path; state detection avoids
+// activating to prevent focus steal. The script names only generic UI labels,
+// never profiles — see TestConnectFirstAwsVpnProfile_DoesNotLeakProfileName.
 func connectFirstAwsVpnProfile() error {
 	const script = `
 tell application "System Events"

--- a/utils/suggesthistory.go
+++ b/utils/suggesthistory.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"andriiklymiuk/corgi/utils/atomicfile"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -87,11 +88,10 @@ func AppendSuggestEntry(workspaceRoot string, e SuggestEntry) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal suggest history: %w", err)
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := atomicfile.Write(path, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write suggest history: %w", err)
 	}
-	return os.Rename(tmp, path)
+	return nil
 }
 
 // ShouldSkip reports whether a candidate slug is already known and so should be

--- a/utils/tunnel/access.go
+++ b/utils/tunnel/access.go
@@ -8,13 +8,10 @@ import (
 	"time"
 )
 
-// Exposure is how reachable an endpoint is, which is a different question from
-// whether it has a stable URL.
-//
-// corgi already treats "is there a tunnel" as a yes/no, and gates the mutating
-// tools on it. That is too blunt: a named tunnel behind an identity proxy is
-// not open to the internet, and a quick tunnel is open to anyone who guesses
-// the hostname. Those deserve different answers.
+// Exposure is how reachable an endpoint is — a different question from whether
+// it has a stable URL. "Is there a tunnel" is too blunt to gate on: a named
+// tunnel behind an identity proxy is not open to the internet, and a quick
+// tunnel is open to anyone who guesses the hostname.
 type Exposure string
 
 const (
@@ -54,13 +51,10 @@ const accessProbeTimeout = 10 * time.Second
 
 // ProbeAccess asks whether an identity proxy stands in front of a URL.
 //
-// The check is deliberately positive-only: corgi downgrades an endpoint to
-// "private" solely on evidence that an unauthenticated request was intercepted.
-// Guessing the other way — assuming protection because a probe failed, or
-// because the config said so — would relax a security gate on a hunch, and the
-// failure mode is an open shell endpoint.
-//
-// It follows no redirects, because the redirect itself is the evidence.
+// Positive-only by design: an endpoint is downgraded to "private" solely on
+// evidence that an unauthenticated request was intercepted, because guessing
+// the other way relaxes a security gate onto an open shell endpoint. Follows no
+// redirects — the redirect is the evidence.
 func ProbeAccess(ctx context.Context, rawURL string) AccessResult {
 	return ProbeAccessWith(ctx, rawURL, &http.Client{})
 }

--- a/utils/tunnel/localtunnel.go
+++ b/utils/tunnel/localtunnel.go
@@ -6,14 +6,11 @@ import (
 	"strings"
 )
 
-// Localtunnel wraps the npm `localtunnel` CLI (`lt --port <port>`).
-// It emits exactly one line: "your url is: https://<sub>.localtunnel.me".
+// Localtunnel wraps the npm `localtunnel` CLI (`lt --port <port>`), which emits
+// one line: "your url is: https://<sub>.localtunnel.me".
 //
-// Named mode: localtunnel supports `--subdomain <name>` to request a specific
-// subdomain on the public server. Per the official README the request is
-// best-effort — if the subdomain is in use, the server picks a different
-// random one. Pass only the leading subdomain label as `tunnel.hostname`
-// (e.g. `my-api`); the trailing `.localtunnel.me` is fixed.
+// `tunnel.hostname` takes only the leading subdomain label (`my-api`) and is
+// best-effort — the server picks a random one if it is taken.
 type Localtunnel struct{}
 
 func (Localtunnel) Name() string { return "localtunnel" }


### PR DESCRIPTION
Cleanup pass over the whole repo. Started as "remove the comment slop", turned up three real bugs on the way.

**79 files, +370 / −816.**

## Two bugs worth the review

### The session log was never closed on an error exit

`cmd/exit.go` describes `exitProcess` as "the one exit sequence: close the session log, then exit". Three call sites used it. **101 called `os.Exit` directly** and skipped the close.

That close does three things nothing else does:

- `flushPendingLocked()` — `logWriter` holds a trailing line until its newline arrives. Skipping the close **drops it**, on exactly the error paths where it is the line you want.
- `renameByStatusLocked()` — the log keeps its pre-status name.
- `CloseSessionLog` deletes the log when it turned out empty — so every such exit left a stray file behind.

Every `os.Exit` in `cmd/` is now `exitProcess`. Exit codes are unchanged; the log is closed first.

`TestExitProcessFlushesSessionLog` pins it. With the close removed the assertion reports `session log lost the trailing line, got ""`.

### A failed atomic write left its temp file forever

Ten places wrote a sibling `.tmp` and renamed it over the target. **None removed the temp file when the rename failed**, and nothing else ever cleans it up.

They are now one helper, `utils/atomicfile.Write`, which removes it on that path.

The fixed `.tmp` name is kept on purpose: `os.CreateTemp` would give each write a random suffix, and three existing tests assert on the exact `.tmp` name to prove no temp file survives a successful write. They would still pass, but stop testing anything.

## Dead code

`cmd/logs.go` carried two log-merge implementations. The shipping one is `drainStreams`; the heap-based one it replaced was never deleted — `mergeHeap` and its five `heap.Interface` methods, `buildMergeHeap`, `mergeStream.advance`, and the `eof` field it needed were all unreachable. Also `ShortRepoName` and `gitOutNoPrompt`.

`deadcode -test ./...` now reports nothing.

## Smaller things

- `drainStreams` allocated a whole `mergeStream` **per log line** just to pass `writeMergedLine` three strings. It takes them directly now, so the tail loop allocates nothing per line.
- `probeTunnelExposure`'s doc comment sat above `var probeDelays`, so godoc attached it to the wrong symbol.
- Three identical copies of the "load the compose file or exit" block in `stop`, `ps` and `open` → `mustLoadCorgiServices`, same output and exit code.
- Two staticcheck simplifications.

## Comments

They were already why-comments rather than restatements, so this only shortens them. Multi-paragraph rationale blocks are cut to the two or three lines carrying the reason, and the 43 `// ---- name ----` dividers go entirely.

Blocks of 5+ lines: **61 → 8**, and the survivors are tables, not prose.

The first commit is comment-only — every hunk in it touches a comment line and nothing else.

## Verification

| check | result |
|---|---|
| `gofmt -l .` | 0 |
| `go build ./...` | OK |
| `go vet ./...` | OK |
| `deadcode -test ./...` | 0 findings |
| `staticcheck ./...` | 4 findings, all pre-existing false positives |
| `go test ./...` | pass |
| `go test -race ./utils/... ./cmd/...` | pass |

Every one of the four commits builds on its own, so `git bisect` still works.

**The four staticcheck findings left standing are deliberate.** Three flag error strings ending in `..`, `topics:` and `queues:` — those are git and YAML syntax, not punctuation. The fourth reads a determinism check as `x != x`.

## One thing to know

`TestIdleWakeLockReleasesWhenQuietAndReacquiresOnActivity` is flaky under full-package load. It failed once here, so I checked out `15688be` and reproduced it there. **Pre-existing, not from this branch** — untouched, flagged for a separate fix.

## Where to look

The exit sweep is 101 call sites. It is mechanical and every check is green, but it is the change worth your eyes — it is isolated in the last commit.