### PR TITLE
Prompt-audit cleanup, MCP server instructions, fuller tool contracts

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -115,7 +115,7 @@ func runMCP(cmd *cobra.Command, _ []string) {
 
 	warnStrandedAgentData()
 
-	s := server.NewMCPServer("corgi", APP_VERSION)
+	s := server.NewMCPServer("corgi", APP_VERSION, server.WithInstructions(mcpServerInstructions))
 	registerMCPTools(s)
 	registerMCPResources(s)
 
@@ -1169,7 +1169,7 @@ func registerMCPTools(s *server.MCPServer) {
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_status",
-		mcp.WithDescription("Live health snapshot of declared services and db_services (TCP/HTTP probe)."),
+		mcp.WithDescription("Live health of every declared service and db_service, probed right now (TCP, or HTTP when a healthCheck path is declared). Returns one entry per target: {label, kind, port, url, healthy, detail}. This is the liveness truth — corgi_ps only says whether a pid or container exists. Targets with no declared port are not probed and do not appear, so an empty list is not a healthy stack. Read-only."),
 		composeOpt,
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
 		return mcpStatus(validateArgs{ComposePath: r.GetString("composePath", "")})
@@ -1185,14 +1185,14 @@ func registerMCPTools(s *server.MCPServer) {
 	registerAgentSurfaceTools(s, composeOpt)
 
 	s.AddTool(mcp.NewTool("corgi_ps",
-		mcp.WithDescription("Runtime snapshot of declared topology with a cheap port-listening probe."),
+		mcp.WithDescription("Runtime snapshot of the detached run: one row per declared service and db_service, {name, kind, port, status, url, startedAt}, reconciled against corgi_services/.state.json with a cheap port-listening check. status is process/container state (running | crashed | stopped), not health — db_services and container-backed services never report crashed. Use corgi_status for liveness. Read-only."),
 		composeOpt,
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
 		return mcpPs(validateArgs{ComposePath: r.GetString("composePath", "")})
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_up",
-		mcp.WithDescription("Start all databases and services DETACHED and return promptly with the run-state."),
+		mcp.WithDescription("Start every database and service detached and return the run-state {services[], dbServices[]} with each entry's name, pid, port, status. Not instant: it clones missing repos, runs every beforeStart (installs, migrations, builds) and brings databases up before returning — minutes on a cold stack. Returning is not a ready gate; poll corgi_status until healthy. Fails with E_ALREADY_RUNNING while a run is live — call corgi_down first. A service that crashed on spawn shows status \"crashed\" in the returned array."),
 		composeOpt,
 		mcp.WithString("profile", mcp.Description(profileDesc)),
 		mcp.WithBoolean("seed", mcp.Description("Seed db_services that have a dump/seed source")),
@@ -1209,14 +1209,14 @@ func registerMCPTools(s *server.MCPServer) {
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_down",
-		mcp.WithDescription("Stop detached services and bring db_service containers down. Idempotent."),
+		mcp.WithDescription("Stop the detached run: end the service processes, run each service's afterStart, bring db_service containers down, clear the run-state. Idempotent — nothing running is a clean no-op. Returns {stopped[], failed[]}."),
 		composeOpt,
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
 		return mcpDown(validateArgs{ComposePath: r.GetString("composePath", "")})
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_logs",
-		mcp.WithDescription("Read the last N lines of a service's newest captured log run."),
+		mcp.WithDescription("Read the last N lines of a service's newest captured log run (capture is on by default for detached runs). Returns {service, lines[]}. Needs a prior corgi_up; a service that never spawned has no log. To wait for a specific line use corgi_wait_for_log instead of polling this. Read-only."),
 		composeOpt,
 		serviceOpt,
 		mcp.WithNumber("lines", mcp.Description("Number of trailing lines (default 200)")),
@@ -1277,7 +1277,7 @@ func registerMCPTools(s *server.MCPServer) {
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_restart",
-		mcp.WithDescription("Stop the detached stack then start it again DETACHED. Returns the new run-state."),
+		mcp.WithDescription("corgi_down then corgi_up in one call; returns the new run-state. Same cost and caveats as corgi_up: beforeStart re-runs unless its cacheKey is warm, and returning is not a ready gate — poll corgi_status."),
 		composeOpt,
 		mcp.WithString("profile", mcp.Description(profileDesc)),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
@@ -1288,7 +1288,7 @@ func registerMCPTools(s *server.MCPServer) {
 	}))
 
 	s.AddTool(mcp.NewTool("corgi_db_query",
-		mcp.WithDescription("Run a single non-interactive query against a running db_service container. Returns {service, output}."),
+		mcp.WithDescription("Run one non-interactive query inside a running db_service container through its driver's own client (psql, redis-cli, mongosh, …); write the query in that client's syntax. Returns {service, output, truncated}. The db_service must already be up (corgi_up). Writes are not blocked — a mutating statement runs. Disabled over a public tunnel unless CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1."),
 		composeOpt,
 		serviceOpt,
 		mcp.WithString("query", mcp.Required(), mcp.Description("Query/command to run (e.g. SQL for psql)")),

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -63,7 +63,7 @@ func registerAgentMCPTools(s *server.MCPServer) {
 		mcp.WithDescription(
 			"Resolve a human name like \"the recipe app\" to one registered workspace. Read-only. "+
 				"Returns either a single workspace or a candidate list — it never guesses, because picking the "+
-				"wrong one means editing the wrong repository. Echo the resolved path back to the user before working."),
+				"wrong one means editing the wrong repository."),
 		mcp.WithString("query", mcp.Required(), mcp.Description("What the user called it")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
 		return mcpWorkspaceResolve(r.GetString("query", ""))
@@ -172,8 +172,7 @@ func registerAgentMCPTools(s *server.MCPServer) {
 			"Open a public tunnel to a running service so the user can watch it on their phone while you edit. "+
 				"Returns immediately with state \"starting\"; poll corgi_preview_state for the URL. "+
 				"The stack must already be up (corgi_up). Refused for a workspace marked sensitive. "+
-				"A quick tunnel's URL changes if it restarts; declare a named tunnel in the service's tunnel: block for a stable one. "+
-				"Prefer corgi_diff when the question is \"what changed\" — it needs no tunnel and survives bad signal."),
+				"A quick tunnel's URL changes if it restarts; declare a named tunnel in the service's tunnel: block for a stable one."),
 		composeOpt,
 		serviceOpt,
 		mcp.WithString("branch", mcp.Description("Branch being previewed, recorded for context")),
@@ -189,8 +188,7 @@ func registerAgentMCPTools(s *server.MCPServer) {
 	s.AddTool(mcp.NewTool("corgi_preview_state",
 		mcp.WithDescription(
 			"State of one preview, or all of them. States: starting (no URL yet), ready, broken (the tunnel is up "+
-				"but nothing answers on the port — usually a build in progress), stopped. "+
-				"Tell the user which state it is in rather than handing over a URL that shows a stack trace."),
+				"but nothing answers on the port — usually a build in progress), stopped. A url is present only in ready."),
 		composeOpt,
 		mcp.WithString("id", mcp.Description("Preview id or service name; omit for all")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
@@ -214,7 +212,7 @@ func registerAgentMCPTools(s *server.MCPServer) {
 
 	s.AddTool(mcp.NewTool("corgi_preview_stop",
 		mcp.WithDescription(
-			"Tear a preview down. Do this when the user is finished — a forgotten preview is a public URL onto seeded data."),
+			"Tear a preview down and close its public URL. An un-stopped preview is reaped after idleMinutes unless frozen."),
 		composeOpt,
 		mcp.WithString("id", mcp.Required(), mcp.Description("Preview id or service name")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {

--- a/cmd/mcp_instructions.go
+++ b/cmd/mcp_instructions.go
@@ -1,0 +1,16 @@
+package cmd
+
+// mcpServerInstructions is handed to every MCP client at initialize. It is the
+// only guidance a client that never loads the corgi skills — the Claude app
+// connector on a phone, a bare MCP inspector — gets before its first call, so
+// it carries the few facts that a tool description alone cannot: which call to
+// make first, what is and is not a ready gate, and what the tunnel gate hides.
+const mcpServerInstructions = `corgi runs a multi-service development stack from one corgi-compose.yml: databases in Docker, service repositories, generated env files with cross-service URLs.
+
+Orient first. corgi_context answers "where am I" in one call (topology, ports, health, each repository's branch). When the user names a stack by a human name, corgi_workspace_resolve maps it to one registered workspace and returns candidates instead of guessing; echo the resolved path before working in it.
+
+corgi_up is always detached and is not a ready gate: it runs every beforeStart (installs, migrations, builds) before returning, which takes minutes on a cold stack, then poll corgi_status until healthy. corgi_status is the only liveness truth; corgi_ps status only says whether a process or container exists. For one service that is down, corgi_why returns a single verdict. To wait for a log line, corgi_wait_for_log blocks instead of polling corgi_logs.
+
+corgi_exec, corgi_db_query, corgi_pr_open, corgi_worktrees_* and corgi_preview_* are refused while the server is reachable over a public tunnel unless CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1 is set on the machine. A workspace marked sensitive refuses remote session start and previews by design.
+
+corgi_diff shows a change without a tunnel or a running stack and is the default way to show work on a bad connection. Stop a preview when the user is done with it; a forgotten preview is a public URL onto seeded data.`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -22,6 +22,16 @@ launches it in. Any tool also accepts an explicit `composePath`.
 stdio is the default and recommended transport for local use — the client owns
 the process lifecycle and nothing is exposed on the network.
 
+## Server instructions
+
+At `initialize` the server sends a short instructions block: which call to make
+first (`corgi_context`, or `corgi_workspace_resolve` for a stack named by a human),
+that `corgi_up` is not a ready gate, that `corgi_status` — not `corgi_ps` — is
+liveness, and which tools the public-tunnel gate refuses. Clients that honour
+instructions (Claude Code, Claude Desktop, the Claude app connector) show it to the
+model before its first tool call, so a client with no corgi skills loaded still gets
+the rules. The plugin's skills carry the same rules in more depth.
+
 ## HTTP transport
 
 Instead of stdio, corgi can serve the same tools/resources over Streamable HTTP:
@@ -95,15 +105,15 @@ still bind to `localhost` or front it with an authenticated proxy.
 | `corgi_plan` | `{composePath?, profile?}` | dry-run plan (`order`, `databases`, `services`, `warnings`) | `computeDryRunPlan` |
 | `corgi_status` | `{composePath?}` | `[{label, port, kind, url, healthy, detail}]` | `collectStatusRows` + `probeAll` |
 | `corgi_env` | `{composePath?}` | `{service: {KEY: {value, source}}}` | `utils.ResolveAllEnv` |
-| `corgi_ps` | `{composePath?}` | `[{name, kind, port, status, url}]` | `buildPsRows` |
+| `corgi_ps` | `{composePath?}` | `[{name, kind, port, status, url, startedAt}]` — `status` is process/container state, not health | `buildPsRows` |
 | `corgi_up` | `{composePath?, profile?, seed?, serviceBranch?, serviceDir?}` | run-state (`services[]`, `dbServices[]`) — **always detached** | run prelude + `runDetached` machinery |
 | `corgi_down` | `{composePath?}` | `{stopped[], failed[]}` | stop machinery (`stopProcessGroup`) |
 | `corgi_logs` | `{service, lines?}` | `{service, lines[]}` | newest captured log run |
-| `corgi_exec` | `{service, command, ensureDeps?, serviceBranch?, serviceDir?}` | `{exitCode, output, durationMs}` | `RunServiceCommandExitCode` (output captured) |
+| `corgi_exec` | `{service, command, ensureDeps?, serviceBranch?, serviceDir?}` | `{exitCode, output, truncated, durationMs}` | `RunServiceCommandExitCode` (output captured) |
 | `corgi_test` | `{composePath?, service?, profile?, ensureDeps?, serviceBranch?, serviceDir?}` | `{services[], passed}` | `runTests` (does not start db/services) |
 | `corgi_doctor` | `{composePath?}` | `{ok, checks[]}` | `buildDoctorResult` (required tools, Docker, ports) |
 | `corgi_restart` | `{composePath?, profile?}` | run-state — **always detached** | `corgi_down` then `corgi_up` |
-| `corgi_db_query` | `{composePath?, service, query}` | `{service, output}` | `utils.ExecDBQueryCapture` (non-interactive) |
+| `corgi_db_query` | `{composePath?, service, query}` | `{service, output, truncated}` | `utils.ExecDBQueryCapture` (non-interactive) |
 | `corgi_schema` | `{}` | the JSON Schema (draft-07) as text | `utils.ComposeJSONSchema` |
 | `corgi_context` | `{composePath?, noGit?}` | topology + status + per-repo git state + tier/profiles + validation | `buildContextReport` |
 | `corgi_why` | `{composePath?, service, logLines?}` | `{verdict, detail, dependencies[], port, lastExitCode, env, logTail[], nextStep}` | `diagnoseService` |

--- a/plugins/corgi/commands/corgi-mobile-screenshots.md
+++ b/plugins/corgi/commands/corgi-mobile-screenshots.md
@@ -12,9 +12,9 @@ before the next:
 
 1. **Capture** the matrix — N screens × iPhone / iPad / Android-phone+tablet × every locale,
    into `/tmp`, then copy into the repo. Drive via deep links + Maestro (the `mobile` skill).
-   Non-negotiables: **one Maestro flow PER SCREEN**; **`takeScreenshot` INSIDE the flow**
+   Non-negotiables: **one Maestro flow per screen**; **`takeScreenshot` inside the flow**
    (a shell shot after captures home — Maestro relaunches); gate home with
-   `extendedWaitUntil` (NOT `assertVisible … timeout`); **double `waitForAnimationToEnd`**
+   `extendedWaitUntil` (not `assertVisible … timeout`); **double `waitForAnimationToEnd`**
    to beat the push-slide; **stage to `/tmp`** so Metro's watcher doesn't hot-reload
    mid-shoot; **stabilize per locale** (terminate+relaunch, hard-reboot if it rots);
    switch locale **in-app** (tap by language autonym); recreate persisted game state per
@@ -33,16 +33,16 @@ before the next:
    into fastlane's per-field `.txt` tree + stages the framed shots. `deliver`
    (`skip_binary_upload`, `submit_for_review: false`) updates the in-flight App Store
    version; `supply` (`skip_upload_apk/aab`, `track: production`, `validate_only` to dry-run)
-   updates the Play listing. **Submit-for-review is opt-in, default OFF** — keep upload and
+   updates the Play listing. **Submit-for-review is opt-in, default off** — keep upload and
    submit as separate targets gated by a flag (`SUBMIT_FOR_REVIEW=1`) so iterating never
    starts the review clock; when submitting, App Store needs `submission_information`
    (`export_compliance_uses_encryption: false`, `add_id_info_uses_idfa: false`) +
    `automatic_release`, Play needs `changes_not_sent_for_review: false`. **iOS auth, no env:**
-   App Store Connect **API key json file** at a gitignored path (no 2FA) — NOT the `altool`
+   App Store Connect **API key json file** at a gitignored path (no 2FA) — not the `altool`
    app-specific password from Keychain, which `deliver` can't use. Map locales per store
    (`ru` → ASC `ru` / Play `ru-RU`).
 
-**Verify before done** — `magick identify` every PNG and **READ a montage** of every
+**Verify before done** — `magick identify` every PNG and **read a montage** of every
 screen × locale (wrong-screen / wrong-language / mid-transition shots all pass a file
 check); **revert the capture-only app edits** (LogBox / resume-to-route / import skips) and
 shut the sims/emulators down; **never commit** the API-key / service-account json.

--- a/plugins/corgi/commands/corgi-mobile.md
+++ b/plugins/corgi/commands/corgi-mobile.md
@@ -15,15 +15,15 @@ Per `plugins/corgi/skills/mobile/SKILL.md`:
 2. **Navigate** — deep link (`adb shell am start … -d "<scheme>://<route>"` /
    `xcrun simctl openurl booted "<scheme>://<route>"`) or Maestro `scrollUntilVisible` +
    `tapOn`.
-3. **Drive + assert** with a Maestro flow **FILE** (`--device <udid>` when two devices
+3. **Drive + assert** with a Maestro flow **file** (`--device <udid>` when two devices
    attached); `screenshot` (`adb … screencap` / `simctl io … screenshot`); crop a detail
-   with `sips`; **READ** the frame.
+   with `sips`; **read** the frame.
 4. **Honor the gotchas** — Maestro `inputText` ASCII-only; local iOS builds run in a
    **non-login shell** with `LANG=en_US.UTF-8` (else the `visionos` pod error, then
    `Encoding::CompatibilityError`); background long builds + poll the log; a Metro
-   `--clear` redbox is usually a STALE desync (cold reload + `tapOn: Dismiss`); a system
-   dialog over the app reads as `element not found` (dismiss the SYSTEM button); SceneKit
-   shader failures + a missing `particleImage` only show at RUNTIME (magenta / square
-   particles) → verify on a sim BEFORE any TestFlight submit.
+   `--clear` redbox is usually a stale desync (cold reload + `tapOn: Dismiss`); a system
+   dialog over the app reads as `element not found` (dismiss the system button); SceneKit
+   shader failures + a missing `particleImage` only show at runtime (magenta / square
+   particles) → verify on a sim before any TestFlight submit.
 5. **Verify before done** — screenshot evidence; native visuals need a real on-device
    render, not just a green build.

--- a/plugins/corgi/commands/corgi-new.md
+++ b/plugins/corgi/commands/corgi-new.md
@@ -12,9 +12,9 @@ Before asking anything, look around:
 - `cat` each service's manifest to infer language/runtime and likely port.
 - Check for existing `.env`, `docker-compose.yml`, `Makefile` — pull defaults from them.
 - Note which service dirs ship a `Dockerfile` or their own compose file — those can run with no `start:` scripts at all (see the rung rule in Step 3).
-- Check for an already-existing `corgi-compose.yml`. If present, stop: ask the user whether they want to edit it (offer `/corgi-add-service` if one day that exists, otherwise read `skills/corgi/references/yml-schema.md` and edit directly) rather than overwrite.
+- Check for an already-existing `corgi-compose.yml`. If present, stop: ask the user whether they want to edit it (read `skills/corgi/references/yml-schema.md` and edit directly; `corgi create` is the interactive editor and needs a TTY) rather than overwrite.
 
-Present what you found in 3–5 bullets. Don't proceed blindly.
+Present what you found before asking anything.
 
 ## Step 2 — Ask only what you can't infer
 

--- a/plugins/corgi/commands/corgi-ship.md
+++ b/plugins/corgi/commands/corgi-ship.md
@@ -10,14 +10,14 @@ Run the **ship** flow for `$ARGUMENTS`.
 
 Per `plugins/corgi/skills/ship/SKILL.md`:
 
-1. **Gate first.** Verify the change on a device + READ a screenshot (the `mobile` skill) —
+1. **Gate first.** Verify the change on a device + read a screenshot (the `mobile` skill) —
    native-invisible changes ship magenta/blank. Tests + lint green. `df -h` for disk.
-2. **Shell + locale.** Build in a NON-LOGIN shell that EXPORTS the locale:
+2. **Shell + locale.** Build in a non-login shell that exports the locale:
    `nohup bash -c 'export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8; make <ship-target>' > build/ship.log 2>&1 &`.
-   The locale must be exported in the PARENT (EAS's nested pod install inherits it), not
+   The locale must be exported in the parent (EAS's nested pod install inherits it), not
    only inline in the Makefile.
-3. **Bump ONCE.** `make ship` bumps the version first; if it dies after the bump, re-run the
-   build+submit targets DIRECTLY (they don't bump) — never `make ship` again.
+3. **Bump once.** `make ship` bumps the version first; if it dies after the bump, re-run the
+   build+submit targets directly (they don't bump) — never `make ship` again.
 4. **Background + poll** the log for `BUILD SUCCEEDED|Submitting|Submitted your app|error:` —
    there is no completion event for the detached build. `stop` → kill
    `xcodebuild|gradle|eas build|eas submit|fastlane`.

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent
-description: Use when working on a corgi stack from a phone or another device through Claude Code Remote Control, or when setting that up — "work on the recipe app", "which stacks do I have", "start a branch across the api and mobile repos", "show me the diff", "keep corgi running when I'm away", "why did my remote session die", "set up agent mode", "notify my phone when a session needs me", "set up telegram notifications", "run it under my work account", "start a session in that repo from my phone", "set up remote session start". Covers resolving a stack by name, materializing one branch across every repository in it, reading a cross-repo diff, supervising `claude remote-control` so it survives reboots and the ten-minute network timeout, and starting/stopping a session in any registered workspace on demand (corgi_session_start, profiles, session URLs). NOT for authoring corgi-compose.yml (corgi skill), starting a stack (run skill), or diagnosing a broken stack (debug skill).
+description: Use when working on a corgi stack from a phone or another device through Claude Code Remote Control, or when setting that up — resolving a stack by name, putting one branch across every repository in it, reading a cross-repo diff, previewing a running service over a tunnel, picking up where a restarted session left off, keeping `claude remote-control` alive across reboots and the ten-minute network timeout, phone notifications (Telegram / Slack / Discord / ntfy), Claude account profiles, and starting or stopping a session in any registered workspace on demand. NOT for authoring corgi-compose.yml (corgi skill), starting a stack (run skill), or diagnosing a broken stack (debug skill).
 ---
 
 # Corgi agent mode
@@ -120,7 +120,18 @@ code.
 
 The existing tools still apply, pointed at the worktree directories:
 `corgi_up`, `corgi_status`, `corgi_logs`, `corgi_test`, `corgi_down`. See the
-`run` and `debug` skills.
+`run` and `debug` skills. The orientation and repair tools work the same way:
+
+- `corgi_context` — one call for topology, ports, health and every repo's branch;
+  make it first in a workspace you have not looked at this session.
+- `corgi_why { service }` — one verdict for a service that is down (dependency,
+  port owner, exit code, env, log tail) instead of reading three snapshots.
+- `corgi_wait_for_log { service, pattern }` — block until a log line matches;
+  never poll `corgi_logs` on a timer.
+- `corgi_checkpoint { name }` / `corgi_restore { name }` — mark every repo's branch,
+  HEAD and uncommitted work before a cross-repo change, and put it all back.
+- `corgi_checkout { branch }` — every repo onto one branch (or its own default),
+  fast-forwarded; dirty repos are skipped, never clobbered.
 
 ## Setting agent mode up
 
@@ -246,7 +257,7 @@ the one to use.
 
 ### If the phone cannot open the launcher
 
-Check these before suspecting corgi — all three have been real:
+Check these before suspecting corgi:
 
 | symptom | cause | say |
 |---|---|---|
@@ -280,7 +291,13 @@ diagnosis the wrong way.
 `corgi agent status` shows `lastReason`, and `corgi agent logs <workspace>`
 (or the `corgi_session_events` tool) shows the whole timeline — every start,
 exit with its classified cause, and captured session link, newest first. Use
-the timeline when the current reason is not enough. The common reasons:
+the timeline when the current reason is not enough.
+
+A restarted session starts with none of the earlier conversation. Call
+`corgi_session_brief { workspace }` first when the user picks up where they left
+off: it reports the branch each repository was on, which held uncommitted
+changes, and which cross-repo worktrees exist. `null` means nothing restarted,
+which is the ordinary case. The common reasons:
 
 | reason | what to say |
 |---|---|

--- a/plugins/corgi/skills/autopilot/SKILL.md
+++ b/plugins/corgi/skills/autopilot/SKILL.md
@@ -30,7 +30,7 @@ Supervised loop. One iteration = one `/corgi-queue` pickup → `stories` (spec g
    - `mode: uninitialized` (no state file yet — genuine **first run**, NOT a stop) → `corgi autopilot resume --json` to init `running`, continue.
    - `mode: running` → continue.
    - `mode: stopped` (kill switch) or `mode: paused` → emit heartbeat noting why, **end the iteration** (no pickup).
-   The `uninitialized` sentinel tells a first run apart from an explicit `stop` — both used to look like `stopped`; don't mistake first run for the kill switch.
+   The `uninitialized` sentinel tells a first run apart from an explicit `stop`; don't mistake first run for the kill switch.
 2. **Workspace + tracker** — as `tracker` Phase 0: `ls corgi-compose.yml *.corgi-compose.yml`; detect Linear/Jira MCP. No compose or no tracker MCP → `corgi autopilot pause` with a note, surface what to connect, stop. Don't guess a layout.
 
 ## Phase 1 — Resolve a batch (delegate to tracker pickup)

--- a/plugins/corgi/skills/ci/SKILL.md
+++ b/plugins/corgi/skills/ci/SKILL.md
@@ -195,14 +195,12 @@ packages instead of starting empty; the markers slot stays exact-match on
 purpose. GitHub also scopes caches per ref — a fresh PR restores only what its
 base branch saved, so a scheduled default-branch run is what keeps new PRs
 warm. Neither a
-workflow expression nor a composite action can loop, so the copies stay — but
-the action warns by itself when an ecosystem does not fit, which used to be a
-hand-written step.
+workflow expression nor a composite action can loop, so the copies stay; the
+action warns by itself when an ecosystem does not fit.
 
-**`corgi cache paths` now says when caching is off.** A workspace where no
+**`corgi cache paths` says when caching is off.** A workspace where no
 service declares a `cacheKey` gets a list of the install steps that could opt
-in, on stderr, naming the lockfile for each. Silence used to be the only signal
-that every CI run was reinstalling everything.
+in, on stderr, naming the lockfile for each.
 
 GitLab cannot read the plan mid-run — its cache config is static YAML — so
 generate it, commit it, and guard it:

--- a/plugins/corgi/skills/corgi/SKILL.md
+++ b/plugins/corgi/skills/corgi/SKILL.md
@@ -17,13 +17,13 @@ Safe synchronous probes:
 - `corgi doctor` (alias `check`) — preflight: tools installed, Docker up, ports free
 - `corgi status` (aliases `health`, `healthcheck`) — post-run: TCP/HTTP probe each port
 
-Both exit 0 on success, 1 on failure. Add global `--json` for machine-readable output. Driving corgi from an agent: see `../../../docs/agents.md`.
+Both exit 0 on success, 1 on failure. Add global `--json` for machine-readable output. Driving corgi from an agent: see `https://github.com/Andriiklymiuk/corgi/blob/main/docs/agents.md`.
 
 ### Driving corgi as an agent
 
-Corgi auto-detects non-interactive mode (CI/agent env vars like `CLAUDECODE`, or no TTY) and errors with exit code 2 instead of prompting; `--interactive` forces prompts back. Global `--json` emits pure JSON on stdout (`doctor`, `status`, `list`, `config`, `ps`, `docs --json-schema`; `run --json` prints a startup summary then streams logs to stderr). Exit codes: 0 success, 1 failure, 2 usage/missing input. Full guide + recipes: `../../../docs/agents.md`.
+Corgi auto-detects non-interactive mode (CI/agent env vars like `CLAUDECODE`, or no TTY) and errors with exit code 2 instead of prompting; `--interactive` forces prompts back. Global `--json` emits pure JSON on stdout (`doctor`, `status`, `list`, `config`, `ps`, `docs --json-schema`; `run --json` prints a startup summary then streams logs to stderr). Exit codes: 0 success, 1 failure, 2 usage/missing input. Full guide + recipes: `https://github.com/Andriiklymiuk/corgi/blob/main/docs/agents.md`.
 
-Detached lifecycle (preferred for agents): `corgi run --detach` (starts services that outlive corgi, returns immediately, errors `ALREADY_RUNNING` if already running — use `--force`), then `corgi ps`/`status` for real running/crashed status, `corgi stop [--service x]` to tear down, `corgi restart` for full-stack restart. See the "Lifecycle (detached)" section in `../../../docs/agents.md`.
+Detached lifecycle (preferred for agents): `corgi run --detach` (starts services that outlive corgi, returns immediately, errors `E_ALREADY_RUNNING` if already running — use `--force`), then `corgi ps`/`status` for real running/crashed status, `corgi stop [--service x]` to tear down, `corgi restart` for full-stack restart. See the "Lifecycle (detached)" section in `https://github.com/Andriiklymiuk/corgi/blob/main/docs/agents.md`.
 
 `corgi tunnel` is also long-running (one tunnel subprocess per service, blocks until Ctrl+C). Background it the same way you background `corgi run`. See `references/long-running.md` if invoking from an agent.
 
@@ -37,11 +37,11 @@ Detached lifecycle (preferred for agents): `corgi run --detach` (starts services
 | Adding `healthCheck:` to a service or db | `references/healthchecks.md` |
 | `corgi doctor` or `corgi run` failed | `references/debugging.md` |
 | Explaining / choosing a CLI flag | `references/commands.md` |
-| Setting up webhook tunnels (Stripe/GitHub/e-sign/etc.) | `../../../docs/tunnel.md` (full) or `references/commands.md#corgi-tunnel-services` |
+| Setting up webhook tunnels (Stripe/GitHub/e-sign/etc.) | `https://github.com/Andriiklymiuk/corgi/blob/main/docs/tunnel.md` (full) or `references/commands.md#corgi-tunnel-services` |
 | Producing a service map / relation diagram for the project | run `/corgi-describe` (see `references/describe-output.md`) |
 | Running `corgi run` inside an agent loop | `references/long-running.md` |
-| Driving corgi non-interactively (`--json`, exit codes, scaffolding flags) | `../../../docs/agents.md` |
-| Driving corgi from an MCP client (Claude Code/Desktop tools) | `../../../docs/mcp.md` |
+| Driving corgi non-interactively (`--json`, exit codes, scaffolding flags) | `https://github.com/Andriiklymiuk/corgi/blob/main/docs/agents.md` |
+| Driving corgi from an MCP client (Claude Code / Desktop / the phone connector) | `references/mcp-tools.md`; transport, auth and tunnels in `https://github.com/Andriiklymiuk/corgi/blob/main/docs/mcp.md` |
 | Persisting / re-reading service logs after a crash | `references/commands.md#corgi-logs` (`corgi run --logs` + `corgi logs`) |
 | Opening a DB shell (psql / redis-cli / mongosh / …) | `references/commands.md#corgi-db-shell-service-name` |
 | Running corgi in CI / disabling spinners and color | `references/commands.md#corgi-run-flags` (`--ci`, auto-detected from `CI` env) |

--- a/plugins/corgi/skills/corgi/references/commands.md
+++ b/plugins/corgi/skills/corgi/references/commands.md
@@ -196,7 +196,7 @@ Compose `services.<name>.tunnel:` block enables named/static mode (stable URL ac
 
 Auth-needing providers (e.g. ngrok) preflight before any tunnel spawns; corgi prints the exact login command and exits without partial state.
 
-Full docs: [docs/tunnel.md](../../../../docs/tunnel.md).
+Full docs: [docs/tunnel.md](https://github.com/Andriiklymiuk/corgi/blob/main/docs/tunnel.md).
 
 ### `corgi init` (aliases: `initialize`, `clone`)
 

--- a/plugins/corgi/skills/corgi/references/db-drivers.md
+++ b/plugins/corgi/skills/corgi/references/db-drivers.md
@@ -47,7 +47,7 @@ No hardcoded host-port default per driver — host port is whatever you set in `
 | `skytable` | 2003 | `SKYTABLE_` | `skytable/skytable:latest` | |
 | `dynamodb` | 4566 | `DYNAMODB_` | `localstack/localstack:3.8` (`SERVICES=dynamodb`) | localstack-backed local emulator |
 | `localstack` | 4566 | `AWS_` | `localstack/localstack:latest` | Unified AWS emulator — see below |
-| `supabase` | 54321 | `SUPABASE_` | wraps `supabase` CLI | Local auth + storage. Reads ports from `supabase/config.toml`. Seeds `buckets:` + `authUsers:` on `up`. See below + [docs/drivers/supabase.md](../../../../docs/drivers/supabase.md) |
+| `supabase` | 54321 | `SUPABASE_` | wraps `supabase` CLI | Local auth + storage. Reads ports from `supabase/config.toml`. Seeds `buckets:` + `authUsers:` on `up`. See below + [docs/drivers/supabase.md](https://github.com/Andriiklymiuk/corgi/blob/main/docs/drivers/supabase.md) |
 | `image` | (you set) | `<SERVICE>_` | (you set via `image:`) | Generic stateless docker-image driver. For services that ship as a public image with no DB/state (gotenberg, mailhog, jaeger). See below |
 
 ## localstack special keys
@@ -109,7 +109,7 @@ required:
     install: [brew install supabase/tap/supabase]
 ```
 
-Full docs: [docs/drivers/supabase.md](../../../../docs/drivers/supabase.md)
+Full docs: [docs/drivers/supabase.md](https://github.com/Andriiklymiuk/corgi/blob/main/docs/drivers/supabase.md)
 
 ## image driver (generic docker image)
 

--- a/plugins/corgi/skills/corgi/references/mcp-tools.md
+++ b/plugins/corgi/skills/corgi/references/mcp-tools.md
@@ -1,0 +1,74 @@
+# corgi MCP tools
+
+`corgi mcp` serves the CLI as MCP tools (stdio by default; `--http` for a phone or a
+remote client). Every tool takes an optional `composePath` (default: cwd). Results are
+JSON; errors carry the same stable `E_*` codes the CLI uses. The server sends these
+rules as its instructions at initialize, so a client with no skills loaded still sees
+them.
+
+## Order of operations
+
+1. `corgi_context` — where am I: topology, ports, health, each repo's branch/dirty
+   state, active tier, profiles, validation. Make it first in a workspace you have
+   not looked at this session.
+2. `corgi_workspace_resolve { query }` when the user names a stack by a human name —
+   returns one workspace or candidates; never guesses. Echo the resolved path back
+   before working in it.
+3. `corgi_up` → poll `corgi_status` → work → `corgi_down`.
+
+## Stack lifecycle
+
+| Tool | Args | Returns | Notes |
+|------|------|---------|-------|
+| `corgi_validate` | `composePath?` | `{ok, errors[], warnings[]}` | static, no side effects |
+| `corgi_plan` | `composePath?, profile?` | `{order, databases, services, warnings}` | dry run |
+| `corgi_doctor` | `composePath?` | `{ok, checks[]}` | required tools, Docker, ports |
+| `corgi_up` | `composePath?, profile?, seed?, serviceBranch?, serviceDir?` | run-state `{services[], dbServices[]}` | **always detached; not a ready gate.** Runs every `beforeStart` before returning — minutes on a cold stack. `E_ALREADY_RUNNING` while a run is live → `corgi_down` first |
+| `corgi_status` | `composePath?` | `[{label, kind, port, url, healthy, detail}]` | **the only liveness truth** — live TCP/HTTP probe. Targets without a declared port are not listed |
+| `corgi_ps` | `composePath?` | `[{name, kind, port, status, url, startedAt}]` | `status` = process/container exists (`running`/`crashed`/`stopped`), not health; db_services and container-backed services never show `crashed` |
+| `corgi_why` | `service, logLines?` | `{verdict, detail, dependencies[], port, lastExitCode, env, logTail[], nextStep}` | one verdict for one down service — use before the ps/status/logs ladder |
+| `corgi_logs` | `service, lines?` | `{service, lines[]}` | newest captured run; needs a prior `corgi_up` |
+| `corgi_wait_for_log` | `service, pattern, timeoutSec?` | `{matched, line, waitedMs}` | **blocks** until a line matches — use instead of polling `corgi_logs` |
+| `corgi_restart` | `composePath?, profile?` | run-state | `corgi_down` + `corgi_up`, same caveats |
+| `corgi_down` | `composePath?` | `{stopped[], failed[]}` | runs `afterStart`, brings dbs down; idempotent |
+| `corgi_env` | `composePath?` | `{service: {KEY: {value, source}}}` | real values — never echo into a transcript |
+| `corgi_exec` | `service, command, ensureDeps?, serviceBranch?, serviceDir?` | `{exitCode, output, truncated, durationMs}` | one-off command in the service's resolved env; **tunnel-gated** |
+| `corgi_test` | `service?, profile?, ensureDeps?, serviceBranch?, serviceDir?` | `{services[], passed}` | runs each `test` script; starts nothing |
+| `corgi_db_query` | `service, query` | `{service, output, truncated}` | driver's own client syntax; writes are not blocked; **tunnel-gated** |
+| `corgi_schema` | — | JSON Schema text | also the `corgi://schema` resource |
+
+## Repositories
+
+| Tool | Args | Returns | Notes |
+|------|------|---------|-------|
+| `corgi_checkout` | `branch?, allowDirty?` | `[{name, branch, status, usedDefaultBranch, message}]` | every repo onto one branch (or its own default), fast-forwarded; dirty repos skipped |
+| `corgi_checkpoint` | `name?` | `{name, createdAt, repos[]}` | records branch, HEAD and uncommitted work per repo |
+| `corgi_restore` | `name` | `{checkpoint, safetyCheckpoint, restored[], failed[]}` | current uncommitted work is checkpointed first |
+| `corgi_worktrees_materialize` | `branch, services?` | one entry per service with `dir` | one shared branch across every repo; **edit in the returned `dir`**, not the user's checkout; **tunnel-gated** |
+| `corgi_diff` | `base?, branch?, includePatch?` | per-repo diff | read-only, no tunnel, no running stack — the default way to show a change on a bad connection |
+| `corgi_pr_open` | `branch, title, body?, base?, draft?` | one PR per repo with commits | pushes, calls `gh`/`glab`, cross-links siblings; **tunnel-gated** |
+| `corgi_worktrees_release` | `branch, force?` | removed/kept | keeps a worktree with uncommitted changes unless `force`; **tunnel-gated** |
+
+## Agent mode (Remote Control)
+
+| Tool | Args | Returns | Notes |
+|------|------|---------|-------|
+| `corgi_workspaces` | — | registered stacks with `status` (`ok`/`unreachable`/`disabled`) | |
+| `corgi_workspace_resolve` | `query` | one workspace or candidates | never guesses |
+| `corgi_agent_status` | — | daemon health, per-workspace session, restarts, wake lock, account | answers "is it up" / "why did it die" |
+| `corgi_session_start` | `workspace, profile?, name?` | `state: starting` | poll `corgi_agent_status` for `running` + `sessionUrl`; idempotent |
+| `corgi_session_stop` | `workspace` | `state: stopping` | stopping a non-running workspace is a no-op |
+| `corgi_session_events` | `workspace, limit?` | timeline, newest first | starts, exits with cause, session links; never session output |
+| `corgi_session_brief` | `workspace?` | previous session's branches / dirty repos / worktrees, or `null` | call first when the user resumes after a restart |
+| `corgi_preview_start` | `service, branch?, provider?, idleMinutes?` | `state: starting` | public tunnel to a running service; refused for `sensitive`; **tunnel-gated** |
+| `corgi_preview_state` | `id?` | `starting` / `ready` (has `url`) / `broken` / `stopped` | `broken` = tunnel up, port silent — usually a build |
+| `corgi_preview_freeze` | `id, frozen?` | — | pin against idle reaping; **tunnel-gated** |
+| `corgi_preview_stop` | `id` | — | close the public URL when the user is done; **tunnel-gated** |
+
+## The tunnel gate
+
+Over a public tunnel the mutating tools (`corgi_exec`, `corgi_db_query`, `corgi_pr_open`,
+`corgi_worktrees_*`, `corgi_preview_*`) return an error unless
+`CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1` is set on the server's machine. Read-only tools and
+session start/stop stay available; a workspace marked `sensitive` refuses remote start and
+previews regardless.

--- a/plugins/corgi/skills/debug/SKILL.md
+++ b/plugins/corgi/skills/debug/SKILL.md
@@ -63,7 +63,7 @@ run this **before** the ladder. It is the whole of Steps 0–2 for one service, 
 one call:
 
 ```
-corgi why api --json
+corgi why api --json        # MCP: corgi_why { service: "api" }
 ```
 
 Returns a single `verdict` plus the evidence behind it: unmet `dependencies`,
@@ -88,7 +88,7 @@ If `why` does not explain it, fall through to the ladder below.
 ## Step 0 — Snapshot (broken-stack mode)
 
 ```
-corgi context --json   # orientation in one call: topology, ports, status, each repo's branch/dirty, tier, validation
+corgi context --json   # orientation in one call: topology, ports, status, each repo's branch/dirty, tier, validation (MCP: corgi_context)
 corgi ps --json        # name/kind/port/status/url (+ startedAt); reconciles corgi_services/.state.json
 corgi status --json    # live TCP/HTTP probe — the ONLY liveness truth
 # uptime = startedAt from `corgi ps --json`; an older corgi omits it → cat corgi_services/.state.json

--- a/plugins/corgi/skills/mobile-screenshots/SKILL.md
+++ b/plugins/corgi/skills/mobile-screenshots/SKILL.md
@@ -10,7 +10,7 @@ Goal isn't "a screenshot" — it's **N screens × every device class × every lo
 **framed** (device mockup + headline + bg), at **exact store sizes**, optionally
 **uploaded**. Four stages: **capture → frame → export → upload**. Driving one device is
 the [`mobile`](../mobile/SKILL.md) skill; this is the matrix + the store pipeline on top.
-Every quirk below cost a real session — honor them or re-shoot.
+Skip a quirk below and you re-shoot.
 
 Pipeline at a glance:
 1. **Capture** raw app screens — per screen, per locale, per device — into `/tmp`, then copy into the repo.
@@ -22,22 +22,22 @@ Pipeline at a glance:
 Drive via deep links + Maestro (see the `mobile` skill). The store twist is reliability
 across a long run of many screens × locales × devices.
 
-**The capture recipe that actually holds (learned the hard way):**
-- **One Maestro flow PER SCREEN.** Multiple screens in one flow lag/scramble — screen N's
+**The capture recipe:**
+- **One Maestro flow per screen.** Multiple screens in one flow lag/scramble — screen N's
   shot lands on screen N-1, or two adjacent screens swap. One screen, one `maestro test`.
-- **`takeScreenshot` INSIDE the flow**, not a shell screenshot after. Maestro relaunches
+- **`takeScreenshot` inside the flow**, not a shell screenshot after. Maestro relaunches
   the app to home on test exit → a `simctl io … screenshot` / `adb … screencap` taken
   after the flow captures **home**. Keep the shot in the flow.
 - **Gate home before navigating** with `extendedWaitUntil` on a locale-neutral home anchor
-  (the app name shows on home in every language). `assertVisible` does NOT take a `timeout`
+  (the app name shows on home in every language). `assertVisible` does not take a `timeout`
   in current Maestro ("Unknown Property: timeout") — use `extendedWaitUntil { visible, timeout }`.
-- **Beat the push-slide with a DOUBLE `waitForAnimationToEnd`.** The first returns before
+- **Beat the push-slide with a double `waitForAnimationToEnd`.** The first returns before
   the slide even starts (catches a mid-transition frame, prev screen peeking at the edge);
   the second waits the slide out.
 - **Write shots to `/tmp`, copy into the repo only after.** Writing PNGs inside the Expo
   project trips **Metro's file-watcher → a "Refreshing…" hot reload mid-capture** that
   corrupts the next screens. Or add the screenshots dir to `metro.config` `watchFolders`/blocklist.
-- **Stabilize PER LOCALE** (terminate + relaunch the app, wait ~12–18s). Sims/emulators
+- **Stabilize per locale** (terminate + relaunch the app, wait ~12–18s). Sims/emulators
   **degrade over a long run** — snaps start failing (empty/MISSING), corrupt PNGs, or
   leaking home/settings. A fresh app per locale resets it. If even one locale still rots,
   hard-reboot the device (`simctl shutdown`+`boot`).
@@ -47,8 +47,8 @@ across a long run of many screens × locales × devices.
 - **Locale switch is in-app**, not external — the locale store is MMKV (not writable from
   the host). Open Settings, tap the language. **Language autonyms are stable across
   locales** (e.g. "Français" reads the same in every UI language) → tap by autonym.
-- **If the locale store IS host-writable (AsyncStorage/zustand-persist), bake the locale
-  into the relaunch instead.** A FRESH mount renders **native tab-bar labels** (`NativeTabs`)
+- **If the locale store is host-writable (AsyncStorage/zustand-persist), bake the locale
+  into the relaunch instead.** A fresh mount renders **native tab-bar labels** (`NativeTabs`)
   in the target language; an in-app switch updates the JS content but leaves NativeTabs'
   **cached native labels stale** (mixed-language tab bar in the shot). Set the persisted
   locale key in the same manifest patch as the seed (below), then relaunch.
@@ -88,7 +88,7 @@ Metro **cold restart**. Patch the persisted store from the host instead, then re
 - **Horizontal pickers (dice die-row) scroll only in their own zone** — swipe across the
   pills' x-range, not over the stepper, or it's a no-op and a clipped option's tap lands on
   the wrong control. On wide screens (iPad/tablet) all options show → no swipe needed.
-- **Android tablet emulators boot LANDSCAPE** + show a persistent **launcher taskbar**.
+- **Android tablet emulators boot landscape** + show a persistent **launcher taskbar**.
   `adb -s <dev> emu rotate` → portrait (modern AVDs resist; set `hw.initialOrientation=portrait`
   in the AVD `config.ini`). The taskbar can't be hidden via `policy_control`; app content
   lays out **above** that inset, so **chop a fixed bottom band (~130px) in post** — removes
@@ -106,7 +106,7 @@ Metro **cold restart**. Patch the persisted store from the host instead, then re
   SpringBoard **"Open?"** confirm (Maestro `tapOn` the localized "Open"). Plain
   `simctl launch` **reuses the cached bundle** — it won't pick up a new route / fresh JS.
 
-**Temporary app edits for clean DEV captures (revert after, flag to the user):**
+**Temporary app edits for clean dev captures (revert after, flag to the user):**
 - Silence the dev LogBox toast: `LogBox.ignoreAllLogs(true)` at the entry.
 - If a screen lazy-`import()`s a native module whose async chunk doesn't resolve in dev,
   it redboxes — guard/skip that import for captures.
@@ -116,7 +116,7 @@ Metro **cold restart**. Patch the persisted store from the host instead, then re
 
 ## 2 · Frame — the app-store-screenshots editor skill
 Don't hand-roll device frames + headline layout. Use the **app-store-screenshots** skill
-(`ParthJadhav/app-store-screenshots` on GitHub — the one we used) — it scaffolds a Next.js
+(`ParthJadhav/app-store-screenshots` on GitHub) — it scaffolds a Next.js
 + ShadCN editor that holds a phone/tablet mockup, localized headlines, theme/background,
 and a one-click bundle export at every store size.
 Drop the raw captures into its `public/screenshots/<platform>/<device>/{locale}/NN.png`,
@@ -146,7 +146,7 @@ deliver** (App Store) / **supply** (Play). Stage the framed shots + parsed listi
 into fastlane's layout, then run the lane. Same idea as a `make submit`, for media+text.
 
 **Author the listings as one markdown file per locale** (`store-listings/{en,ru,uk,fr}.md`),
-NOT straight into fastlane's `metadata/<locale>/*.txt` tree. The MD is the human-editable
+not straight into fastlane's `metadata/<locale>/*.txt` tree. The MD is the human-editable
 source of truth — App Store name / subtitle / keywords / promo / description + Play title /
 short / full, all in one reviewable file per language. A small staging script
 (`stage-store-assets.mjs`) parses each MD **positionally** (fixed heading order) and writes
@@ -155,30 +155,30 @@ fastlane's many tiny per-field `.txt` files + copies the framed shots into
 diff per locale beats hand-editing a dozen `.txt` files; keep keys at parity across locales
 (same idea as the app's i18n `en/ru/uk/fr` parity).
 
-- **App Store** — `deliver(skip_binary_upload: true, submit_for_review: false, overwrite_screenshots: true, sync_screenshots: true, force: true)` updates the **currently editable / in-flight version** (App Store now needs only iPhone 6.9" + iPad 13" sets). It does NOT submit — the user presses Submit.
+- **App Store** — `deliver(skip_binary_upload: true, submit_for_review: false, overwrite_screenshots: true, sync_screenshots: true, force: true)` updates the **currently editable / in-flight version** (App Store now needs only iPhone 6.9" + iPad 13" sets). It does not submit — the user presses Submit.
 - **Play** — `supply(skip_upload_apk: true, skip_upload_aab: true, track: "production")` updates the **main store listing** (title/short/full + phone & tablet shots). `validate_only: true` for a dry run first. Screenshots go in `metadata/android/<locale>/images/{phoneScreenshots,tenInchScreenshots}/`.
-- **Auth, no env (preferred):** App Store Connect **API key json file** at a fixed gitignored path → fastlane reads it, **no 2FA**. Fallbacks: `ASC_*` env (CI), then Apple-ID via Keychain (`fastlane fastlane-credentials add` — the **real** password + a cached 2FA session; this is NOT the app-specific password `altool` keeps in Keychain, `deliver`/spaceship can't use that). Play: a service-account json (file or env).
-- **Keychain beats a plaintext key file — but store it base64.** Safer than a gitignored `.p8`/json on disk: keep the key in the macOS Keychain, inject per-run (`ASC_KEY_CONTENT` env + `is_key_content_base64: true`). **Store base64, NOT the raw PEM** — `security -w` returns a multi-line PEM as HEX, and `app_store_connect_api_key` then dies `invalid curve name (OpenSSL::PKey::ECError)`. `base64 <key.p8 | tr -d '\n'` stays single-line printable → round-trips clean. The key is **account/team-level** (one issuer per team) → store ONCE; one shared Keychain item serves every app in the team. `issuer_id` is the UUID at the top of ASC → Users and Access → Integrations → App Store Connect API, **not** the key's name.
+- **Auth, no env (preferred):** App Store Connect **API key json file** at a fixed gitignored path → fastlane reads it, **no 2FA**. Fallbacks: `ASC_*` env (CI), then Apple-ID via Keychain (`fastlane fastlane-credentials add` — the **real** password + a cached 2FA session; this is not the app-specific password `altool` keeps in Keychain, `deliver`/spaceship can't use that). Play: a service-account json (file or env).
+- **Keychain beats a plaintext key file — but store it base64.** Safer than a gitignored `.p8`/json on disk: keep the key in the macOS Keychain, inject per-run (`ASC_KEY_CONTENT` env + `is_key_content_base64: true`). **Store base64, not the raw PEM** — `security -w` returns a multi-line PEM as HEX, and `app_store_connect_api_key` then dies `invalid curve name (OpenSSL::PKey::ECError)`. `base64 <key.p8 | tr -d '\n'` stays single-line printable → round-trips clean. The key is **account/team-level** (one issuer per team) → store once; one shared Keychain item serves every app in the team. `issuer_id` is the UUID at the top of ASC → Users and Access → Integrations → App Store Connect API, **not** the key's name.
 - **Locale codes differ per store** — map your app locales to ASC vs Play codes (e.g. `ru` → App Store `ru`, Play `ru-RU`; `en` → `en-US`/`en-US`). Get it wrong and the upload no-ops or mis-files.
-- **`deliver` REPLACES all screenshots for the sizes you send** (`overwrite`/`sync`) — send the full set per display family, not a partial.
-- **Submit-for-review is opt-in, default OFF.** Upload-only lands the changes in the editable App Store version / staged Play listing; you press Submit by hand. Gate the actual review submit behind a flag (e.g. `SUBMIT_FOR_REVIEW=1` → a separate `*Submit*` target), so iterating on the listing never trips the review clock. When you DO submit: App Store `deliver(submit_for_review: true)` needs the review questions answered up front (`submission_information` `export_compliance_uses_encryption: false`, `add_id_info_uses_idfa: false`) or it stalls, and `automatic_release` decides auto-vs-manual release on approval; Play's analog is `supply(changes_not_sent_for_review: false)` to send the staged listing changes for review.
-- **"Invalid screen size" on a size you KNOW is current = stale fastlane.** New device slots ship in `deliver` releases; an old fastlane rejects a valid current size (e.g. iPhone 6.9" 1320×2868) it doesn't recognize. Upgrade fastlane before doubting the shot.
-- **Don't push the App Store NAME by default.** The title is globally unique + account-locked; `deliver` setting `name` fails `the app name ... already being used ... on a different account - /data/attributes/name` if anyone else owns it. Gate the `name.txt` write behind a flag (`ASC_SET_NAME=1`); set the title in App Store Connect directly. Subtitle/keywords/promo/description still upload.
-- **A brand-new app's FIRST version "No data"-crashes the metadata pass.** `deliver` calls `fetch_app_store_review_detail`, which raises `No data (RuntimeError)` before screenshots upload until the review-detail object exists. Fill **App Review Information** in ASC once, OR push screenshots-only with `skip_metadata: true`.
+- **`deliver` replaces all screenshots for the sizes you send** (`overwrite`/`sync`) — send the full set per display family, not a partial.
+- **Submit-for-review is opt-in, default off.** Upload-only lands the changes in the editable App Store version / staged Play listing; you press Submit by hand. Gate the actual review submit behind a flag (e.g. `SUBMIT_FOR_REVIEW=1` → a separate `*Submit*` target), so iterating on the listing never trips the review clock. When you do submit: App Store `deliver(submit_for_review: true)` needs the review questions answered up front (`submission_information` `export_compliance_uses_encryption: false`, `add_id_info_uses_idfa: false`) or it stalls, and `automatic_release` decides auto-vs-manual release on approval; Play's analog is `supply(changes_not_sent_for_review: false)` to send the staged listing changes for review.
+- **"Invalid screen size" on a size you know is current = stale fastlane.** New device slots ship in `deliver` releases; an old fastlane rejects a valid current size (e.g. iPhone 6.9" 1320×2868) it doesn't recognize. Upgrade fastlane before doubting the shot.
+- **Don't push the App Store name by default.** The title is globally unique + account-locked; `deliver` setting `name` fails `the app name ... already being used ... on a different account - /data/attributes/name` if anyone else owns it. Gate the `name.txt` write behind a flag (`ASC_SET_NAME=1`); set the title in App Store Connect directly. Subtitle/keywords/promo/description still upload.
+- **A brand-new app's first version "No data"-crashes the metadata pass.** `deliver` calls `fetch_app_store_review_detail`, which raises `No data (RuntimeError)` before screenshots upload until the review-detail object exists. Fill **App Review Information** in ASC once, or push screenshots-only with `skip_metadata: true`.
 - **`sync_screenshots` is beta-gated** — `deliver` refuses it unless `FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS` is set; export it in the lane.
 - **Listing fields have hard length caps — validate before upload.** App Store: name/subtitle ≤30, keywords ≤100, promo ≤170 chars; `deliver` aborts `An attribute value is too long ... cannot be longer than 100 characters - /data/attributes/keywords`. Localized listings carry localized field *labels*, so measure **positionally** (the Nth App Store block), not by the English label — else non-`en` locales slip past unchecked.
 - **A 500 loop on screenshot upload is ASC being flaky, not you.** `deliver` repeats `Waiting for screenshots to appear ... Server error got 500`; name + metadata already committed, so just re-run screenshots-only later (deliver itself notes only a 503 self-recovers).
 - **Staging App Review Info via fastlane writes the phone (PII) into `metadata/review_information/` — keep that subdir out of git** (pull the phone from the Keychain, not a committed file). Repos differ on whether `metadata/` is committed or gitignored, so ignore **only** `review_information/`, not all of `metadata/`, or you break a repo that commits its listing text. Trap: `.gitignore` has **no inline comments** — a `path/ # note` line silently fails to ignore, leaking the file; put the comment on its own line.
-- **The submission-required listing fields deliver CAN set — stage them or "Add for Review" stays blocked.** Per-locale `support_url.txt` + `marketing_url.txt` (version-level) and `privacy_url.txt` (app-info-level) under `metadata/<locale>/`, plus app-level `metadata/copyright.txt` and `metadata/primary_category.txt`. Miss the support URL and ASC blocks submission with a per-locale "Support URL must be filled". `primary_category` takes the **API enum** (`HEALTH_AND_FITNESS`, `ENTERTAINMENT`, `UTILITIES`, …), not a display name. (Age rating, pricing, and the App Privacy data questionnaire are NOT deliver-settable — ASC UI only.)
-- **A login-less app still draws a Guideline 2.1 demo-account rejection** — Apple's automated check sees "login" and rejects for a missing demo account. Stage `metadata/review_information/notes.txt` that states plainly there's no account/login, as **natural prose, not a checklist**, leading with WHY the app exists + the value/problem it solves, then: external services = none, no paid/subscriptions/UGC, each permission explained, same in all regions, tested on a physical device. Notes help future/auto submissions — but `deliver` can NOT reply in Resolution Center or attach the **screen recording** Apple demands, so the rejection reply stays manual.
-- **fastlane rewrites `fastlane/README.md` (its action docs) on EVERY run** — clobbering a hand-written README and churning git each deploy. Gitignore `fastlane/README.md` (keep any custom doc under a different name).
+- **The submission-required listing fields deliver can set — stage them or "Add for Review" stays blocked.** Per-locale `support_url.txt` + `marketing_url.txt` (version-level) and `privacy_url.txt` (app-info-level) under `metadata/<locale>/`, plus app-level `metadata/copyright.txt` and `metadata/primary_category.txt`. Miss the support URL and ASC blocks submission with a per-locale "Support URL must be filled". `primary_category` takes the **API enum** (`HEALTH_AND_FITNESS`, `ENTERTAINMENT`, `UTILITIES`, …), not a display name. (Age rating, pricing, and the App Privacy data questionnaire are not deliver-settable — ASC UI only.)
+- **A login-less app still draws a Guideline 2.1 demo-account rejection** — Apple's automated check sees "login" and rejects for a missing demo account. Stage `metadata/review_information/notes.txt` that states plainly there's no account/login, as **natural prose, not a checklist**, leading with why the app exists + the value/problem it solves, then: external services = none, no paid/subscriptions/UGC, each permission explained, same in all regions, tested on a physical device. Notes help future/auto submissions — but `deliver` can not reply in Resolution Center or attach the **screen recording** Apple demands, so the rejection reply stays manual.
+- **fastlane rewrites `fastlane/README.md` (its action docs) on every run** — clobbering a hand-written README and churning git each deploy. Gitignore `fastlane/README.md` (keep any custom doc under a different name).
 
 ## Guardrails
 - Capture, frame, export, upload are **separate** — verify each before the next. A scrambled
   capture frames a scrambled slide; a wrong-size export rejects at upload.
 - **Validate every PNG** (`magick identify`) — "ok" must mean a fresh, valid frame, not a
   stale/half-written file that happens to be valid.
-- **READ the montages** (`magick montage`, downscale tall shots with `sips -Z`). Eyeball
+- **Read the montages** (`magick montage`, downscale tall shots with `sips -Z`). Eyeball
   every screen × locale before declaring done — wrong-screen, wrong-language, and
   mid-transition shots all pass a file check.
 - **Revert the capture-only app edits** (LogBox / resume / import skips) and shut the
@@ -198,7 +198,7 @@ diff per locale beats hand-editing a dozen `.txt` files; keep keys at parity acr
 - `deliver` "Invalid screen size" on a current slot → stale fastlane; upgrade it.
 - `deliver` "app name already used on a different account" → stop pushing `name`; set the title in ASC.
 - `No data (RuntimeError)` on a first-ever version → fill App Review Information in ASC, or `skip_metadata` for screenshots-only.
-- `deliver` "attribute value is too long / cannot be longer than N characters" → a listing field over cap; trim it and re-check EVERY locale positionally (localized labels hide the overflow).
+- `deliver` "attribute value is too long / cannot be longer than N characters" → a listing field over cap; trim it and re-check every locale positionally (localized labels hide the overflow).
 - `deliver` looping `Server error got 500` on screenshots → transient ASC; re-run later, don't touch config.
 - `.gitignore` line with an inline `# comment` → git ignores nothing on it; a staged secret/PII (App Review phone, keys) sneaks into the commit. Comment on its own line.
 - ASC "Support URL must be filled" / "Add for Review" greyed out → stage support/marketing/privacy URLs + copyright + primary_category; age-rating/pricing/App-Privacy are ASC-UI only.
@@ -212,7 +212,7 @@ diff per locale beats hand-editing a dozen `.txt` files; keep keys at parity acr
 - **[`design-parity`](../design-parity/SKILL.md)** — the other reason to capture: proving a
   screen matches its design (frames pulled to the repo, labelled side-by-sides, deviation
   table). Store screenshots sell the app; design parity proves it was built as drawn.
-- **app-store-screenshots** skill (external — `ParthJadhav/app-store-screenshots`, the one
-  we used) — the Next.js framing editor + Export-bundle that does stages 2–3 (device frame,
+- **app-store-screenshots** skill (external — `ParthJadhav/app-store-screenshots`) — the
+  Next.js framing editor + Export-bundle that does stages 2–3 (device frame,
   localized headline, background, and rendering every store size). Drive its export headless
   for stage 3's `bun export`.

--- a/plugins/corgi/skills/mobile/SKILL.md
+++ b/plugins/corgi/skills/mobile/SKILL.md
@@ -6,67 +6,66 @@ description: Use when verifying a mobile (Expo / React Native) change on a real 
 # Verify mobile change on device
 
 ## Overview
-Change NOT done till you DROVE on device + READ screenshot. Green build still render
-magenta. Pick surface → navigate → drive+assert Maestro → screenshot → look. Evidence
-before "works".
+A change is not done until you drove it on a device and read the screenshot. A green
+build can still render magenta. Pick surface → navigate → drive+assert Maestro →
+screenshot → look. Evidence before "works".
 
 ## Pick surface first
-- **JS / TS / Skia / RN styles / shaders** → hot-reload over Metro. Use **Android
+- **JS / TS / Skia / RN styles / shaders** → hot-reload over Metro. Use the **Android
   emulator** — fastest, no rebuild. Edit, save, live.
-- **Native (Swift / Kotlin / SceneKit / new native dep / config plugin)** → NO hot-reload.
-  Rebuild (`expo run:ios` / `expo run:android`) to see. JS reload won't.
+- **Native (Swift / Kotlin / SceneKit / new native dep / config plugin)** → no hot-reload.
+  Rebuild (`expo run:ios` / `expo run:android`) to see it. A JS reload won't.
 - One Metro serves both Android + iOS; `expo run:*` reuses a running one.
-- **Fast ≠ representative — a JS/style edit still renders DIFFERENTLY iOS↔Android.** Absolute
-  positioning, `overflow`/clipping, font metrics, shadows and safe-area diverge per platform
-  (this is exactly how an Android-only run ships an iOS-only clip / mis-centre / cut-off).
-  The Android emulator is the fast inner loop; for any shape- or layout-sensitive change,
-  spot-check the SAME screen on the iOS sim before you trust it or ship — don't conclude
-  from one platform.
+- **Fast ≠ representative — a JS/style edit still renders differently on iOS and Android.**
+  Absolute positioning, `overflow`/clipping, font metrics, shadows and safe-area diverge
+  per platform, which is how an Android-only run ships an iOS-only clip / mis-centre /
+  cut-off. The Android emulator is the fast inner loop; for any shape- or layout-sensitive
+  change, spot-check the same screen on the iOS sim before you trust it or ship.
 
 ## Drive loop
 1. **Navigate** — deep link beats menu-tapping:
    - Android `adb shell am start -a android.intent.action.VIEW -d "<scheme>://<route>" <pkg>`
    - iOS `xcrun simctl openurl booted "<scheme>://<route>"`
    - or Maestro `scrollUntilVisible` + `tapOn`.
-2. **Drive+assert Maestro** — flow MUST be a FILE (no stdin `-`). Two devices attached
+2. **Drive+assert Maestro** — **flow must be a file** (no stdin `-`). Two devices attached
    (emulator + sim) → pass `--device <udid | emulator-5554>`. Tools: `tapOn:` text or
    `point: "50%,40%"`, `scrollUntilVisible`, `waitForAnimationToEnd`, `takeScreenshot`.
 3. **Screenshot** — `adb exec-out screencap -p > f.png` / `xcrun simctl io booted
    screenshot f.png`. Zoom detail: `sips -c <H> <W> --cropOffset <top> <left> f.png --out
    crop.png`.
-4. **READ it.** Never assert "renders fine" on a frame you didn't open. Design
-   reference at hand (Figma export, ticket mockup / bug screenshot) → Read it NEXT
+4. **Read it.** Never assert "renders fine" on a frame you didn't open. Design
+   reference at hand (Figma export, ticket mockup / bug screenshot) → Read it next
    to the capture and compare spacing / colour / type / icons — "renders" ≠
-   "matches design". A change that HAS a design behind it wants the full
+   "matches design". A change that has a design behind it wants the full
    pull-design → capture-same-states → labelled side-by-side → deviation-table pass:
    **[`design-parity`](../design-parity/SKILL.md)**.
-5. **Geometry bug? MEASURE, don't eyeball.** A wrong shape (circle gone square,
-   clipped / oval disc, mis-aligned pill, off-centre number) is INVISIBLE at
+5. **Geometry bug? Measure, don't eyeball.** A wrong shape (circle gone square,
+   clipped / oval disc, mis-aligned pill, off-centre number) is invisible at
    full-frame scale — confirm it by the node's real box, not by squinting:
    - Android: `adb shell uiautomator dump /sdcard/u.xml && adb pull /sdcard/u.xml .`,
      then grep `content-desc="…" …bounds="[x1,y1][x2,y2]"` — `x2-x1` / `y2-y1` is
      the true px size (a square where you want a circle, or a cell far larger than
      its disc, is the tell).
-   - Crop + UPSCALE that box: `sips -c <h> <w> --cropOffset <top> <left> f.png --out
+   - Crop + upscale that box: `sips -c <h> <w> --cropOffset <top> <left> f.png --out
      c.png && sips -z <H> <W> c.png` (then open `c.png`).
-   - Re-toggle the state and re-measure: a bug that only shows AFTER a state change
+   - Re-toggle the state and re-measure: a bug that only shows after a state change
      (a freshly-toggled day) won't appear on first paint.
-6. **Mutating action? Confirm it PERSISTED.** After a tap that writes state (toggle a
-   day, save a value), re-open the screen — or a DIFFERENT view of the same data — and
+6. **Mutating action? Confirm it persisted.** After a tap that writes state (toggle a
+   day, save a value), re-open the screen — or a different view of the same data — and
    check the change is still there. The optimistic first frame can lie; the round-trip
    through the store is the proof it actually wrote.
-7. **Setting that drives output? CHANGE it and watch the value RECOMPUTE.** Don't just
+7. **Setting that drives output? Change it and watch the value recompute.** Don't just
    confirm a setting saved — change it and verify every dependent screen moves (the
    countdown, the prediction, the badge, the chart). If the setting "saves" but the output
-   doesn't budge, a DERIVED value is overriding it — a history/auto average, a cached
+   doesn't budge, a derived value is overriding it — a history/auto average, a cached
    default, something computed from the data instead of from the setting. That silent
    override (the setting only *looks* applied) is a common, screenshot-invisible bug, and
    the on-device before/after is the only proof. The fix is usually to make the screen read
    the setting directly and surface the computed value as a *suggestion*, not an override.
 
-## Gotchas (each bit a real session)
+## Gotchas
 - **A feature behind a flag, or with no seeded data, can't be driven — force it locally,
-  then revert.** Waiting for the flag/data means the UI ships unverified. Add ONE obvious
+  then revert.** Waiting for the flag/data means the UI ships unverified. Add one obvious
   constant that turns the feature on and fakes the missing values (dates, counters, a
   "delivered" state), shoot every state by flipping it, then **revert and grep for it before
   committing** — a preview constant left on ships the unreleased feature to everyone. Check
@@ -74,15 +73,15 @@ before "works".
   and you already know you're on this path. Seeding real data through the admin/API beats it
   whenever that's available.
 - **Manual-layout text clips in two classic ways.** A fit-to-content sizing call collapses a
-  multi-line label to ONE line (the tail truncates) — measure with a **width-constrained**
-  fit and set the height from that. And a padded/inset label often does NOT count its insets
+  multi-line label to one line (the tail truncates) — measure with a **width-constrained**
+  fit and set the height from that. And a padded/inset label often does not count its insets
   in the measured size, so a chip cuts its own text ("5 da…") — add the padding by hand.
   Both look fine in code review and only show in a screenshot you read.
 - **A nil value formatted into a sentence prints the gap** — "From the ", "publish X from
   to get…", a double space. Hide the whole line/clause when the value is missing (a separate
   string variant for it), instead of interpolating an empty placeholder. Real data usually
   has the value, so this only ever surfaces on the edge case your users hit.
-- **Maestro WEB mode must run `--headless` locally.** Headed launches the *system* Chrome,
+- **Maestro web mode must run `--headless` locally.** Headed launches the *system* Chrome,
   so if the developer already has Chrome open, Chrome's single-instance handoff leaves the
   driver attached to a blank `data:,` tab it cannot measure — the run dies before it ever
   navigates, with `NullPointerException: null cannot be cast to non-null type kotlin.Int at
@@ -96,109 +95,109 @@ before "works".
   via `adb`. Prove cross-locale: type a Latin word matching only via another locale's
   string.
 - **A fixed-coordinate tap on a CTA misses after the screen reflows.** Tapping a remembered
-  `(x,y)` for "Start" / "Submit" / "Continue" lands on the WRONG control once selecting an
-  option REMOVED a line above it (a "need ≥2 players" warning clears, a validation row
-  disappears) — the button shifted UP, your tap hits whatever is now there (often a
+  `(x,y)` for "Start" / "Submit" / "Continue" lands on the wrong control once selecting an
+  option removed a line above it (a "need ≥2 players" warning clears, a validation row
+  disappears) — the button shifted up, your tap hits whatever is now there (often a
   destructive "Leave" / "Cancel" below it), and the flow silently resets. Re-read the
-  node's REAL bounds AFTER the state change (`uiautomator dump` + grep the `text=` bounds,
+  node's real bounds after the state change (`uiautomator dump` + grep the `text=` bounds,
   or Maestro `tapOn:` by text), never reuse pre-change coordinates across a mutating tap.
-- **Local iOS build MUST be a NON-LOGIN shell — which then MUST re-export `LANG`.**
-  `nohup bash -c 'export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8; …; make <prod-target>'` — NOT
+- **Local iOS build must be a non-login shell — which then must re-export `LANG`.**
+  `nohup bash -c 'export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8; …; make <prod-target>'` — not
   `bash -lc`. Login profile puts a broken Ruby on PATH → `pod install` dies with a
-  misleading `visionos` CocoaPods error at prebuild. BUT non-login shell drops the
+  misleading `visionos` CocoaPods error at prebuild. But non-login shell drops the
   profile's locale → without the explicit `LANG`, `pod install` dies with
-  `Encoding::CompatibilityError` ("CocoaPods requires UTF-8"). Need BOTH. **It bites
-  again one level down:** `eas build --local` runs its OWN nested prebuild + `pod
-  install` that inherits the PARENT shell's env — so a Makefile that sets `LANG`
-  *inline* on its prebuild step is necessary but NOT sufficient; the ambient shell must
+  `Encoding::CompatibilityError` ("CocoaPods requires UTF-8"). Need both. **It bites
+  again one level down:** `eas build --local` runs its own nested prebuild + `pod
+  install` that inherits the parent shell's env — so a Makefile that sets `LANG`
+  *inline* on its prebuild step is necessary but not sufficient; the ambient shell must
   `export LANG`/`LC_ALL` too, or EAS's internal pod install dies the same way while the
   Makefile's own one succeeded (a baffling "pods worked, then the build failed on pods").
 - **Long builds → background + poll log.** `nohup … > build/log 2>&1 &`, then poll:
   `until grep -qiE "BUILD SUCCEEDED|BUILD FAILED|Submitting|successfully uploaded|error:" build/log; do sleep 20; done`.
-  The `nohup … &` WRAPPER returns instantly — a task-runner marks THAT "complete" the
+  The `nohup … &` wrapper returns instantly — a task-runner marks that "complete" the
   moment it backgrounds, so there is **no completion event for the real build**; never
   wait for a done signal, poll the log for milestones. No foreground tool for 20 min.
-- **Local iOS archive needs GBs of free disk — `df -h` FIRST.** A local prod build writes
+- **Local iOS archive needs GBs of free disk — `df -h` first.** A local prod build writes
   DerivedData + an archive + the IPA (10 GB+). Run low mid-build and `pod install` / the
-  archive dies with an ENOSPC or a generic install failure — NOT a clear "disk full."
+  archive dies with an ENOSPC or a generic install failure — not a clear "disk full."
   Reclaim before launching: `~/Library/Developer/Xcode/DerivedData`, old
   `~/Library/Developer/Xcode/Archives`, stale `build/*.ipa`.
-- **Maestro `launchApp` RESUMES the last screen, not home.** A flow assuming home (tap
+- **Maestro `launchApp` resumes the last screen, not home.** A flow assuming home (tap
   "Settings"…) fails `element not found` when the app resumes mid-app from a prior run
   (e.g. a game arena left open). Start from a known state — deep-link to the target route,
   or `launchApp: { clearState: true }` — don't assume the home screen.
 - **Metro `--clear` while a dev client is connected** → `Requiring unknown module N` redbox
-  on a lazy `import()` (async-chunk id desync). Usually STALE — cold relaunch + one-two
+  on a lazy `import()` (async-chunk id desync). Usually stale — cold relaunch + one-two
   Maestro `tapOn: "Dismiss"` clears it to a healthy screen. Not a code bug.
-- **SceneKit / Metal shader-modifier failures render MAGENTA at RUNTIME, not xcodebuild.** A
-  clean prod build BUILDS + SHIPS a magenta board uncaught. Verify a native shader on a
-  sim/device BEFORE the store submit. Classic trigger: `#pragma arguments float3` + a KVC
+- **SceneKit / Metal shader-modifier failures render magenta at runtime, not xcodebuild.** A
+  clean prod build builds + ships a magenta board uncaught. Verify a native shader on a
+  sim/device before the store submit. Classic trigger: `#pragma arguments float3` + a KVC
   uniform binding — hardcode colour literals instead.
-- **Programmatic `SCNParticleSystem` with no `particleImage` draws hard SQUARES.** Set a
+- **Programmatic `SCNParticleSystem` with no `particleImage` draws hard squares.** Set a
   soft radial (white→transparent) puff texture → smoke/fire/splash read as round puffs.
 - **`expo-doctor` non-zero during a build usually benign** (peer-dep + RN-directory-metadata
   warnings) — doesn't fail the build or the submit.
-- **Native dep version/ABI skew → `DYLD Symbol missing` CRASH AT LAUNCH.** A native module
+- **Native dep version/ABI skew → `DYLD Symbol missing` crash at launch.** A native module
   built against a different core ABI than the one linked — usually one dep drifted off the
   SDK's pinned version, a single patch is enough → `Termination Reason: DYLD … Symbol not
-  found … (terminated at launch; ignore backtrace)`. Build + store upload pass CLEAN, no JS
-  runs, the build just won't open. PRE-SHIP gate: run the SDK's version-alignment check (Expo:
-  `npx expo install --check`) and pin the offender EXACT — a `~` range re-resolves it right
+  found … (terminated at launch; ignore backtrace)`. Build + store upload pass clean, no JS
+  runs, the build just won't open. Pre-ship gate: run the SDK's version-alignment check (Expo:
+  `npx expo install --check`) and pin the offender exact — a `~` range re-resolves it right
   back up — then reinstall + clean rebuild.
 - **System dialog over the app blocks Maestro** — iCloud "verify password" re-auth, a push
   / ATT / location permission — reads as `element not found` (UI occluded, not gone).
-  Dismiss step taps the SYSTEM button ("Not Now" / "Allow"), not the app's "Cancel" /
+  Dismiss step taps the system button ("Not Now" / "Allow"), not the app's "Cancel" /
   "Skip". A change newly hitting a platform service (a sync that now actually queries)
   surfaces a prompt older runs never saw — whole suite suddenly fails on the home screen →
   screenshot before assuming a regression.
 - **Stale incremental Android autolinking → bogus slug-derived package.** `expo
-  run:android` prebuilds INCREMENTALLY; a leftover `android/**/autolinking.json` keyed on
+  run:android` prebuilds incrementally; a leftover `android/**/autolinking.json` keyed on
   `com.<slug>` (slug `my-app` → `com.myapp`, not the real `com.org.app`) makes the
   generated `ReactNativeApplicationEntryPoint` reference `com.<slug>.BuildConfig` →
   `compileDebugJavaWithJavac` "package com.<slug> does not exist." `rm -rf android` for a
-  clean prebuild. (Expo uses `expo-modules-autolinking`, NOT RN CLI —
+  clean prebuild. (Expo uses `expo-modules-autolinking`, not RN CLI —
   `react-native.config.js` `project.android.packageName` is ineffective.)
 - **`make … | tee log` reports tee's exit (0), not the build's** — and a Makefile `eas
   build … || (test -f ipa)` fallback masks failure too. `exit ${PIPESTATUS[0]}` after the
-  pipe; trust GROUND TRUTH (new IPA timestamp + "Submitted your app to App Store Connect"),
+  pipe; trust ground truth (new IPA timestamp + "Submitted your app to App Store Connect"),
   never the exit code.
 - **Maestro can't flip a SwiftUI / `@expo/ui` Toggle by tapping its label** — label Text +
   switch are separate elements. Tap the switch control (`point` on the row's right edge);
   gate it with the `checked` selector (`when: notVisible: { id, checked: true }`) so it
   flips only when off.
-- **A gesture-handler `Pressable` as the SIZED flex cell stretches its child — circle →
+- **A gesture-handler `Pressable` as the sized flex cell stretches its child — circle →
   square.** RNGH `Pressable` doesn't hold a fixed pixel width the way a plain `View` does,
-  and an INLINE / dynamic width style (worse with React Compiler on) lets the child disc
-  grow to fill the cell → a "circle" renders as a rounded square — and often only AFTER a
+  and an inline / dynamic width style (worse with React Compiler on) lets the child disc
+  grow to fill the cell → a "circle" renders as a rounded square — and often only after a
   re-render (a freshly-toggled day) while the first-paint ones still look right. Fix: size
-  the cell with a plain `View` / STATIC `StyleSheet` entry, keep the shape a FIXED, centred
+  the cell with a plain `View` / static `StyleSheet` entry, keep the shape a fixed, centred
   child, and mirror the screen's already-working sibling cell (e.g. the month-view DayCell)
   instead of re-deriving sizes inline. `onLayout` on an RNGH Pressable is flaky too — put
   it on a plain wrapper.
 - **Absolute-fill background behind a separately-centred label clips / offsets on iOS.** A
-  disc drawn as a `position:absolute` layer BEHIND a sibling number can sit off-centre or
-  get clipped at the top on iOS (fine on Android). Fix: make it ONE in-flow element — a
-  fixed circle with the label INSIDE it — so the cell centres the whole unit. (Keep an
+  disc drawn as a `position:absolute` layer behind a sibling number can sit off-centre or
+  get clipped at the top on iOS (fine on Android). Fix: make it one in-flow element — a
+  fixed circle with the label inside it — so the cell centres the whole unit. (Keep an
   absolute layer only for a shape that must bleed past the cell, like a joined period
   pill.)
 - **A native 3D / Skia view (SceneKit, react-native-skia, a Metal/GL surface) inside a
   react-navigation `formSheet` (`sheetAllowedDetents: "fitToContents"`) breaks RN layout for
-  its SIBLINGS.** A sibling box (a toggle row, a label) overlaps the native view no matter
-  the child order, a wrapper `View`, a fixed-height slot, OR `position:absolute` — `maestro
+  its siblings.** A sibling box (a toggle row, a label) overlaps the native view no matter
+  the child order, a wrapper `View`, a fixed-height slot, or `position:absolute` — `maestro
   hierarchy` shows the two `bounds` overlapping by tens of px (the sheet's content-fit
-  measure + the native view reporting no intrinsic box). MEASURE with `maestro hierarchy`
+  measure + the native view reporting no intrinsic box). Measure with `maestro hierarchy`
   before reshuffling flex for an hour; clean separation may need the native view in its own
   detent-sized container (or dropping the sibling). It renders fine on a plain (non-sheet)
   screen — so it's the sheet, not your styles.
 - **Dismiss an iOS `formSheet` in Maestro with a grabber swipe-down, not a backdrop tap.**
   The backdrop tap is racy (works once, misses the next — leaving the sheet open so the next
   step fails); `swipe: { start: "50%,38%", end: "50%,97%", duration: 600 }` is reliable. And
-  in a capture SWEEP (open → `takeScreenshot` → dismiss → next), the screenshot can race the
-  present animation and silently grab the PREVIOUS screen — the flow logs `COMPLETED` but the
-  PNG is the list behind the sheet. READ every captured frame; `COMPLETED` ≠ the right screen.
-- **To drive or screenshot a PAYWALL, the product must be UNOWNED** — tapping an OWNED premium
-  item usually EQUIPS it (no sheet opens), so a sweep silently captures the store grid instead.
-  Reset the purchases SDK's anonymous user to all-unowned by reinstalling the SAME build
+  in a capture sweep (open → `takeScreenshot` → dismiss → next), the screenshot can race the
+  present animation and silently grab the previous screen — the flow logs `COMPLETED` but the
+  PNG is the list behind the sheet. Read every captured frame; `COMPLETED` ≠ the right screen.
+- **To drive or screenshot a paywall, the product must be unowned** — tapping an owned premium
+  item usually equips it (no sheet opens), so a sweep silently captures the store grid instead.
+  Reset the purchases SDK's anonymous user to all-unowned by reinstalling the same build
   (`simctl uninstall` + `simctl install <existing .app>` — also re-triggers onboarding, Skip
   it; no rebuild needed). A sandbox/test SDK key (e.g. RevenueCat Test Store `test_…`) returns
   SDK-configured prices, so set those to match prod to capture prod-looking paywalls without
@@ -208,65 +207,65 @@ before "works".
   `<scheme>://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081` to attach and pull
   the bundle. The dev-launcher menu re-appears after a `force-stop` (Continue, or
   `keyevent 4`, to dismiss). But `adb shell input keyevent 4` (back) on a top-level route
-  drops the app to a BLANK screen — you backed OUT of the route, it didn't crash — recover
+  drops the app to a blank screen — you backed out of the route, it didn't crash — recover
   by re-launching the dev-client URL (or `<scheme>://<route>`), not by waiting.
-- **An agent / tool file-write may not trip Metro fast-refresh — you read the OLD bundle.** A
+- **An agent / tool file-write may not trip Metro fast-refresh — you read the old bundle.** A
   save that doesn't come from the editor's own save sometimes never reaches Metro's watcher,
-  so the device still runs the PREVIOUS code and your "fix" looks unchanged (or falsely
+  so the device still runs the previous code and your "fix" looks unchanged (or falsely
   passes). Before trusting any after-edit screenshot, confirm a fresh `Android Bundled … (N
-  modules)` / `iOS Bundled …` line appeared in the Metro log SINCE your edit; if not, force a
+  modules)` / `iOS Bundled …` line appeared in the Metro log since your edit; if not, force a
   reload (re-launch the dev-client URL, or dev-menu → Reload) and re-shoot. A delta bundle
-  (`… (1 module)`) is the proof it picked up the change. **WORSE after a prod build's
+  (`… (1 module)`) is the proof it picked up the change. **Worse after a prod build's
   `cleanPrebuild` (`rm ios/android`):** the still-running Metro from `expo run:ios`
-  detaches — a tool-write, a `touch`, AND a cold app relaunch all fail to re-bundle (you
-  keep running the OLD code; a stray `(1 module)` delta for an unrelated file fools you into
-  thinking it reloaded). Only KILL Metro (`lsof -ti :8081 | xargs kill`) + restart
+  detaches — a tool-write, a `touch`, and a cold app relaunch all fail to re-bundle (you
+  keep running the old code; a stray `(1 module)` delta for an unrelated file fools you into
+  thinking it reloaded). Only kill Metro (`lsof -ti :8081 | xargs kill`) + restart
   `expo start --dev-client --clear` — a full `(N modules)` re-bundle — loads the new code.
-- **A cold relaunch (force-stop → launcher / deep-link) RE-BUNDLES over Metro — a black /
-  blank frame with NO mounted UI for tens of seconds is NORMAL, not a crash.** The first
+- **A cold relaunch (force-stop → launcher / deep-link) re-bundles over Metro — a black /
+  blank frame with no mounted UI for tens of seconds is normal, not a crash.** The first
   probe after a kill catches the bundle still loading: empty view tree (Android `uiautomator
   dump` returns nothing / your target node missing), a blank iOS screenshot, Maestro
   `element not found`. Don't read it as a failure and burn retries — poll: re-dump / re-shoot
-  in a loop until a known node appears, or watch the Metro log for the `Bundled` line, THEN
-  screenshot / navigate / assert. Hits BOTH platforms (the JS bundle loads on cold start
+  in a loop until a known node appears, or watch the Metro log for the `Bundled` line, then
+  screenshot / navigate / assert. Hits both platforms (the JS bundle loads on cold start
   either way); a dev/Metro build pays it on every relaunch, a release build doesn't.
-- **Two apps on the machine → the dev client attaches to the WRONG Metro.** When a second
+- **Two apps on the machine → the dev client attaches to the wrong Metro.** When a second
   Expo project is already running `expo start`, it owns the default Metro port 8081, so a
-  freshly-launched dev client auto-attaches there and serves the OTHER project's bundle —
+  freshly-launched dev client auto-attaches there and serves the other project's bundle —
   a baffling redbox (e.g. a "missing native module" naming a module/file the current app
-  doesn't even use, or just the wrong screen). `expo run:ios --port 8082` moves THIS
+  doesn't even use, or just the wrong screen). `expo run:ios --port 8082` moves this
   project's Metro to a free port, but the launched binary still asks for 8081, and the
   `<scheme>://expo-development-client/?url=http://localhost:<port>` deep link often does
-  NOT redirect it. Fix: set the binary's saved packager location, then relaunch — iOS
+  not redirect it. Fix: set the binary's saved packager location, then relaunch — iOS
   `xcrun simctl spawn booted defaults write <bundleId> RCT_jsLocation "localhost:<port>"`;
   Android `adb reverse tcp:<port> tcp:<port>` then the dev-client `?url=` deep link.
   Symptom = wrong-app bundle, not a code bug.
 - **Native `headerSearchBarOptions` (react-native-screens) on iOS 26 floats to the bottom by
-  default.** The default `placement: "automatic"` drops the search field to the BOTTOM of the
+  default.** The default `placement: "automatic"` drops the search field to the bottom of the
   screen, overlapping content (a UIKit root-screen toolbar-integration bug) → set
   `placement: "stacked"` and it anchors below the title bar as expected (rn-screens forces
   `allowToolbarIntegration:false` for stacked, which dodges the bug). These header/search
-  options are JS nav config → they HOT-RELOAD on an already-built dev client (no native
+  options are JS nav config → they hot-reload on an already-built dev client (no native
   rebuild), so iterate the layout live on the sim. (`headerLargeTitle` can also render blank
   in some expo-router setups — if it does on yours, draw the big title in-content instead of
   fighting it; verify per-app, don't assume.) A documented "native X can't anchor / doesn't
-  work here" is often a STALE, fixable conclusion — re-test the native option on-device first.
-- **"Search visible at rest AND tucking on scroll" (Telegram-style) wants a working large
+  work here" is often a stale, fixable conclusion — re-test the native option on-device first.
+- **"Search visible at rest and tucking on scroll" (Telegram-style) wants a working large
   title; without one, drive it from JS.** `hideWhenScrolling: true` on its own leaves a
-  stacked search HIDDEN at rest (pull-to-reveal). To show it at the top and hide it once the
-  list scrolls, keep `headerSearchBarOptions` mounted and REMOVE it (set `undefined`) past a
+  stacked search hidden at rest (pull-to-reveal). To show it at the top and hide it once the
+  list scrolls, keep `headerSearchBarOptions` mounted and remove it (set `undefined`) past a
   scroll threshold — with hysteresis whose gap clears the search bar's own height, or the
   layout shift from removing it bounces the offset back over the threshold (flicker loop).
   Gate to iOS — a Material toolbar search icon (Android) is compact and shouldn't hide on
   scroll.
 
 ## Native extension targets (apple-targets widgets / App Clips)
-A widget / App Clip / share extension via `@bacons/apple-targets` is a SECOND signed
+A widget / App Clip / share extension via `@bacons/apple-targets` is a second signed
 target — own bundle id, profile, capabilities. Each bites once:
-- **First build needs a ONE-TIME INTERACTIVE `eas` credential sync.** The non-login
+- **First build needs a one-time interactive `eas` credential sync.** The non-login
   `--non-interactive` prod build can't create a new target's id + profile → "Credentials
   are not set up. Run this command again in interactive mode." Run `eas build --platform
-  ios --profile production --local` (interactive, Apple login + 2FA) ONCE; after that the
+  ios --profile production --local` (interactive, Apple login + 2FA) once; after that the
   non-interactive build works.
 - **Target `name` must be space-free + match the EAS-registered target.** `name: "My
   Widget"` makes the Xcode target "My Widget" but EAS keys creds on the sanitized
@@ -274,15 +273,15 @@ target — own bundle id, profile, capabilities. Each bites once:
   target … in project.pbxproj." Space-free `name` + a `displayName` for the label; pin
   `bundleIdentifier`.
 - **An App Group (or any capability) on the extension is a credential black hole.** `eas`
-  does NOT sync capabilities to the EXTENSION App ID ("Synced capabilities: No updates"
+  does not sync capabilities to the extension App ID ("Synced capabilities: No updates"
   yet signing fails "profile doesn't support the … App Group"). Reuse can't add a
   capability; even a freshly-regenerated profile lacks it until you enable it on the
   **identifier** by hand (portal → Identifiers → the extension id → App Groups ✓ → assign
-  the group), then delete + recreate the PROFILE. Delete the PROFILE, **not** the
-  identifier — deleting the App ID re-registers it WITHOUT the capability, strictly worse.
-  A deep-link-only widget needs NO entitlements — declare none, skip the saga; add the App
+  the group), then delete + recreate the profile. Delete the profile, **not** the
+  identifier — deleting the App ID re-registers it without the capability, strictly worse.
+  A deep-link-only widget needs no entitlements — declare none, skip the saga; add the App
   Group only when the widget must read app data (shared-UserDefaults "last result").
-- **`cleanPrebuild` (rm ios/android) does NOT touch `targets/`.** A stale
+- **`cleanPrebuild` (rm ios/android) does not touch `targets/`.** A stale
   `generated.entitlements` re-links on the next prebuild after you drop it from
   `expo-target.config.js` — delete it by hand. Gitignore the generated artifacts.
 
@@ -293,13 +292,13 @@ on-device render gate it leans on. In short:
 - iOS: repo's prod build-and-submit target (`make`/script step) = clean prebuild → IPA →
   `eas submit` to TestFlight, in the non-login shell. Bump the marketing version first if
   the last already shipped — but a build that FAILED after a bump leaves that version
-  UNSHIPPED, so reuse it, don't bump again. Apple processes ~5–10 min after the upload.
+  unshipped, so reuse it, don't bump again. Apple processes ~5–10 min after the upload.
 - **Verify-before-ship:** native visual changes (shaders, particles, a 3D scene) invisible
   to the compiler — a real on-device render is the only proof. Magenta + square particles
   pass the build.
-- **A build that compiles + uploads can still DIE AT LAUNCH** — a native version/ABI-skew
-  (dyld symbol-missing) crash shows in NEITHER the build NOR the store upload, only when the
-  build OPENS on a device. Install + open it ONCE before trusting the ship; if it bounces,
+- **A build that compiles + uploads can still die at launch** — a native version/ABI-skew
+  (dyld symbol-missing) crash shows in neither the build nor the store upload, only when the
+  build opens on a device. Install + open it once before trusting the ship; if it bounces,
   read the device crashlog (Console.app / Devices & Simulators → View Device Logs).
   `DYLD … Symbol not found` = native version skew (see Gotchas), not app code.
 
@@ -311,7 +310,7 @@ on-device render gate it leans on. In short:
 - Maestro flow via stdin, or Cyrillic `inputText` → write a flow file, use ASCII.
 - Hold a foreground shell through a 20-min build → background + poll the log.
 - Maestro `element not found` on a screen you know renders → a system dialog (iCloud
-  re-auth / permission) on top; dismiss the SYSTEM button, not the app's.
+  re-auth / permission) on top; dismiss the system button, not the app's.
 - `bash -c` non-login build but no `LANG` export → visionos gone but
   `Encoding::CompatibilityError` coming; export `LANG=en_US.UTF-8` too.
 - New apple-targets extension + straight `--non-interactive` build → "Credentials not set
@@ -333,7 +332,7 @@ on-device render gate it leans on. In short:
   launch crash that builds + ships clean. Run the SDK version-alignment check; pin exact.
 - "Uploaded = done" with nobody opening the build → a launch-time version/ABI-skew crash
   passes build + upload; install, open once, read the crashlog.
-- "Looks like a circle" from a full-frame screenshot → MEASURE the node bounds + zoom-crop;
+- "Looks like a circle" from a full-frame screenshot → measure the node bounds + zoom-crop;
   square discs, top-clipped shapes and off-centre numbers are invisible at scale.
 - RNGH `Pressable` sized with an inline / dynamic width (React Compiler on) → child stretches
   (circle → square, often only after a re-render); size with a plain View + static StyleSheet,
@@ -355,27 +354,27 @@ on-device render gate it leans on. In short:
   feature to everyone.
 - Label text ending in "…", or a sentence with a double space / dangling preposition → not a
   font issue: single-line sizing, uncounted padding, or a nil value formatted into the string.
-- Concluded a layout / shape change is fine from ONE platform → iOS and Android clip, centre
+- Concluded a layout / shape change is fine from one platform → iOS and Android clip, centre
   and size differently; spot-check shape-sensitive UI on the iOS sim too before ship.
 - Hand-building a custom cell / shape with inline, per-render sizes → mirror the screen's
   existing working component and lift sizes into a static StyleSheet; inline / dynamic styles
   are where shape bugs (and React Compiler surprises) hide.
-- Your edit isn't showing on device → you may be reading the OLD bundle; confirm a new Metro
+- Your edit isn't showing on device → you may be reading the old bundle; confirm a new Metro
   `Bundled` line since the edit (force a reload if none) before concluding anything.
 - Edit still not loading after a prod build's `cleanPrebuild` → Metro detached; a touch /
-  relaunch won't do it — KILL Metro + `expo start --dev-client --clear` for a full re-bundle.
+  relaunch won't do it — kill Metro + `expo start --dev-client --clear` for a full re-bundle.
 - An hour reshuffling flex because a toggle / label overlaps a native (SceneKit / Skia)
   preview → it's the native-view-inside-`formSheet` layout limit; `maestro hierarchy` to
   measure, give the native view its own detent-sized container or drop the sibling.
 - Backdrop-tap to dismiss a `formSheet` in a capture sweep → racy; grabber swipe-down, and
-  READ every captured frame (a sweep can log `COMPLETED` yet grab the prior screen).
-- `tapOn` a premium item opens no paywall / it just equips → the product is OWNED; reset to
+  read every captured frame (a sweep can log `COMPLETED` yet grab the prior screen).
+- `tapOn` a premium item opens no paywall / it just equips → the product is owned; reset to
   unowned (reinstall the same build) so the paywall sheet opens.
 - Verified a mutating tap by the optimistic frame only → re-open the screen / another view and
-  confirm the write PERSISTED through the store, not just the instant paint.
+  confirm the write persisted through the store, not just the instant paint.
 - Changed a setting and nothing downstream moved → a derived / auto value (an average, a
   cached default, a value computed from the data) is overriding it; the setting isn't the
-  source of truth. True for ANY setting → output — units, theme, thresholds, sort order, a
+  source of truth. True for any setting → output — units, theme, thresholds, sort order, a
   prediction — so change-it-and-watch is the universal test; the fix is to read the setting
   directly and demote the computed value to a suggestion.
 
@@ -384,7 +383,7 @@ on-device render gate it leans on. In short:
   pulling the frames to the repo, making a flagged/unseeded feature reachable, labelled
   side-by-sides, and the deviation table (fixed vs deliberate) the MR needs.
 - **`ship` skill** — driving a local-build → App Store / Play submit (LANG/shell rules,
-  no-double-bump, background+poll, ground-truth verify, `stopShip`). It gates on THIS
+  no-double-bump, background+poll, ground-truth verify, `stopShip`). It gates on this
   skill's device render before submitting.
 - **`purchases` skill** — IAP / store-metadata + RevenueCat: a version-controlled
   source-of-truth for product ids + App Review notes, and pushing IAP `reviewNote` via the
@@ -395,7 +394,7 @@ on-device render gate it leans on. In short:
   device-driving + gotchas layer; lean on `expo:*` for API/SDK specifics.
 - **`stories` skill → `references/expo-verification.md`** — the build-time "is an Expo
   change verified?" checklist (detect Expo, rebuild scope, Maestro/screenshot proof). It
-  defers HERE for the actual drive loop + the gotchas above.
+  defers here for the actual drive loop + the gotchas above.
 - Test on the **latest iOS** (the current simulator runtime), not a pinned version — a
   feature floor (e.g. accessory / Control widgets) is a deployment-target detail, not the
   test target.

--- a/plugins/corgi/skills/review/SKILL.md
+++ b/plugins/corgi/skills/review/SKILL.md
@@ -236,7 +236,6 @@ review untouched code.
 - **Leaked secrets** — always `severity: blocking`; flag the file + line + that a secret is present; never echo the value into a finding or comment.
 - Repo-standard / convention violations (names, patterns, style).
 - Scope creep (changes outside the ticket's stated scope).
-- Perf footguns.
 - **User-facing copy that names internal tech** — a string/label exposing an
   engine, library, vendor, or infra detail to end users (`nit`); suggest selling
   the user benefit, not the mechanism. Skip if the ticket is about that copy.
@@ -281,11 +280,7 @@ Both are only findings when they are real. Do not invent an abstraction
 objection to have something to say, and do not call a hot path slow without
 naming what runs and how often.
 
-**Temper with the intent note** — before emitting any finding, check it against
-the ticket's rationale, constraints, and discussion. A choice the ticket
-explicitly justifies (deliberate hack, scoped approach, known debt with a
-follow-up) is not a bug; drop it or downgrade to a soft note citing the
-ticket's reasoning.
+**Temper with the intent note** (P1.5, point 2) before emitting any finding.
 
 **Finding shape** (exact — used by P4/P5):
 ```
@@ -658,10 +653,6 @@ P4 order) and cross-link the two replies. Then one combined report (6).
    `git worktree add` off the fetched head so the user's work is untouched (`stories`
    P3 worktree rules). Gate: `corgi test --service` / `corgi exec` + scoped self-review
    (`stories` P3.5). **Minimum diff — only what the threads ask.**
-   **Minimal code comments.** Don't narrate the change in code comments — it should read
-   from the diff and the PR/commit message. Add a comment only for a genuinely non-obvious
-   invariant that would otherwise be lost, and only where the file already comments. No
-   "// added/changed X" notes.
 4. **Reply + resolve per thread** (§5) — what changed (commit/line), or why you pushed
    back. **Reply INSIDE the reviewer's thread** — GitHub `in_reply_to`, GitLab
    `POST …/discussions/<id>/notes`; never `gh pr comment` / `glab mr note create`,

--- a/plugins/corgi/skills/ship/SKILL.md
+++ b/plugins/corgi/skills/ship/SKILL.md
@@ -6,44 +6,44 @@ description: Use when shipping an Expo / React Native app to the stores via the 
 # Ship a local build to the stores
 
 ## Overview
-Ship = repo's prod LOCAL build+submit target (`make ship`, or `make localIosProd` +
-`localAndroidProd`) → clean prebuild → IPA/AAB → `eas submit` to TestFlight + Play. Build
-COMPILING ≠ shipped. **Ground truth = a new IPA/AAB on disk + a "Submitted…" line**, never
-the exit code. Long + unattended → background + poll.
+Ship = the repo's local prod build+submit target (`make ship`, or `make localIosProd` +
+`localAndroidProd`) → clean prebuild → IPA/AAB → `eas submit` to TestFlight + Play. A
+build compiling ≠ shipped. **Ground truth = a new IPA/AAB on disk + a "Submitted…" line**,
+never the exit code. Long + unattended → background + poll.
 
 ## Before you ship
 - **Render gate (`mobile` skill).** Native-invisible change (shader, particles, 3D scene,
-  Skia) compiles + ships MAGENTA / square / blank. Drive on device + READ the screenshot
-  FIRST. Green build ≠ verified build.
+  Skia) compiles + ships magenta / square / blank. Drive on device + read the screenshot
+  first. Green build ≠ verified build.
 - Tests + lint/types green. A ship is no place to find a broken bundle.
 - `df -h` first — a local iOS archive writes DerivedData + archive + IPA (10 GB+); low disk
   kills `pod install` / the archive mid-run with a misleading error.
 
-## The shell + locale rule (this is the #1 ship failure)
-Run the build in a **NON-LOGIN** shell that **also EXPORTS the locale**:
+## The shell + locale rule
+Run the build in a **non-login** shell that **also exports the locale**:
 ```
 nohup bash -c 'export LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8; make <ship-target>' > build/ship.log 2>&1 &
 ```
 - `bash -lc` (login) puts a broken rbenv Ruby on PATH → `pod install` dies with a
   misleading CocoaPods `visionos` error at prebuild. So: non-login.
-- BUT a non-login shell drops the profile's locale → empty `LANG`/`LC_ALL` →
+- But a non-login shell drops the profile's locale → empty `LANG`/`LC_ALL` →
   `Encoding::CompatibilityError` ("CocoaPods requires UTF-8"). So: export it.
-- **And it bites one level down:** `eas build --local` runs its OWN nested prebuild +
-  `pod install` inheriting the PARENT env. A Makefile that sets `LANG` *inline* for its
-  own prebuild step is necessary but NOT sufficient — if the ambient shell's `LANG` is
+- **And it bites one level down:** `eas build --local` runs its own nested prebuild +
+  `pod install` inheriting the parent env. A Makefile that sets `LANG` *inline* for its
+  own prebuild step is necessary but not sufficient — if the ambient shell's `LANG` is
   empty, EAS's internal pod install dies the same way while the Makefile's succeeded.
   Always export in the parent. (Check first: `echo "LANG=$LANG"` — empty is the tell.)
 
-## Version bump — ONCE
+## Version bump — once
 `make ship` bumps the marketing version (and EAS bumps iOS buildNumber / Android
-versionCode per attempt) FIRST, then builds. **If the build dies after the bump, the
-version is bumped but UNSHIPPED — do NOT run `make ship` again** (it double-bumps). Re-run
-the build+submit targets DIRECTLY (`make localIosProd && make localAndroidProd`) — they
+versionCode per attempt) first, then builds. **If the build dies after the bump, the
+version is bumped but unshipped — don't run `make ship` again** (it double-bumps). Re-run
+the build+submit targets directly (`make localIosProd && make localAndroidProd`) — they
 don't bump — reusing the already-bumped version.
 
 ## Drive it
 1. **Background + poll** — there's no foreground tool for 20–40 min, and the `nohup … &`
-   wrapper "completes" the instant it backgrounds (any task-runner marks THAT done) — so
+   wrapper "completes" the instant it backgrounds (any task-runner marks that done) — so
    there is **no completion event for the real build**. Poll the log:
    ```
    until grep -qiE "BUILD SUCCEEDED|BUILD FAILED|Submitting|successfully uploaded|Submitted your app|error:" build/ship.log; do sleep 25; done
@@ -58,25 +58,25 @@ don't bump — reusing the already-bumped version.
 - **iOS:** a new `*.ipa` (fresh timestamp) + `✔ Submitted your app to Apple App Store
   Connect!` / `successfully uploaded to App Store Connect`. Apple processes ~5–10 min after.
 - **Android:** a new `*.aab` + `✔ Submitted your app to Google Play Store!`. Play submits
-  land as a **DRAFT** release by default (`changes_not_sent_for_review` / draft status) —
+  land as a **draft** release by default (`changes_not_sent_for_review` / draft status) —
   you promote it in Play Console; "submitted" ≠ "released".
-- **`build/.submit-skipped`** (or the WARNING line) — a Makefile `eas build … || (test -f
-  ipa)` fallback + `tee`'d logs report exit 0 while a submit was SKIPPED. If that file is
-  non-empty, the upload did NOT happen — upload by hand (Transporter / `make submitIos`).
-- **A build that compiles + uploads can still DIE AT LAUNCH** — native version/ABI skew
-  (`DYLD Symbol not found`) shows in NEITHER build NOR upload. Install + open the binary
-  ONCE; if it bounces, it's dep-version skew (pin exact, see `mobile`), not app code.
+- **`build/.submit-skipped`** (or the warning line) — a Makefile `eas build … || (test -f
+  ipa)` fallback + `tee`'d logs report exit 0 while a submit was skipped. If that file is
+  non-empty, the upload did not happen — upload by hand (Transporter / `make submitIos`).
+- **A build that compiles + uploads can still die at launch** — native version/ABI skew
+  (`DYLD Symbol not found`) shows in neither build nor upload. Install + open the binary
+  once; if it bounces, it's dep-version skew (pin exact, see `mobile`), not app code.
 
 ## Red flags — stop
 - `bash -lc` for the build → `visionos` CocoaPods error incoming; non-login shell.
 - Non-login but no `LANG` export → `Encoding::CompatibilityError`; export `LANG`/`LC_ALL`.
-- Pods "worked" but the build later failed on pods → it's EAS's NESTED pod install with an
+- Pods "worked" but the build later failed on pods → it's EAS's nested pod install with an
   empty ambient `LANG`; export it in the parent shell, not just inline in the Makefile.
 - Re-running `make ship` after a post-bump failure → double version bump; re-run the
   build+submit targets directly instead.
 - Trusting a "build completed" exit code / a `tee`'d "✓" → `tee` reports tee's exit and a
   Makefile `||` masks failure; trust the new IPA/AAB timestamp + the "Submitted…" line.
-- "Uploaded = released" on Play → it's a DRAFT; promote it in Play Console.
+- "Uploaded = released" on Play → it's a draft; promote it in Play Console.
 - "Uploaded = done" with nobody opening the build → a launch-time ABI-skew crash passes
   build + upload; install + open once.
 - Shipping a native shader/scene/Skia change straight to a store with no on-device render →

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -335,34 +335,24 @@ batch-level, not per-branch. Re-present only changed specs. Blocked held out.
 Superpowers-escalated stories pass here too: their `writing-plans` output is the
 spec.
 
-**Fast-path — collapse the approval round to inline diagnosis ONLY when all hold.**
-Gate just confirms intent before branching. Collapse it (state diagnosis + the exact
-change inline, then go — that _is_ the gate, they can still stop you) **only when
-every one is true:**
+**Fast-path — collapse the approval round to inline diagnosis.** The gate confirms
+intent before branching; it collapses (state diagnosis + the exact change inline, then
+go — that _is_ the gate, the user can still stop you) in exactly two cases:
 
-- exactly **one** named item (one ticket, or one specific fix the user named),
-- tier **adjustment or bug** (never feature),
-- **single service**, no cross-service contract,
-- you can state the **exact change in one sentence**, no open question.
+- **One unambiguous item:** one ticket or one named fix, tier adjustment or bug, single
+  service, no cross-service contract, and you can state the exact change in one
+  sentence with no open question. Anything else — feature tier, >1 story,
+  multi-service, an ambiguous target, a clarifying question you had to ask yourself —
+  is the full gate. A vague "just fix it" with no scope is open intent, not clearance.
+- **Blanket pre-authorization:** the user explicitly pre-approved the changes
+  sight-unseen and told you to proceed to PR/MR ("I approve all changes", "do them all
+  and open the MRs"). That is the sign-off for any tier, span, or batch size; state
+  each spec inline and go. The signal is explicit approval plus a directive, not
+  impatience.
 
-**Any one false → full gate:** feature tier · >1 story · multi-service · ambiguous
-target · you had to ask yourself a clarifying question · can't name the change in one
-sentence. **Unsure → full gate.** "User said 'just fix it'" is **not** clearance if
-you can't say exactly what "it" is — a vague directive = _open_ intent → gate. The
-fast-path skips the _pause_, never the _thinking_.
-
-**Fast-path drops the approval pause, NOT the tracker artifacts.** Even on a
-one-liner, post the **spec comment (with its QA "what to test" section)** (Phase 1 triage) —
-durable record, and a visual/QA defect is what a human must re-verify. Don't skip.
-
-**Blanket pre-authorization collapses the gate for ANY tier/span.** The single-item
-fast-path above is for _unambiguous_ changes. Separately, when the user has **explicitly
-pre-approved the changes sight-unseen** and told you to proceed to PR/MR ("I approve all
-changes", "do them all and open the MRs") — that _is_ the sign-off, even for a feature /
-multi-service / multi-story batch. State each spec inline (diagnosis + change) and go;
-the tracker still gets the spec comment (QA section included). NOT the same as a vague "just fix it" with
-no scope (that stays _open_ intent → full gate). Signal = explicit approval + a directive
-to proceed, not mere impatience.
+Either way the fast-path drops the pause — never the thinking, and not the artifacts:
+post the spec comment (with its QA section) even for a one-liner. It is the durable
+record, and a visual/QA defect is what a human must re-verify.
 
 ## Phase 3 — Branch + implement + verify per story
 

--- a/plugins/corgi/skills/stories/references/expo-verification.md
+++ b/plugins/corgi/skills/stories/references/expo-verification.md
@@ -77,7 +77,7 @@ installers are often denied). Keep flows in the repo's `e2e/` so they ship with
 the PR; they are the mobile equivalent of the visual/e2e harness for
 FAILS-on-base regression checks when the bug is reproducible by flow.
 
-Quirks that WILL bite (each cost a failed run once):
+Quirks:
 
 - **Always `launchApp: {stopApp: true}`** — apps that persist/resume their last
   route do not start on the home screen; tap sequences assuming the menu fail.

--- a/plugins/corgi/skills/suggest-proactive/SKILL.md
+++ b/plugins/corgi/skills/suggest-proactive/SKILL.md
@@ -26,7 +26,7 @@ A scheduled **push** wrapper around `suggest`: on a cadence (owned by `/schedule
 
 ## Phase 1 — Rank (reuse `suggest`)
 
-- Invoke the `suggest` skill flow (its **Phases 0–3**) **scoped to this workspace, both lenses**, to produce the ranked shortlist. Do NOT re-spec everything — only the chosen survivor gets specced (Phase 3), and only after it survives dedupe.
+- Invoke the `suggest` skill flow (its **Phases 0–3**) **scoped to this workspace, both lenses**, to produce the ranked shortlist. Don't re-spec everything — only the chosen survivor gets specced (Phase 3), and only after it survives dedupe.
 - State explicitly to yourself: **ranking + evidence + measurable-outcome rules are owned by `suggest`; this skill only consumes the ranked list.**
 
 ## Phase 2 — Dedupe + rate-limit
@@ -51,7 +51,10 @@ A scheduled **push** wrapper around `suggest`: on a cadence (owned by `/schedule
 ## Phase 5 — Arm/maintain the schedule
 
 - Point at `references/schedule-config.md` for the literal CronCreate args.
-- If the user asked to set it up: emit the config (weekly, **off-:00 minute**, `durable: true`, the **absolute workspace path** in the prompt) and **warn about the 7-day auto-expire** (CronCreate recurring jobs fire a final time then delete after 7 days) — offer to re-arm, and offer a `--once` next-Monday one-shot as the conservative default for first-time users.
+- If the user asked to set it up: an unattended weekly cadence is a `/schedule` routine
+  (weekly, off-:00 minute, the absolute workspace path in the prompt). A first-time trial
+  is a one-shot `CronCreate` job — session-only, so say it dies with the session and a
+  recurring one expires after 7 days.
 - Disarm: `CronList` → `CronDelete` by id (see the reference).
 
 ## [[workspace-memory]] integration (loose)

--- a/plugins/corgi/skills/suggest-proactive/references/schedule-config.md
+++ b/plugins/corgi/skills/suggest-proactive/references/schedule-config.md
@@ -1,46 +1,40 @@
-# Arming the proactive-suggest schedule (`/schedule` / CronCreate)
+# Arming the proactive-suggest schedule
 
-`suggest-proactive` does **not** schedule itself — the host harness `/schedule`
-(CronCreate) owns the cadence and fires the job while the REPL is idle. This is the
-exact config to arm, disarm, and re-arm it.
+`suggest-proactive` does **not** schedule itself. Two host mechanisms can fire it, and
+they are not the same thing:
 
-## Arm (recurring, weekly)
+- **`/schedule`** creates a cloud routine on a cron. It outlives the terminal session.
+  Use it for the unattended weekly run.
+- **`CronCreate`** is session-only: the job lives in memory, fires while the REPL is
+  idle, dies when the session ends, and a recurring job auto-expires after 7 days.
+  Use it for a one-off or a same-day trial.
 
-Create the job via CronCreate with a standard 5-field cron, an **off-:00 minute** (to
-avoid fleet pile-up), `durable: true` (survives session restarts →
-`.claude/scheduled_tasks.json`), and the **absolute workspace path** baked into the
-prompt (the cron fires with no implied cwd):
+Either way the prompt names the absolute workspace path — the job fires with no implied
+cwd, and the skill refuses to run without a `corgi-compose.yml`.
 
-```
-cron:      "23 9 * * 1"          # ~weekly, Monday ~09:23 local (off-minute on purpose)
-recurring: true
-durable:   true
-prompt:    "Run /corgi-suggest-proactive in workspace /abs/path/to/workspace"
-```
+## Arm (recurring, weekly) — `/schedule`
 
-- **Default cadence is weekly** — it matches the rate-limit (default 1 ticket/week).
-  Hourly/daily is allowed, but the per-week cap (hard ceiling 3) still binds, so a
-  tighter cadence does NOT file more.
-- The prompt MUST name the absolute workspace path. The skill `cd`s / resolves there
-  and refuses if no `corgi-compose.yml` is found.
-
-## 7-day auto-expire — you MUST warn the user
-
-CronCreate **recurring** jobs fire a final time and then **delete themselves after 7
-days**. When you arm a recurring job, tell the user this and offer to **re-arm** it
-when it lapses. Re-arming is just creating the job again with the same config.
-
-## One-shot alternative (conservative default for first-timers)
-
-For a first run, prefer a single next-Monday shot instead of a recurring job — it
-proves the flow end-to-end without committing to a cadence:
+Weekly matches the rate limit (default 1 ticket/week; hard ceiling 3 — a tighter
+cadence does not file more). Pick an off-:00 minute.
 
 ```
-cron:      "23 9 * * 1"          # next Monday ~09:23
+cron:    "23 9 * * 1"          # Monday ~09:23 local
+prompt:  "Run /corgi-suggest-proactive in workspace /abs/path/to/workspace"
+```
+
+## Trial run — `CronCreate`, one shot
+
+For a first run, a single next-Monday shot proves the flow without committing to a
+cadence:
+
+```
+cron:      "23 9 * * 1"
 recurring: false
-durable:   true
 prompt:    "Run /corgi-suggest-proactive in workspace /abs/path/to/workspace"
 ```
+
+A recurring `CronCreate` job also works for a week-long trial; tell the user it
+expires after 7 days and offer to move it to `/schedule` when it lapses.
 
 ## Disarm
 
@@ -48,6 +42,9 @@ prompt:    "Run /corgi-suggest-proactive in workspace /abs/path/to/workspace"
 CronList                          # find the job id
 CronDelete <id>                   # remove it
 ```
+
+`CronList` / `CronDelete` only see `CronCreate` jobs; a `/schedule` routine is managed
+through `/schedule` itself.
 
 Cancelling the job is safe at any time — the `corgi_services/suggest-history.json` state stays
 consistent (it's only appended to by the run itself).


### PR DESCRIPTION
## What

Follow-up to a `/claude-api prompt-audit` run over `plugins/corgi/` and the MCP tool descriptions. Nothing here changes runtime behaviour except the MCP server now sending `instructions` at initialize.

### Skills (cruft removed)
- **mobile / ship / mobile-screenshots + their commands** — ~200 ALL-CAPS emphasis words lowered; content unchanged. Identifiers (`LANG`, `BUILD SUCCEEDED`, `DYLD`, `$ARGUMENTS`, locale codes, ASC enums) verified intact.
- **stories** — the fast-path gate rule was stated three times across three commits; now one paragraph with the same conditions.
- **review** — verbatim duplicate of the "temper with the intent note" rule, a leftover `Perf footguns.` stub, and a third copy of the no-explanatory-comments rule in Mode B removed.
- **suggest-proactive** — `schedule-config.md` claimed `durable: true` survives restarts. CronCreate is session-only; `/schedule` routines are what survive. Rewritten to name both.
- **ci / autopilot** — "now says / used to" phrasing dropped.
- **corgi-new** — referenced `/corgi-add-service` (does not exist); now points at `corgi create`. "3–5 bullets" cap dropped.
- **corgi** — `ALREADY_RUNNING` → `E_ALREADY_RUNNING` (matches `utils/errcodes.go`).
- **agent** — frontmatter description rewritten as intent categories instead of twelve quoted phrases. This is the one change worth a trigger check.
- History-narrative clauses ("each bit a real session", "learned the hard way", "the one we used") dropped.

### Skills (gaps filled)
- `agent` skill never mentioned `corgi_session_brief` or the agent-surface tools (`corgi_context`, `corgi_why`, `corgi_wait_for_log`, `corgi_checkpoint`/`restore`, `corgi_checkout`). Added.
- `debug` names the MCP equivalents next to the CLI calls.
- New `skills/corgi/references/mcp-tools.md` — every tool, args, returns, caveats, the tunnel gate.
- The plugin's `../../../docs/*.md` links only resolve inside this repo; an installed plugin (`/plugin install corgi@corgi`) has no `docs/`. Replaced with GitHub URLs.

### MCP
- Seven tools (`corgi_status`, `corgi_ps`, `corgi_logs`, `corgi_up`, `corgi_down`, `corgi_restart`, `corgi_db_query`) had one-sentence descriptions. They now state return shape, preconditions, that `corgi_ps` status is not health, that `corgi_up` runs every `beforeStart` before returning and is not a ready gate, `E_ALREADY_RUNNING`, and the tunnel gate.
- `server.WithInstructions` — new `cmd/mcp_instructions.go` sends orientation rules at initialize, so the Claude app connector on a phone (no skills loaded) gets them too.
- Conversational steering ("echo the path back", "tell the user which state") removed from four descriptions; the `agent` skill and the server instructions carry it.
- `docs/mcp.md` documents the instructions and the corrected return shapes.

## Verification
- `go build ./...`, `go vet ./cmd/`, `go test ./cmd/` — 1099 passed.
- No test or doc pinned the old description strings.
- Added lines scanned for paths, tokens, client names — none.

## Worth a look
- `plugins/corgi/skills/agent/SKILL.md:3` — replay a few of the old trigger phrases ("which stacks do I have", "why did my remote session die") and confirm the skill still fires.
- `plugins/corgi/skills/mobile/SKILL.md` — the largest diff; it is case-only apart from the Overview and one bolded phrase.
