### PR TITLE
Phone: descriptive session names, and a launcher rebuilt around one action per card

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -487,7 +487,7 @@ func printWorkspaceState(w supervisor.RunState) {
 }
 
 func workspaceUsageLine(id string) string {
-	absPath, configDir, ok := workspaceSessionTarget(id)
+	absPath, configDir, ok := workspaceSessionTarget(id, runningProfile(id))
 	if !ok || absPath == "" {
 		return ""
 	}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -270,10 +270,12 @@ func remoteResolver(dir string, foreground bool) func(id, profile, name string) 
 		if err != nil {
 			return supervisor.SpawnConfig{}, err
 		}
-		cfg := spawnConfigFrom(w, resolved, foreground)
+		cfg := spawnConfigFrom(w, resolved, profile, foreground)
 		cfg.Origin = supervisor.OriginRemote
 		cfg.Profile = profile
 		if n := sanitizeSessionName(name); n != "" {
+			// A name typed on the phone beats anything composed here: it says
+			// what the session is *for*, which no local probe can know.
 			cfg.Name = n
 		}
 		return cfg, nil
@@ -319,10 +321,10 @@ func spawnConfigForWorkspace(w workspace.Workspace, user *config.UserConfig, for
 		utils.Infof("agent: skipping %s (not enabled — run `corgi agent init` there, or set autostart: true)\n", w.ID)
 		return supervisor.SpawnConfig{}, false
 	}
-	return spawnConfigFrom(w, resolved, foreground), true
+	return spawnConfigFrom(w, resolved, "", foreground), true
 }
 
-func spawnConfigFrom(w workspace.Workspace, r config.Resolved, foreground bool) supervisor.SpawnConfig {
+func spawnConfigFrom(w workspace.Workspace, r config.Resolved, profile string, foreground bool) supervisor.SpawnConfig {
 	cfg := supervisor.SpawnConfig{
 		WorkspaceID:       r.ID,
 		Dir:               w.AbsPath,
@@ -350,7 +352,7 @@ func spawnConfigFrom(w workspace.Workspace, r config.Resolved, foreground bool) 
 	if kind.BuildsArgvFromSettings {
 		// The session name shown in claude.ai/code. Meaningless to a kind handed
 		// a complete argv, where it would be a setting that never takes effect.
-		cfg.Name = r.ID
+		cfg.Name = defaultSessionName(r.ID, w.AbsPath, profile, time.Now())
 	}
 	if cfg.Spawn == "" && kind.SupportsSpawn {
 		// Isolate each on-demand session, so two remote sessions in one
@@ -797,7 +799,7 @@ func init() {
 	agentBriefCmd.Flags().Bool("json", false, "Machine-readable output")
 
 	agentSessionStartCmd.Flags().String("profile", "", "Profile from the agent config's profiles: section (e.g. work)")
-	agentSessionStartCmd.Flags().String("name", "", "Session name shown in claude.ai (default: the hostname prefix remote control picks)")
+	agentSessionStartCmd.Flags().String("name", "", "Session name shown in claude.ai (default: workspace · branch · start time)")
 	agentSessionCmd.AddCommand(agentSessionStartCmd, agentSessionStopCmd)
 
 	agentWorkspacesCmd.AddCommand(agentWorkspacesListCmd, agentWorkspacesForgetCmd, agentWorkspacesRelocateCmd)

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -148,7 +148,7 @@ func TestWorkspaceActivityReadsTheTimeline(t *testing.T) {
 	agentD, _ := agentDir()
 	events.NewLog(agentD).Append("acme", events.Event{Kind: "exited", Cause: "network-timeout", Reason: "boom"})
 
-	live, _, last := workspaceActivity("acme", "")
+	live, _, last := workspaceActivity("acme", "", "")
 	if live != 0 {
 		t.Errorf("live = %d with no workspace path", live)
 	}
@@ -156,7 +156,7 @@ func TestWorkspaceActivityReadsTheTimeline(t *testing.T) {
 		t.Errorf("lastEvent = %+v", last)
 	}
 
-	if _, _, none := workspaceActivity("ghost", ""); none != nil {
+	if _, _, none := workspaceActivity("ghost", "", ""); none != nil {
 		t.Errorf("a workspace with no timeline has no last event, got %+v", none)
 	}
 }
@@ -306,7 +306,7 @@ func TestWorkspaceUsageIsOmittedWhenIdle(t *testing.T) {
 	stack := stackWithAgentConfig(t, "")
 	registerStack(t, agentD, "acme", stack)
 
-	if got := workspaceUsage("acme", stack); got != nil {
+	if got := workspaceUsage("acme", stack, ""); got != nil {
 		t.Errorf("the first call must not block on a scan, got %+v", got)
 	}
 	deadline := time.Now().Add(3 * time.Second)
@@ -319,10 +319,10 @@ func TestWorkspaceUsageIsOmittedWhenIdle(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if got := workspaceUsage("acme", stack); got != nil {
+	if got := workspaceUsage("acme", stack, ""); got != nil {
 		t.Errorf("a workspace with no transcripts must report no usage, got %+v", got)
 	}
-	if got := workspaceUsage("acme", ""); got != nil {
+	if got := workspaceUsage("acme", "", ""); got != nil {
 		t.Errorf("no path means no usage, got %+v", got)
 	}
 	if line := workspaceUsageLine("acme"); line != "" {
@@ -617,7 +617,7 @@ func TestWorkspaceActivityCountsLiveSessions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	live, _, _ := workspaceActivity("acme", stack)
+	live, _, _ := workspaceActivity("acme", stack, "")
 	if live != 1 {
 		t.Errorf("live = %d, want the one running process", live)
 	}

--- a/cmd/agent_remote_resolver_test.go
+++ b/cmd/agent_remote_resolver_test.go
@@ -121,3 +121,35 @@ func TestRemoteResolverRejectsAnUnknownProfile(t *testing.T) {
 		t.Errorf("an unknown profile must error and list the defined ones, got %v", err)
 	}
 }
+
+func TestRemoteResolverNamesTheSessionByBranch(t *testing.T) {
+	agentDir := t.TempDir()
+	stack := stackWithAgentConfig(t, "version: 1\nworkspace:\n  id: acme\n")
+	gitRepoOnBranch(t, stack, "feature/referral")
+	registerStack(t, agentDir, "acme", stack)
+
+	cfg, err := remoteResolver(agentDir, false)("acme", "", "")
+
+	if err != nil {
+		t.Fatalf("a normal workspace must resolve, got %v", err)
+	}
+	if !strings.HasPrefix(cfg.Name, "acme · feature/referral · ") {
+		t.Errorf("name = %q, want the workspace and its branch — a bare id makes every session look alike", cfg.Name)
+	}
+}
+
+func TestRemoteResolverPrefersThePhoneSuppliedName(t *testing.T) {
+	agentDir := t.TempDir()
+	stack := stackWithAgentConfig(t, "version: 1\nworkspace:\n  id: acme\n")
+	gitRepoOnBranch(t, stack, "main")
+	registerStack(t, agentDir, "acme", stack)
+
+	cfg, err := remoteResolver(agentDir, false)("acme", "", "fix login redirect")
+
+	if err != nil {
+		t.Fatalf("a normal workspace must resolve, got %v", err)
+	}
+	if cfg.Name != "fix login redirect" {
+		t.Errorf("name = %q, want the name typed on the phone", cfg.Name)
+	}
+}

--- a/cmd/agent_session_name.go
+++ b/cmd/agent_session_name.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+const (
+	// maxSessionNameLen is sanitizeSessionName's cap, applied to the names
+	// corgi composes as well: past it, claude.ai's session list truncates and
+	// the tail is lost anyway.
+	maxSessionNameLen = 60
+	// sessionNameSep reads as one label on a phone, where the list is narrow.
+	sessionNameSep = " · "
+	// minBranchRoom is the shortest branch fragment still worth showing. Below
+	// it the branch is dropped instead: "fix/l…" identifies nothing.
+	minBranchRoom = 8
+)
+
+// defaultSessionName is what a session corgi started itself is called in
+// claude.ai/code's list when nobody named it.
+//
+// The workspace id alone made every session in a workspace identical — a list
+// of four rows all called "corgi" says nothing about which one to open — so
+// the branch being worked on and the clock time the session started come with
+// it:
+//
+//	corgi · fix/login-redirect · 18:55
+//	corgi (work) · main · 09:02
+//
+// The branch is dropped when the workspace is not a git checkout or sits on a
+// detached HEAD, and shortened before either of the other two parts: the id
+// says which workspace and the clock says which run, and a name that loses
+// either stops identifying anything.
+func defaultSessionName(id, dir, profile string, now time.Time) string {
+	head := strings.TrimSpace(id)
+	if p := strings.TrimSpace(profile); p != "" {
+		head += " (" + p + ")"
+	}
+	clock := now.Format("15:04")
+	short := clipSessionName(head + sessionNameSep + clock)
+
+	branch := utils.CurrentBranch(dir)
+	if branch == "" {
+		return short
+	}
+	room := maxSessionNameLen - runeLen(head) - runeLen(clock) - 2*runeLen(sessionNameSep)
+	if room < minBranchRoom {
+		return short
+	}
+	if runeLen(branch) > room {
+		branch = string([]rune(branch)[:room-1]) + "…"
+	}
+	return head + sessionNameSep + branch + sessionNameSep + clock
+}
+
+// clipSessionName trims by rune, never by byte: cutting a multi-byte character
+// in half would put an invalid UTF-8 sequence in the argv.
+func clipSessionName(name string) string {
+	r := []rune(name)
+	if len(r) <= maxSessionNameLen {
+		return name
+	}
+	return strings.TrimSpace(string(r[:maxSessionNameLen]))
+}
+
+func runeLen(s string) int { return len([]rune(s)) }

--- a/cmd/agent_session_name_test.go
+++ b/cmd/agent_session_name_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func gitRepoOnBranch(t *testing.T, dir, branch string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "--initial-branch=" + branch},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"commit", "--allow-empty", "-m", "root"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git unavailable or too old for %v: %v %s", args, err, out)
+		}
+	}
+}
+
+func TestDefaultSessionNameCarriesBranchAndClock(t *testing.T) {
+	dir := t.TempDir()
+	gitRepoOnBranch(t, dir, "fix/login-redirect")
+
+	got := defaultSessionName("corgi", dir, "", time.Date(2026, 9, 3, 18, 55, 0, 0, time.UTC))
+
+	if want := "corgi · fix/login-redirect · 18:55"; got != want {
+		t.Errorf("name = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSessionNameNamesTheProfile(t *testing.T) {
+	dir := t.TempDir()
+	gitRepoOnBranch(t, dir, "main")
+
+	got := defaultSessionName("corgi", dir, "work", time.Date(2026, 9, 3, 9, 2, 0, 0, time.UTC))
+
+	if want := "corgi (work) · main · 09:02"; got != want {
+		t.Errorf("name = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSessionNameDropsAnUnknownBranch(t *testing.T) {
+	// Not a git checkout: the branch is the only part that may go missing.
+	got := defaultSessionName("corgi", t.TempDir(), "", time.Date(2026, 9, 3, 18, 55, 0, 0, time.UTC))
+
+	if want := "corgi · 18:55"; got != want {
+		t.Errorf("name = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSessionNameKeepsIdAndClockWhenItMustShorten(t *testing.T) {
+	dir := t.TempDir()
+	gitRepoOnBranch(t, dir, "feature/"+strings.Repeat("long-", 12))
+
+	got := defaultSessionName("corgi", dir, "", time.Date(2026, 9, 3, 18, 55, 0, 0, time.UTC))
+
+	if n := len([]rune(got)); n > maxSessionNameLen {
+		t.Errorf("name is %d runes (%q), want at most %d", n, got, maxSessionNameLen)
+	}
+	if !strings.HasPrefix(got, "corgi · feature/") || !strings.HasSuffix(got, " · 18:55") {
+		t.Errorf("name = %q, want the id and the clock kept around a shortened branch", got)
+	}
+}
+
+func TestDefaultSessionNameDropsTheBranchWhenThereIsNoRoom(t *testing.T) {
+	dir := t.TempDir()
+	gitRepoOnBranch(t, dir, "some-branch")
+	id := strings.Repeat("w", 50)
+
+	got := defaultSessionName(id, dir, "", time.Date(2026, 9, 3, 18, 55, 0, 0, time.UTC))
+
+	if want := id + " · 18:55"; got != want {
+		t.Errorf("name = %q, want %q — a branch stub identifies nothing", got, want)
+	}
+	if n := len([]rune(got)); n > maxSessionNameLen {
+		t.Errorf("name is %d runes, want at most %d", n, maxSessionNameLen)
+	}
+}

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -442,7 +442,7 @@ func checkWorkspaceTrust() []agentCheck {
 	}
 	var checks []agentCheck
 	for _, ws := range registry.Sorted() {
-		absPath, configDir, ok := workspaceSessionTarget(ws.ID)
+		absPath, configDir, ok := workspaceSessionTarget(ws.ID, runningProfile(ws.ID))
 		if !ok || absPath == "" {
 			continue
 		}

--- a/cmd/agent_up.go
+++ b/cmd/agent_up.go
@@ -115,7 +115,7 @@ func runAgentUp(cmd *cobra.Command, _ []string) {
 		// Same trust pre-check init does: an untrusted folder produces a phone
 		// card that can only ever fail, so say it now, while the fix is one
 		// `claude` run away in the terminal the user is already in.
-		if absPath, cfgDir, ok := workspaceSessionTarget(res.Workspace); ok {
+		if absPath, cfgDir, ok := workspaceSessionTarget(res.Workspace, runningProfile(res.Workspace)); ok {
 			warnIfUntrusted(cfgDir, absPath)
 		}
 	}

--- a/cmd/agent_workspace_test.go
+++ b/cmd/agent_workspace_test.go
@@ -66,18 +66,34 @@ func TestWorkspaceSessionTarget(t *testing.T) {
 	t.Setenv("CORGI_DATA_DIR", t.TempDir())
 	agentD := mustAgentDir()
 
-	if _, _, ok := workspaceSessionTarget("nope"); ok {
+	if _, _, ok := workspaceSessionTarget("nope", ""); ok {
 		t.Error("an unknown workspace must not resolve")
 	}
 
 	stack := stackWithAgentConfig(t, "")
 	registerStack(t, agentD, "acme", stack)
-	absPath, configDir, ok := workspaceSessionTarget("acme")
+	absPath, configDir, ok := workspaceSessionTarget("acme", "")
 	if !ok || absPath != stack {
 		t.Fatalf("workspaceSessionTarget = %q, %v; want the registry path", absPath, ok)
 	}
 	if configDir != "" {
 		t.Errorf("no user config → default account, got %q", configDir)
+	}
+
+	// A workspace running under a profile keeps its sessions and transcripts in
+	// that account's config dir; resolving the default one is why the phone
+	// showed no sessions and no tokens for a second-account workspace.
+	if err := os.WriteFile(agentUserConfigPath(agentD),
+		[]byte("version: 1\nprofiles:\n  work:\n    configDir: ~/claude-configs/work\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, configDir, _ := workspaceSessionTarget("acme", "work"); configDir != "~/claude-configs/work" {
+		t.Errorf("configDir = %q, want the profile's account dir", configDir)
+	}
+	// An unknown profile falls back to the default account rather than failing:
+	// the start that named it already refused.
+	if _, configDir, _ := workspaceSessionTarget("acme", "ghost"); configDir != "" {
+		t.Errorf("configDir = %q, want the default account for an unknown profile", configDir)
 	}
 }
 

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -83,7 +83,7 @@ func registerAgentMCPTools(s *server.MCPServer) {
 				"named entry from the trusted agent config (a different Claude account, e.g. \"work\")."),
 		mcp.WithString("workspace", mcp.Required(), mcp.Description("Workspace id, alias, or human name")),
 		mcp.WithString("profile", mcp.Description("Profile name from the agent config's profiles: section")),
-		mcp.WithString("name", mcp.Description("Session name shown in claude.ai/code, e.g. \"fix login redirect\"")),
+		mcp.WithString("name", mcp.Description("Session name shown in claude.ai/code, e.g. \"fix login redirect\". Defaults to the workspace, its branch and the start time — pass one whenever the task is known, it reads better in the list.")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
 		return mcpSessionStart(r.GetString("workspace", ""), r.GetString("profile", ""), r.GetString("name", ""))
 	}))

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/daemon"
 	"andriiklymiuk/corgi/utils/agent/events"
@@ -47,7 +48,22 @@ type launchWorkspace struct {
 	Note         string   `json:"note,omitempty"`
 	// State is the one word the card leads with: what this workspace is doing
 	// right now, decided here rather than in three places in the page.
-	State      string            `json:"state"`
+	State string `json:"state"`
+	// Everything from here down the daemon already knew and the phone could
+	// not see: `corgi agent status` on the laptop said more than the page you
+	// carry around.
+	Disabled  bool   `json:"disabled,omitempty"`
+	StartedAt int64  `json:"startedAt,omitempty"`
+	Restarts  int    `json:"restarts,omitempty"`
+	Profile   string `json:"profile,omitempty"`
+	WakeLock  bool   `json:"wakeLock,omitempty"`
+	Origin    string `json:"origin,omitempty"`
+	PID       int    `json:"pid,omitempty"`
+	LastCause string `json:"lastCause,omitempty"`
+	// Branch and Dirty describe the checkout a session here would start on —
+	// the answer to "which of these two is the one I was working in?".
+	Branch     string            `json:"branch,omitempty"`
+	Dirty      bool              `json:"dirty,omitempty"`
 	Live       int               `json:"live"`
 	TopSession *launchTopSession `json:"topSession,omitempty"`
 	Usage      *usage.Report     `json:"usage,omitempty"`
@@ -64,6 +80,10 @@ type launchTopSession struct {
 	// since renamed reads as its new name here too.
 	NameSource string `json:"nameSource,omitempty"`
 	NameSince  int64  `json:"nameSince,omitempty"`
+	// WaitingFor is what Claude Code says this session is blocked on, when it
+	// says anything ("input needed", "dialog open", "sandbox request"). Absent
+	// means it did not say, never that the session is idle.
+	WaitingFor string `json:"waitingFor,omitempty"`
 	Where      string `json:"where"`
 	StartedAt  int64  `json:"startedAt,omitempty"`
 	URL        string `json:"url,omitempty"`
@@ -98,10 +118,18 @@ func launchWorkspacesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type wsRunState struct {
-	running  bool
-	url      string
-	note     string
-	sessions []string
+	running   bool
+	url       string
+	note      string
+	sessions  []string
+	disabled  bool
+	startedAt int64
+	restarts  int
+	profile   string
+	wakeLock  bool
+	origin    string
+	pid       int
+	lastCause string
 }
 
 // buildLaunchWorkspaces joins the registry with the daemon's live status into
@@ -112,7 +140,16 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 	running := map[string]wsRunState{}
 	if status != nil {
 		for _, ws := range status.Workspaces {
-			running[ws.WorkspaceID] = wsRunState{running: ws.Running, url: ws.SessionURL, note: ws.LastReason, sessions: ws.Sessions}
+			started := int64(0)
+			if !ws.StartedAt.IsZero() {
+				started = ws.StartedAt.UnixMilli()
+			}
+			running[ws.WorkspaceID] = wsRunState{
+				running: ws.Running, url: ws.SessionURL, note: ws.LastReason, sessions: ws.Sessions,
+				disabled: ws.Disabled, startedAt: started, restarts: ws.Restarts,
+				profile: ws.Profile, wakeLock: ws.WakeLock, origin: ws.Origin,
+				pid: ws.PID, lastCause: string(ws.LastCause),
+			}
 		}
 		for _, d := range status.Diagnostics {
 			if d.Warning == "" {
@@ -132,9 +169,13 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 			ID: ws.ID, Aliases: ws.Aliases, Path: ws.AbsPath,
 			Status: string(ws.Status), Running: s.running, SessionURL: s.url,
 			SessionLinks: s.sessions, Note: s.note, Profiles: profiles,
+			Disabled: s.disabled, StartedAt: s.startedAt, Restarts: s.restarts,
+			Profile: s.profile, WakeLock: s.wakeLock, Origin: s.origin,
+			PID: s.pid, LastCause: s.lastCause,
 		}
-		row.Live, row.TopSession, row.LastEvent = workspaceActivity(ws.ID, ws.AbsPath)
-		row.Usage = workspaceUsage(ws.ID, ws.AbsPath)
+		row.Branch, row.Dirty = workspaceCheckout(ws.ID, ws.AbsPath)
+		row.Live, row.TopSession, row.LastEvent = workspaceActivity(ws.ID, ws.AbsPath, s.profile)
+		row.Usage = workspaceUsage(ws.ID, ws.AbsPath, s.profile)
 		row.State = launchState(row)
 		out = append(out, row)
 	}
@@ -149,6 +190,11 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 // the daemon is supervising, not whether a human is needed.
 func launchState(row launchWorkspace) string {
 	switch {
+	case row.Disabled:
+		// The daemon gave up on this one after repeated failures. It looked
+		// exactly like "stopped" on the phone, and Start on a disabled
+		// workspace is the tap that appears to do nothing.
+		return "disabled"
 	case row.Note != "" && !row.Running:
 		// A start the daemon refused, or a diagnostic: the reason is on the card.
 		return "blocked"
@@ -165,12 +211,12 @@ func launchState(row launchWorkspace) string {
 	return "stopped"
 }
 
-func workspaceActivity(id, absPath string) (int, *launchTopSession, *launchLastEvent) {
+func workspaceActivity(id, absPath, profile string) (int, *launchTopSession, *launchLastEvent) {
 	// The pid-file reader, never listClaudeSessions: its fallback shells out,
 	// and this runs per workspace on a list the phone polls while starting.
 	var live int
 	var top *launchTopSession
-	if _, configDir, ok := workspaceSessionTarget(id); ok && absPath != "" {
+	if _, configDir, ok := workspaceSessionTarget(id, profile); ok && absPath != "" {
 		if sessions, read := localClaudeSessions(absPath, configDir); read {
 			live = len(sessions)
 			top = newestLiveSession(sessions)
@@ -197,6 +243,7 @@ func newestLiveSession(sessions []claudeSession) *launchTopSession {
 			Name:       sessionDisplayName(sess),
 			NameSource: sess.NameSource,
 			NameSince:  sess.NameSince,
+			WaitingFor: sessionWaitingFor(sess),
 			Where:      sessionWhereLabel(sess),
 			StartedAt:  sess.StartedAt,
 			URL:        sess.URL,
@@ -209,6 +256,7 @@ func newestLiveSession(sessions []claudeSession) *launchTopSession {
 		Name:       sessionDisplayName(sessions[0]),
 		NameSource: sessions[0].NameSource,
 		NameSince:  sessions[0].NameSince,
+		WaitingFor: sessionWaitingFor(sessions[0]),
 		Where:      sessionWhereLabel(sessions[0]),
 		StartedAt:  sessions[0].StartedAt,
 	}
@@ -219,6 +267,19 @@ func sessionDisplayName(sess claudeSession) string {
 		return sess.Name
 	}
 	return "session"
+}
+
+// sessionWaitingFor reports what a session is blocked on, in Claude Code's own
+// words, and only when it actually said so: "waiting" with nothing named, or a
+// session that never writes status at all, must not read as an answer.
+func sessionWaitingFor(sess claudeSession) string {
+	if w := strings.TrimSpace(sess.WaitingFor); w != "" {
+		return w
+	}
+	if strings.EqualFold(sess.Status, "waiting") || strings.EqualFold(sess.Tempo, "blocked") {
+		return "your answer"
+	}
+	return ""
 }
 
 func sessionWhereLabel(sess claudeSession) string {
@@ -234,6 +295,60 @@ func sessionWhereLabel(sess claudeSession) string {
 		return sess.Kind
 	}
 	return "session"
+}
+
+// checkoutTTL bounds how often the branch probe runs. `git status` on a big
+// repo is not free and this list is polled every second while a session
+// starts, so the request path serves the last answer and refreshes behind it —
+// the same deal as the usage sums below.
+const checkoutTTL = 20 * time.Second
+
+var checkoutCache = struct {
+	mu    sync.Mutex
+	repos map[string]*cachedCheckout
+}{repos: map[string]*cachedCheckout{}}
+
+type cachedCheckout struct {
+	branch     string
+	dirty      bool
+	computed   time.Time
+	refreshing bool
+}
+
+func workspaceCheckout(id, absPath string) (string, bool) {
+	if absPath == "" {
+		return "", false
+	}
+	checkoutCache.mu.Lock()
+	defer checkoutCache.mu.Unlock()
+	entry := checkoutCache.repos[id]
+	if entry == nil {
+		entry = &cachedCheckout{}
+		checkoutCache.repos[id] = entry
+	}
+	fresh := !entry.computed.IsZero() && time.Since(entry.computed) < checkoutTTL
+	if !fresh && !entry.refreshing {
+		entry.refreshing = true
+		go refreshCheckout(id, absPath)
+	}
+	return entry.branch, entry.dirty
+}
+
+func refreshCheckout(id, absPath string) {
+	state, ok := utils.ProbeRepoState(absPath)
+	checkoutCache.mu.Lock()
+	defer checkoutCache.mu.Unlock()
+	entry := checkoutCache.repos[id]
+	if entry == nil {
+		return
+	}
+	entry.refreshing = false
+	entry.computed = time.Now()
+	if !ok {
+		entry.branch, entry.dirty = "", false
+		return
+	}
+	entry.branch, entry.dirty = state.Branch, state.Dirty
 }
 
 // usageTTL is how long a summed report is reused. Summing a workspace means
@@ -256,36 +371,40 @@ type cachedUsage struct {
 // Zero across both windows is reported as nothing, so an idle workspace shows
 // no number rather than a row of noughts. A stale report is served while a
 // fresh one is summed in the background.
-func workspaceUsage(id, absPath string) *usage.Report {
+func workspaceUsage(id, absPath, profile string) *usage.Report {
 	if absPath == "" {
 		return nil
 	}
-	_, configDir, ok := workspaceSessionTarget(id)
+	_, configDir, ok := workspaceSessionTarget(id, profile)
 	if !ok {
 		return nil
 	}
 
+	// Keyed by account too: the same workspace under a different profile has a
+	// different transcript directory, and a stale entry would report the other
+	// account's tokens.
+	key := id + "\x00" + profile
 	usageCache.mu.Lock()
-	entry := usageCache.reps[id]
+	entry := usageCache.reps[key]
 	if entry == nil {
 		entry = &cachedUsage{}
-		usageCache.reps[id] = entry
+		usageCache.reps[key] = entry
 	}
 	fresh := !entry.computed.IsZero() && time.Since(entry.computed) < usageTTL
 	report := entry.report
 	if !fresh && !entry.refreshing {
 		entry.refreshing = true
-		go refreshUsage(id, absPath, expandTilde(configDir))
+		go refreshUsage(key, absPath, expandTilde(configDir))
 	}
 	usageCache.mu.Unlock()
 	return report
 }
 
-func refreshUsage(id, absPath, configDir string) {
+func refreshUsage(key, absPath, configDir string) {
 	rep := usage.ForDir(absPath, configDir, mungeClaudeProjectDir(absPath), time.Now())
 	usageCache.mu.Lock()
 	defer usageCache.mu.Unlock()
-	entry := usageCache.reps[id]
+	entry := usageCache.reps[key]
 	if entry == nil {
 		return
 	}
@@ -379,8 +498,19 @@ func launchStopHandler(w http.ResponseWriter, r *http.Request) {
 type claudeSession struct {
 	Name string `json:"name"`
 	// Written by Claude Code beside the name; see launchTopSession.
-	NameSource      string `json:"nameSource,omitempty"`
-	NameSince       int64  `json:"nameSince,omitempty"`
+	NameSource string `json:"nameSource,omitempty"`
+	NameSince  int64  `json:"nameSince,omitempty"`
+	// ProcStart is the process's start time as the OS reports it. Claude Code
+	// records it so a recycled pid cannot pass for the process that wrote the
+	// record — see sessionProcessIsLive.
+	ProcStart string `json:"procStart,omitempty"`
+	// Status, WaitingFor and Tempo are Claude Code's own live view of the
+	// session. Not every session writes them (an interactive one on a laptop
+	// often does not), so everything reading them treats absent as unknown
+	// rather than idle.
+	Status          string `json:"status,omitempty"`
+	WaitingFor      string `json:"waitingFor,omitempty"`
+	Tempo           string `json:"tempo,omitempty"`
 	SessionID       string `json:"sessionId"`
 	CWD             string `json:"cwd"`
 	Kind            string `json:"kind"`
@@ -406,7 +536,7 @@ func launchSessionsHandler(w http.ResponseWriter, r *http.Request) {
 		writeLaunchError(w, http.StatusBadRequest, "a workspace is required")
 		return
 	}
-	absPath, configDir, ok := workspaceSessionTarget(id)
+	absPath, configDir, ok := workspaceSessionTarget(id, runningProfile(id))
 	if !ok {
 		writeLaunchError(w, http.StatusNotFound, "unknown workspace")
 		return
@@ -580,7 +710,13 @@ func sessionHistory(workspaceID string) []launchHistoryEntry {
 // config dir (account) its sessions live under. The id is the trusted registry
 // key, and the directory comes from the registry — never from the caller — so a
 // device token cannot point the shell-out at an arbitrary path.
-func workspaceSessionTarget(id string) (absPath, configDir string, ok bool) {
+// workspaceSessionTarget resolves where a workspace's Claude state lives.
+//
+// profile matters: a workspace running under one keeps its session records and
+// its transcripts in that account's config dir, so resolving the default one
+// showed the phone no sessions and no token counts for exactly the workspaces
+// that run under a second account. Pass "" for the default account.
+func workspaceSessionTarget(id, profile string) (absPath, configDir string, ok bool) {
 	registry, _, err := agentRegistry()
 	if err != nil {
 		return "", "", false
@@ -598,7 +734,34 @@ func workspaceSessionTarget(id string) (absPath, configDir string, ok bool) {
 		return ws.AbsPath, "", true
 	}
 	repo, _ := config.LoadRepo(ws.AbsPath)
-	return ws.AbsPath, config.Resolve(id, repo, user).ConfigDir, true
+	resolved := config.Resolve(id, repo, user)
+	if p := strings.TrimSpace(profile); p != "" {
+		// An unknown profile is not this function's error to report — the start
+		// that named it already refused — so fall back to the default account.
+		if withProfile, perr := config.ApplyProfile(resolved, user, p); perr == nil {
+			resolved = withProfile
+		}
+	}
+	return ws.AbsPath, resolved.ConfigDir, true
+}
+
+// runningProfile is the account the daemon actually started this workspace
+// under, for the handlers that are given an id and nothing else.
+func runningProfile(id string) string {
+	dir, err := agentDir()
+	if err != nil {
+		return ""
+	}
+	status, err := daemon.ReadStatus(dir)
+	if err != nil || status == nil {
+		return ""
+	}
+	for _, ws := range status.Workspaces {
+		if ws.WorkspaceID == id {
+			return ws.Profile
+		}
+	}
+	return ""
 }
 
 // bridgeSessionLinks reads the claude.ai session URL a remote-control bridge
@@ -641,6 +804,56 @@ func mungeClaudeProjectDir(dir string) string {
 
 // pidExists is a plain liveness probe. Not PidAlive: a hand-started bridge runs
 // under a shell and is no process-group leader, which PidAlive requires.
+// sessionProcessIsLive answers whether the process that wrote a session record
+// is still the process running under that pid.
+//
+// A live pid is not enough on its own: session records outlive the machine
+// (they sit in the config dir across reboots) and pids are handed out again
+// from low numbers after one, so a stale record whose pid now belongs to
+// something else made a finished session show up as live — a phantom "1 live"
+// on a workspace with nothing running in it. Claude Code writes procStart for
+// exactly this check, so where the OS will tell us a process's start time
+// cheaply, compare it. Where it will not, a live pid stays the best answer
+// available, which is what this did everywhere before.
+func sessionProcessIsLive(cs claudeSession) bool {
+	if !pidExists(cs.PID) {
+		return false
+	}
+	started, ok := processStartTicks(cs.PID)
+	if !ok || strings.TrimSpace(cs.ProcStart) == "" {
+		return true
+	}
+	return strings.TrimSpace(cs.ProcStart) == started
+}
+
+// processStartTicks reads the start time Linux keeps for a pid (field 22 of
+// /proc/<pid>/stat, in clock ticks since boot) — the same value Claude Code
+// stores. ok is false anywhere else, including macOS, where the equivalent
+// costs a subprocess per session and this list is polled every second.
+func processStartTicks(pid int) (string, bool) {
+	if runtime.GOOS != "linux" || pid <= 0 {
+		return "", false
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return "", false
+	}
+	// The second field is the executable name in parentheses and may itself
+	// contain spaces and parentheses, so fields are counted from the last ')'.
+	close := strings.LastIndex(string(data), ")")
+	if close < 0 {
+		return "", false
+	}
+	fields := strings.Fields(string(data)[close+1:])
+	// state is the field after comm, so starttime (22nd overall) is index 19
+	// of what is left.
+	const startTimeOffset = 19
+	if len(fields) <= startTimeOffset {
+		return "", false
+	}
+	return fields[startTimeOffset], true
+}
+
 func pidExists(pid int) bool {
 	if pid <= 0 {
 		return false
@@ -698,7 +911,7 @@ func localClaudeSessions(absPath, configDir string) ([]claudeSession, bool) {
 		if cs.CWD != absPath && !strings.HasPrefix(cs.CWD, absPath+string(filepath.Separator)) {
 			continue
 		}
-		if !pidExists(cs.PID) {
+		if !sessionProcessIsLive(cs) {
 			continue
 		}
 		if strings.HasPrefix(cs.BridgeSessionID, "session_") {
@@ -876,6 +1089,9 @@ const launcherPageHTML = `<!doctype html>
   .sessions .s .when{color:var(--dim2);font-size:.68rem;flex:0 0 auto;max-width:60%;
       overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .sessions .none,.sessions .hint{color:var(--dim2);font-size:.7rem;line-height:1.45;padding:.2rem 0}
+  .kv{display:flex;gap:.6rem;font-size:.72rem;padding:.22rem .1rem;line-height:1.45}
+  .kv b{color:var(--dim2);font-weight:600;flex:0 0 5.4rem}
+  .kv span{color:#c9cfda;min-width:0}
   .tag{font-size:.6rem;font-weight:700;color:var(--amber);border:1px solid rgba(255,166,87,.4);
       border-radius:.35rem;padding:.05rem .3rem;margin-left:.45rem;vertical-align:1px;flex:0 0 auto;
       white-space:nowrap}
@@ -1273,10 +1489,12 @@ const launcherPageHTML = `<!doctype html>
       main.className = 'main';
       main.innerHTML = '<div class="name"><span class="dot ' + esc(dotState(ws)) + '"></span>' + esc(ws.id) + '</div>';
       const path = document.createElement('div');
-      path.className = 'path'; path.title = ws.path; path.textContent = shortPath(ws.path);
+      path.className = 'path'; path.title = ws.path;
+      const short = () => shortPath(ws.path, !!ws.branch) + branchSuffix(ws);
+      path.textContent = short();
       path.onclick = () => {
         const full = path.classList.toggle('full');
-        path.textContent = full ? ws.path : shortPath(ws.path);
+        path.textContent = full ? ws.path + branchSuffix(ws) : short();
       };
       main.appendChild(path);
       const meta = metaLine(ws);
@@ -1408,6 +1626,15 @@ const launcherPageHTML = `<!doctype html>
     if (ws.live > 0) bits.push('<span class="live">' + ws.live + ' live</span>');
     else if (ws.state === 'starting') bits.push('<span class="live">starting</span>');
     else if (ws.state === 'blocked') bits.push('<span class="warn">will not start</span>');
+    else if (ws.state === 'disabled') bits.push('<span class="warn">disabled after repeated failures</span>');
+    // What the daemon knew all along and the phone never showed.
+    const waiting = shortWait(ws.topSession && ws.topSession.waitingFor);
+    if (waiting) bits.push('<span class="warn">waiting: ' + esc(waiting) + '</span>');
+    if (ws.running && ws.startedAt) bits.push('<span>up ' + esc(fmtSpan(Date.now() - ws.startedAt)) + '</span>');
+    if (ws.running && ws.restarts > 0) {
+      bits.push('<span>' + ws.restarts + ' restart' + (ws.restarts > 1 ? 's' : '') + '</span>');
+    }
+    if (ws.profile) bits.push('<span>' + esc(ws.profile) + ' account</span>');
     const e = ws.lastEvent;
     if (e && !(ws.running && e.kind === 'started')) {
       const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + esc(e.cause) : '')
@@ -1460,9 +1687,25 @@ const launcherPageHTML = `<!doctype html>
     return box;
   }
 
-  function shortPath(p) {
+  // The branch a session here would start on, with a * for uncommitted work —
+  // the answer to "which of these two checkouts am I looking at?". Clamped,
+  // because a branch name has no upper bound and the path is sharing the line.
+  function branchSuffix(ws) {
+    if (!ws.branch) return '';
+    return ' \u00b7 ' + clamp(ws.branch, 24) + (ws.dirty ? '*' : '');
+  }
+
+  function clamp(text, max) {
+    const s = String(text || '');
+    return s.length > max ? s.slice(0, max - 1) + '\u2026' : s;
+  }
+
+  // tight drops another segment: when the branch is sharing this line, the
+  // repo directory identifies the checkout and its parents do not.
+  function shortPath(p, tight) {
     const parts = String(p || '').split('/').filter(Boolean);
-    return parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
+    const keep = tight ? 1 : 2;
+    return parts.length > keep ? '…/' + parts.slice(-keep).join('/') : p;
   }
 
   async function toggleSessions(ws, btn, box) {
@@ -1531,7 +1774,9 @@ const launcherPageHTML = `<!doctype html>
       if (liveCount) group('live now');
       for (const sess of running) {
         const where = whereLabel(sess);
-        const when = where + ' \u00b7 ' + fmtWhen(sess.startedAt);
+        const waiting = sessionWaiting(sess);
+        const when = where + ' \u00b7 ' + fmtWhen(sess.startedAt) +
+          (waiting ? ' \u00b7 waiting: ' + waiting : '');
         if (sess.url && safeClaudeUrl(sess.url) && !seen.has(sess.url)) {
           seen.add(sess.url);
           renderLink(sess.url, {
@@ -1574,7 +1819,47 @@ const launcherPageHTML = `<!doctype html>
         el.innerHTML = '<b>' + esc(what.slice(0, 90)) + '</b><span>' + esc(fmtWhen(ev.at)) + '</span>';
         box.appendChild(el);
       }
+      renderWorkspaceFacts(ws, box, group);
     } catch (e) { info.textContent = '\u2717 ' + e.message; }
+  }
+
+  // What the daemon knows about this workspace and the card has no room for.
+  // corgi agent status on the laptop always showed these; the phone did not.
+  function workspaceFacts(ws) {
+    const facts = [];
+    if (ws.branch) facts.push(['checkout', ws.branch + (ws.dirty ? ' \u00b7 uncommitted work' : ' \u00b7 clean')]);
+    if (ws.profile) facts.push(['account', ws.profile]);
+    if (ws.running && ws.startedAt) {
+      const how = ws.origin === 'remote' ? ' \u00b7 started from a phone'
+        : ws.origin === 'auto' ? ' \u00b7 started with the daemon' : '';
+      facts.push(['supervised', 'for ' + fmtSpan(Date.now() - ws.startedAt) + how]);
+    }
+    if (ws.restarts > 0) facts.push(['restarts', String(ws.restarts) + (ws.lastCause ? ' \u00b7 last ' + ws.lastCause : '')]);
+    else if (ws.lastCause) facts.push(['last exit', ws.lastCause]);
+    if (ws.wakeLock) facts.push(['wake lock', 'the machine is held awake while this runs']);
+    if (ws.pid) facts.push(['pid', String(ws.pid)]);
+    if (ws.disabled) facts.push(['disabled', 'the daemon stopped retrying this one \u2014 fix the cause, then Start']);
+    return facts;
+  }
+
+  function renderWorkspaceFacts(ws, box, group) {
+    const facts = workspaceFacts(ws);
+    if (!facts.length) return;
+    group('this workspace');
+    for (const [label, value] of facts) {
+      const el = document.createElement('div');
+      el.className = 'kv';
+      el.innerHTML = '<b>' + esc(label) + '</b><span>' + esc(value) + '</span>';
+      box.appendChild(el);
+    }
+  }
+
+  // Claude Code names what a session is blocked on when it knows; absent means
+  // it did not say, not that the session is idle.
+  function sessionWaiting(sess) {
+    if (sess.waitingFor) return sess.waitingFor;
+    if (sess.status === 'waiting' || sess.tempo === 'blocked') return 'your answer';
+    return '';
   }
 
   function whereLabel(sess) {
@@ -1585,10 +1870,28 @@ const launcherPageHTML = `<!doctype html>
   }
 
   function fmtTokens(n) {
-    if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B';
-    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
-    if (n >= 1e3) return Math.round(n / 1e3) + 'k';
+    // Rounding is applied before the threshold is chosen: 999,500 is 1.0M, not
+    // "1000k", and 999,999,500 is 1.0B.
+    if (Math.round(n / 1e8) >= 10) return (n / 1e9).toFixed(1) + 'B';
+    if (Math.round(n / 1e5) >= 10) return (n / 1e6).toFixed(1) + 'M';
+    if (Math.round(n / 1e3) >= 1) return Math.round(n / 1e3) + 'k';
     return String(n || 0);
+  }
+
+  // "choose: allow or deny the edit" is written for a dialog box; the card has
+  // room for the ask, not the sentence.
+  function shortWait(text) {
+    if (!text) return '';
+    return clamp(String(text).replace(/^choose:\s*/i, ''), 28);
+  }
+
+  function fmtSpan(ms) {
+    const mins = Math.floor(ms / 60000);
+    if (mins < 1) return 'a moment';
+    if (mins < 60) return mins + 'm';
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return hours + 'h';
+    return Math.floor(hours / 24) + 'd';
   }
 
   function fmtWhen(ms) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -43,20 +43,30 @@ type launchWorkspace struct {
 	// SessionLinks are per-session claude.ai URLs captured from remote
 	// control's own output — the only links the site resolves (the ids the
 	// claude CLI lists locally are UUIDs the web does not know).
-	SessionLinks []string          `json:"sessionLinks,omitempty"`
-	Note         string            `json:"note,omitempty"`
-	Live         int               `json:"live"`
-	TopSession   *launchTopSession `json:"topSession,omitempty"`
-	Usage        *usage.Report     `json:"usage,omitempty"`
-	LastEvent    *launchLastEvent  `json:"lastEvent,omitempty"`
-	Profiles     []string          `json:"profiles,omitempty"`
+	SessionLinks []string `json:"sessionLinks,omitempty"`
+	Note         string   `json:"note,omitempty"`
+	// State is the one word the card leads with: what this workspace is doing
+	// right now, decided here rather than in three places in the page.
+	State      string            `json:"state"`
+	Live       int               `json:"live"`
+	TopSession *launchTopSession `json:"topSession,omitempty"`
+	Usage      *usage.Report     `json:"usage,omitempty"`
+	LastEvent  *launchLastEvent  `json:"lastEvent,omitempty"`
+	Profiles   []string          `json:"profiles,omitempty"`
 }
 
 type launchTopSession struct {
-	Name      string `json:"name"`
-	Where     string `json:"where"`
-	StartedAt int64  `json:"startedAt,omitempty"`
-	URL       string `json:"url,omitempty"`
+	Name string `json:"name"`
+	// NameSource and NameSince are Claude Code's own record of where the
+	// session's current name came from — "user" for one someone typed,
+	// "derived"/"auto" for one Claude picked, "hook" for one a hook set — and
+	// when it last changed. corgi shows the live name, so a session Claude has
+	// since renamed reads as its new name here too.
+	NameSource string `json:"nameSource,omitempty"`
+	NameSince  int64  `json:"nameSince,omitempty"`
+	Where      string `json:"where"`
+	StartedAt  int64  `json:"startedAt,omitempty"`
+	URL        string `json:"url,omitempty"`
 }
 
 type launchLastEvent struct {
@@ -125,10 +135,34 @@ func buildLaunchWorkspaces(registry *workspace.Registry, status *daemon.Status) 
 		}
 		row.Live, row.TopSession, row.LastEvent = workspaceActivity(ws.ID, ws.AbsPath)
 		row.Usage = workspaceUsage(ws.ID, ws.AbsPath)
+		row.State = launchState(row)
 		out = append(out, row)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
+}
+
+// launchState reduces running, live sessions, the last event and a refused
+// start to the one word the card leads with. Decided here so the phone and
+// anything else reading /launch/workspaces agree on it. Finer than `corgi
+// agent status`'s workspaceState, which answers a different question: whether
+// the daemon is supervising, not whether a human is needed.
+func launchState(row launchWorkspace) string {
+	switch {
+	case row.Note != "" && !row.Running:
+		// A start the daemon refused, or a diagnostic: the reason is on the card.
+		return "blocked"
+	case row.LastEvent != nil && row.LastEvent.Kind == "attention":
+		// A permission prompt or a question is blocking the session — the one
+		// state where the session is running and still needs a human.
+		return "attention"
+	case row.Live > 0:
+		return "live"
+	case row.Running:
+		// Supervised, but no session has registered yet.
+		return "starting"
+	}
+	return "stopped"
 }
 
 func workspaceActivity(id, absPath string) (int, *launchTopSession, *launchLastEvent) {
@@ -160,19 +194,23 @@ func newestLiveSession(sessions []claudeSession) *launchTopSession {
 			continue
 		}
 		return &launchTopSession{
-			Name:      sessionDisplayName(sess),
-			Where:     sessionWhereLabel(sess),
-			StartedAt: sess.StartedAt,
-			URL:       sess.URL,
+			Name:       sessionDisplayName(sess),
+			NameSource: sess.NameSource,
+			NameSince:  sess.NameSince,
+			Where:      sessionWhereLabel(sess),
+			StartedAt:  sess.StartedAt,
+			URL:        sess.URL,
 		}
 	}
 	if len(sessions) == 0 {
 		return nil
 	}
 	return &launchTopSession{
-		Name:      sessionDisplayName(sessions[0]),
-		Where:     sessionWhereLabel(sessions[0]),
-		StartedAt: sessions[0].StartedAt,
+		Name:       sessionDisplayName(sessions[0]),
+		NameSource: sessions[0].NameSource,
+		NameSince:  sessions[0].NameSince,
+		Where:      sessionWhereLabel(sessions[0]),
+		StartedAt:  sessions[0].StartedAt,
 	}
 }
 
@@ -339,7 +377,10 @@ func launchStopHandler(w http.ResponseWriter, r *http.Request) {
 // the one the site resolves — so a terminal or VS Code session gets a real
 // link, unlike its local SessionID, which the web does not know.
 type claudeSession struct {
-	Name            string `json:"name"`
+	Name string `json:"name"`
+	// Written by Claude Code beside the name; see launchTopSession.
+	NameSource      string `json:"nameSource,omitempty"`
+	NameSince       int64  `json:"nameSince,omitempty"`
 	SessionID       string `json:"sessionId"`
 	CWD             string `json:"cwd"`
 	Kind            string `json:"kind"`
@@ -733,17 +774,17 @@ const launcherPageHTML = `<!doctype html>
 <meta name="theme-color" content="#000000">
 <title>corgi</title>
 <style>
-  /* One scale, one contrast ladder. Sizes are the ones a thumb and an arm's
-     length of daylight need — this page is read on a phone, outdoors, in a
-     hurry, so nothing here is smaller than 12px or shorter than 44px. */
+  /* Compact by default: this is a list you scan, not a poster. Sizes sit where
+     the old page had them — 11-14px, 30px controls — with the spacing and the
+     hairlines doing the work that bigger type was doing badly. */
   :root{
-    --bg:#000;--surface:#101114;--surface2:#191a1e;--press:#212227;
-    --line:#26272c;--hair:#1c1d21;
-    --text:#fff;--dim:#a3a6ad;--dim2:#74777f;
-    --green:#3ddc91;--amber:#ffb84d;--red:#ff6f61;
-    --r:18px;--r-sm:12px;--pill:999px;
-    --tap:48px;--pad:20px;
-    --f-title:1.45rem;--f-row:1.06rem;--f-body:.95rem;--f-sub:.82rem;--f-cap:.75rem;
+    --bg:#08090a;--surface:#0f1012;--surface2:#16171a;--press:#1d1e22;
+    --line:#212228;--hair:#191a1e;
+    --text:#e9eaec;--dim:#9a9ca4;--dim2:#6b6d76;
+    --green:#4cc38a;--amber:#e2a03f;--red:#f2555a;
+    --r:.6rem;--r-sm:.42rem;--pill:999px;
+    --pad:1rem;
+    --f-h1:1.05rem;--f-row:.875rem;--f-body:.8rem;--f-sub:.74rem;--f-cap:.68rem;
   }
   *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
   /* Flex and grid beat the hidden attribute on specificity; this page toggles
@@ -753,210 +794,212 @@ const launcherPageHTML = `<!doctype html>
   body{margin:0;background:var(--bg);color:var(--text);
       font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;
       font-size:var(--f-body);line-height:1.45;-webkit-font-smoothing:antialiased;
-      padding-bottom:calc(2rem + env(safe-area-inset-bottom))}
-  h1,h2,h3{margin:0;letter-spacing:-.02em}
+      padding-bottom:calc(1.5rem + env(safe-area-inset-bottom))}
+  h1,h2,h3{margin:0;letter-spacing:-.01em}
   button,input,select{font-family:inherit}
   button,a,summary,label,input,[role=button]{touch-action:manipulation}
-  :focus-visible{outline:2px solid var(--text);outline-offset:2px;border-radius:6px}
+  :focus-visible{outline:1px solid var(--dim);outline-offset:2px;border-radius:4px}
 
-  /* Header: stays put, so the machine you are driving is never off-screen. */
-  header{position:sticky;top:0;z-index:20;padding:calc(.85rem + env(safe-area-inset-top)) var(--pad) .85rem;
-      background:rgba(0,0,0,.78);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
-      border-bottom:1px solid transparent;transition:border-color .2s}
+  header{position:sticky;top:0;z-index:20;padding:calc(.7rem + env(safe-area-inset-top)) var(--pad) .7rem;
+      background:rgba(8,9,10,.86);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+      border-bottom:1px solid transparent;transition:border-color .15s}
   header.scrolled{border-bottom-color:var(--hair)}
-  .bar{display:flex;align-items:center;gap:.75rem;max-width:34rem;margin:0 auto}
-  .logo{width:2.5rem;height:2.5rem;border-radius:.85rem;background:var(--surface2);
-      display:flex;align-items:center;justify-content:center;font-size:1.3rem;flex:0 0 auto}
+  .bar{display:flex;align-items:center;gap:.55rem;max-width:34rem;margin:0 auto}
+  .logo{width:1.65rem;height:1.65rem;border-radius:.45rem;background:var(--surface2);
+      display:flex;align-items:center;justify-content:center;font-size:.9rem;flex:0 0 auto}
   .bar .main{min-width:0;flex:1}
-  h1{font-size:var(--f-title);font-weight:800;line-height:1.1}
-  #host{display:block;color:var(--dim);font-size:var(--f-sub);margin-top:.1rem;line-height:1.35}
-  #host .what{color:var(--dim);border-bottom:1px dotted var(--dim2);cursor:pointer}
+  h1{font-size:var(--f-h1);font-weight:650;line-height:1.2}
+  #host{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem;line-height:1.35}
+  #host .what{color:var(--dim2);border-bottom:1px dotted #33353c;cursor:pointer}
   #host .down{color:var(--red)}
-  .icon{width:var(--tap);height:var(--tap);border-radius:var(--pill);border:0;flex:0 0 auto;
-      background:var(--surface2);color:var(--text);font-size:1.15rem;cursor:pointer;
+  .icon{width:1.9rem;height:1.9rem;border-radius:var(--r-sm);border:1px solid var(--line);flex:0 0 auto;
+      background:var(--surface);color:var(--dim);font-size:.8rem;cursor:pointer;
       display:flex;align-items:center;justify-content:center}
-  .icon:active{background:var(--press)}
-  .icon.spin{animation:spin .8s linear infinite}
+  .icon:active{background:var(--press);color:var(--text)}
+  .icon.spin{animation:spin .7s linear infinite}
   @keyframes spin{to{transform:rotate(360deg)}}
-  .hostnote{max-width:34rem;margin:.7rem auto 0;color:var(--dim);font-size:var(--f-sub);line-height:1.5}
+  .hostnote{max-width:34rem;margin:.55rem auto 0;color:var(--dim);font-size:var(--f-sub);line-height:1.5}
 
-  main{max-width:34rem;margin:0 auto;padding:.5rem var(--pad) 0}
-  .sectionlabel{font-size:var(--f-cap);font-weight:700;letter-spacing:.09em;text-transform:uppercase;
-      color:var(--dim2);margin:1.1rem .15rem .55rem}
+  main{max-width:34rem;margin:0 auto;padding:.35rem var(--pad) 0}
+  .sectionlabel{display:flex;align-items:center;gap:.5rem;font-size:var(--f-cap);font-weight:600;
+      letter-spacing:.07em;text-transform:uppercase;color:var(--dim2);margin:.85rem .1rem .4rem}
 
-  /* A workspace is one card: identity on the left, the one action on the
-     right, everything else a tap into the sheet. */
-  .ws{background:var(--surface);border-radius:var(--r);padding:.9rem;margin-bottom:.7rem;
-      cursor:pointer;transition:background .12s}
-  .ws:active{background:var(--surface2)}
-  .row{display:flex;align-items:center;gap:.8rem}
-  .ava{width:3rem;height:3rem;border-radius:.95rem;flex:0 0 auto;display:flex;align-items:center;
-      justify-content:center;font-size:1.15rem;font-weight:700;color:#fff;letter-spacing:-.02em;
-      background:linear-gradient(150deg,hsl(var(--h) 42% 34%),hsl(var(--h) 46% 20%))}
+  .ws{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);
+      padding:.6rem .65rem;margin-bottom:.4rem;cursor:pointer;transition:border-color .12s,background .12s}
+  .ws:active{background:var(--surface2);border-color:#2b2d34}
+  /* Top-aligned: a card with a note or a second line must not leave the
+     avatar and the button floating in the middle of it. */
+  .row{display:flex;align-items:flex-start;gap:.55rem}
+  .ava{width:1.6rem;height:1.6rem;border-radius:.45rem;flex:0 0 auto;margin-top:.05rem;display:flex;align-items:center;
+      justify-content:center;font-size:.66rem;font-weight:700;color:#fff;letter-spacing:.01em;
+      background:linear-gradient(150deg,hsl(var(--h) 38% 36%),hsl(var(--h) 42% 22%))}
   .ws .main{min-width:0;flex:1}
-  .name{font-size:var(--f-row);font-weight:700;letter-spacing:-.015em;
+  .nameline{display:flex;align-items:center;gap:.4rem;min-width:0}
+  .name{font-size:var(--f-row);font-weight:600;letter-spacing:-.008em;
       white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .path{color:var(--dim2);font-size:var(--f-sub);margin-top:.05rem;
+  .path{color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem;
       font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
       white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .tags{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-top:.35rem}
-  .pill{display:inline-flex;align-items:center;gap:.3rem;height:1.4rem;padding:0 .5rem;
-      border-radius:var(--pill);font-size:var(--f-cap);font-weight:700;letter-spacing:.01em;
-      background:var(--surface2);color:var(--dim)}
-  .pill.live{background:rgba(61,220,145,.14);color:var(--green)}
-  .pill.warn{background:rgba(255,111,97,.14);color:var(--red)}
-  .pill i{width:.4rem;height:.4rem;border-radius:50%;background:currentColor;
-      animation:pulse 2s ease-in-out infinite}
-  @keyframes pulse{50%{opacity:.35}}
-  .why{color:var(--dim2);font-size:var(--f-sub)}
-  .wnote{color:var(--red);font-size:var(--f-sub);line-height:1.5;margin-top:.6rem}
+  .tags{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-top:.2rem}
+  .why{color:var(--dim2);font-size:var(--f-cap)}
+  .wnote{color:var(--red);font-size:var(--f-cap);line-height:1.5;margin-top:.45rem}
 
-  /* Buttons: exactly one white one per card — Uber's rule, and the reason you
-     never have to read a card twice to know what tapping it does. */
-  .btn{height:2.65rem;min-width:5.2rem;padding:0 1.05rem;border:0;border-radius:var(--r-sm);
-      font-size:var(--f-body);font-weight:700;letter-spacing:-.01em;cursor:pointer;flex:0 0 auto;
-      display:inline-flex;align-items:center;justify-content:center;gap:.35rem;
-      background:var(--surface2);color:var(--text);text-decoration:none;transition:transform .06s}
-  .btn:active{transform:scale(.97)}
+  /* Status: a dot and a word, the way a list of machines reads fastest. */
+  .state{display:inline-flex;align-items:center;gap:.3rem;font-size:var(--f-cap);font-weight:600;
+      color:var(--dim);flex:0 0 auto}
+  .state i{width:.35rem;height:.35rem;border-radius:50%;background:var(--dim2);flex:0 0 auto}
+  .state.live{color:var(--green)}
+  .state.live i{background:var(--green);animation:pulse 2s ease-in-out infinite}
+  .state.attention{color:var(--amber)}
+  .state.attention i{background:var(--amber);animation:pulse 1.4s ease-in-out infinite}
+  .state.blocked{color:var(--red)}
+  .state.blocked i{background:var(--red)}
+  .state.starting i{background:var(--green);animation:pulse .9s ease-in-out infinite}
+  @keyframes pulse{50%{opacity:.3}}
+
+  .btn{height:1.9rem;min-width:3.6rem;padding:0 .7rem;border:1px solid transparent;border-radius:var(--r-sm);
+      font-size:var(--f-sub);font-weight:600;letter-spacing:-.005em;cursor:pointer;flex:0 0 auto;
+      display:inline-flex;align-items:center;justify-content:center;gap:.3rem;
+      background:var(--surface2);border-color:var(--line);color:var(--text);text-decoration:none}
+  .btn:active{background:var(--press)}
   .btn:disabled{opacity:.45}
-  .btn.primary{background:#fff;color:#000}
-  .btn.block{width:100%;height:3.4rem;font-size:1.02rem;margin-top:.7rem}
-  .btn.danger{background:rgba(255,111,97,.13);color:var(--red)}
-  .btn.quiet{background:none;color:var(--dim);font-weight:600}
+  .btn.primary{background:#fff;border-color:#fff;color:#000}
+  .btn.primary:active{background:#d8d9dc}
+  .btn.block{width:100%;height:2.3rem;font-size:var(--f-body);margin-top:.5rem}
+  .btn.danger{background:none;border-color:rgba(242,85,90,.35);color:var(--red)}
+  .btn.quiet{background:none;border-color:var(--line);color:var(--dim);font-weight:500}
 
-  .cardfoot{display:flex;align-items:center;justify-content:space-between;gap:.6rem;width:100%;
-      margin-top:.7rem;padding:.65rem 0 0;border:0;border-top:1px solid var(--hair);
-      background:none;font-family:inherit;font-size:var(--f-sub);color:var(--dim2);
-      text-align:left;cursor:pointer;min-height:2.4rem}
-  .cardfoot .more{color:var(--dim);font-weight:600;flex:0 0 auto}
-  .usage{font-variant-numeric:tabular-nums}
+  .cardfoot{display:flex;align-items:center;justify-content:space-between;gap:.5rem;width:100%;
+      margin-top:.5rem;padding:.45rem 0 0;border:0;border-top:1px solid var(--hair);
+      background:none;font-family:inherit;font-size:var(--f-cap);color:var(--dim2);
+      text-align:left;cursor:pointer;min-height:1.6rem}
+  .cardfoot .more{color:var(--dim);flex:0 0 auto}
+  .usage{font-variant-numeric:tabular-nums;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 
-  /* The live session gets its own row: it is the thing you came here to open. */
-  .top{display:flex;align-items:center;gap:.6rem;margin-top:.7rem;padding:.6rem .7rem;
+  .top{display:flex;align-items:center;gap:.45rem;margin-top:.5rem;padding:.4rem .5rem;
       background:var(--surface2);border-radius:var(--r-sm);color:var(--text);
-      text-decoration:none;min-height:2.9rem}
+      text-decoration:none;min-height:2.1rem}
   .top .tmain{display:flex;flex-direction:column;min-width:0;flex:1}
-  .top .tname{font-size:var(--f-body);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .top .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem}
-  .top .go{color:var(--dim);font-size:1.1rem;flex:0 0 auto}
-  .top .go.small{font-size:var(--f-cap);color:var(--dim2)}
-  .sdot{width:.45rem;height:.45rem;border-radius:50%;background:var(--green);flex:0 0 auto;
+  .top .tname{font-size:var(--f-sub);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .top .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.02rem}
+  .top .go{color:var(--dim2);font-size:.8rem;flex:0 0 auto}
+  .top .go.small{font-size:var(--f-cap)}
+  .sdot{width:.35rem;height:.35rem;border-radius:50%;background:var(--green);flex:0 0 auto;
       animation:pulse 2s ease-in-out infinite}
 
-  .intro{color:var(--dim);font-size:var(--f-body);line-height:1.55;margin:.2rem .15rem 1rem}
-  .skel{background:var(--surface);border-radius:var(--r);height:5.6rem;margin-bottom:.7rem;
-      background-image:linear-gradient(100deg,transparent 20%,rgba(255,255,255,.05) 40%,transparent 60%);
-      background-size:220% 100%;animation:sweep 1.3s linear infinite}
+  .intro{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.15rem .1rem .7rem}
+  .skel{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);height:3.4rem;
+      margin-bottom:.4rem;
+      background-image:linear-gradient(100deg,transparent 20%,rgba(255,255,255,.04) 40%,transparent 60%);
+      background-size:220% 100%;animation:sweep 1.2s linear infinite}
   @keyframes sweep{to{background-position:-220% 0}}
-  .msg{color:var(--dim);font-size:var(--f-body);line-height:1.55;margin:1rem .15rem}
-  .empty{padding:2.4rem .15rem 1rem}
-  .empty h2{font-size:1.35rem;font-weight:800;margin-bottom:.5rem}
-  .empty p{color:var(--dim);font-size:var(--f-body);line-height:1.6;margin:0}
+  .msg{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.8rem .1rem}
+  .empty{padding:1.6rem .1rem .6rem}
+  .empty h2{font-size:var(--f-h1);font-weight:650;margin-bottom:.3rem}
+  .empty p{color:var(--dim);font-size:var(--f-sub);line-height:1.6;margin:0}
   .err{color:var(--red)}
-  code{background:var(--surface2);padding:.12rem .4rem;border-radius:.4rem;font-size:.9em}
+  code{background:var(--surface2);padding:.08rem .3rem;border-radius:.3rem;font-size:.92em;
+      font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 
-  /* Bottom sheet: every secondary control lives here, so the list stays one
-     line of thought. Reachable with a thumb, dismissed with one. */
   body.locked{overflow:hidden}
   .sheet{position:fixed;inset:0;z-index:50;display:flex;align-items:flex-end}
-  .sheet[hidden]{display:none}
-  .scrim{position:absolute;inset:0;background:rgba(0,0,0,.65);opacity:0;transition:opacity .22s;border:0}
+  .scrim{position:absolute;inset:0;background:rgba(0,0,0,.6);opacity:0;transition:opacity .18s;border:0}
   .sheet.on .scrim{opacity:1}
   .panel{position:relative;width:100%;max-width:34rem;margin:0 auto;background:var(--surface);
-      border-radius:1.4rem 1.4rem 0 0;max-height:90vh;overflow-y:auto;-webkit-overflow-scrolling:touch;
-      padding:.4rem var(--pad) calc(1.1rem + env(safe-area-inset-bottom));
-      transform:translateY(101%);transition:transform .26s cubic-bezier(.2,.8,.2,1)}
+      border:1px solid var(--line);border-bottom:0;
+      border-radius:.85rem .85rem 0 0;max-height:88vh;overflow-y:auto;-webkit-overflow-scrolling:touch;
+      padding:.3rem var(--pad) calc(.9rem + env(safe-area-inset-bottom));
+      transform:translateY(101%);transition:transform .22s cubic-bezier(.2,.8,.2,1)}
   .sheet.on .panel{transform:none}
   @media (prefers-reduced-motion:reduce){
     .panel,.scrim{transition:none}
-    .skel,.sdot,.pill i,.icon.spin{animation:none}
+    .skel,.sdot,.state i,.icon.spin{animation:none}
   }
   .panel:focus,.panel:focus-visible{outline:none}
-  .grab{display:block;width:2.4rem;height:.25rem;border-radius:var(--pill);background:#3a3c42;
-      border:0;padding:0;margin:.5rem auto .9rem}
-  .sheet h2{font-size:1.25rem;font-weight:800}
-  .sheet .sub{color:var(--dim2);font-size:var(--f-sub);margin-top:.15rem;word-break:break-all;
+  .grab{display:block;width:2rem;height:.2rem;border-radius:var(--pill);background:#2e3037;
+      border:0;padding:0;margin:.4rem auto .7rem}
+  .sheet h2{font-size:var(--f-h1);font-weight:650}
+  .sheet .sub{color:var(--dim2);font-size:var(--f-cap);margin-top:.1rem;word-break:break-all;
       font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-  .srow{display:flex;align-items:center;gap:.8rem;width:100%;min-height:3.4rem;padding:.7rem 0;
+  .srow{display:flex;align-items:center;gap:.6rem;width:100%;min-height:2.5rem;padding:.5rem 0;
       background:none;border:0;border-top:1px solid var(--hair);color:var(--text);
-      font-size:var(--f-body);font-weight:600;text-align:left;cursor:pointer}
-  .srow:first-of-type{margin-top:.9rem}
-  .srow .sval{margin-left:auto;color:var(--dim);font-weight:500;flex:0 0 auto}
-  .srow .go{color:var(--dim2);font-size:1.05rem;flex:0 0 auto}
+      font-size:var(--f-body);font-weight:500;text-align:left;cursor:pointer}
+  .srow:first-of-type{margin-top:.6rem}
+  .srow .sval{margin-left:auto;color:var(--dim);flex:0 0 auto}
+  .srow .go{color:var(--dim2);font-size:.85rem;flex:0 0 auto}
   .srow.bad{color:var(--red)}
-  .srow .desc{display:block;color:var(--dim2);font-size:var(--f-cap);font-weight:400;margin-top:.1rem}
-  .field{margin-top:.9rem}
-  .field label{display:block;font-size:var(--f-cap);font-weight:700;letter-spacing:.07em;
-      text-transform:uppercase;color:var(--dim2);margin-bottom:.35rem}
-  .field select,.field input{width:100%;height:3rem;background:var(--surface2);border:1px solid var(--line);
-      color:var(--text);border-radius:var(--r-sm);padding:0 .8rem;font-size:var(--f-body)}
+  .srow .desc{display:block;color:var(--dim2);font-size:var(--f-cap);font-weight:400;margin-top:.05rem;
+      line-height:1.45}
+  .field{margin-top:.6rem}
+  .field label{display:block;font-size:var(--f-cap);font-weight:600;letter-spacing:.06em;
+      text-transform:uppercase;color:var(--dim2);margin-bottom:.25rem}
+  .field select,.field input{width:100%;height:2.3rem;background:var(--surface2);border:1px solid var(--line);
+      color:var(--text);border-radius:var(--r-sm);padding:0 .6rem;font-size:var(--f-body)}
   .field input::placeholder{color:var(--dim2)}
+  .field .desc{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.25rem;line-height:1.45}
 
-  /* Session lists inside the sheet. */
-  .grp{display:flex;align-items:center;gap:.6rem;margin:1.1rem 0 .2rem;color:var(--dim2);
-      font-size:var(--f-cap);font-weight:700;letter-spacing:.09em;text-transform:uppercase}
+  .grp{display:flex;align-items:center;gap:.5rem;margin:.85rem 0 .1rem;color:var(--dim2);
+      font-size:var(--f-cap);font-weight:600;letter-spacing:.07em;text-transform:uppercase}
   .grp i{flex:1;height:1px;background:var(--hair)}
-  .s{display:flex;align-items:center;gap:.6rem;min-height:3rem;padding:.55rem 0;
-      border-top:1px solid var(--hair);color:var(--text);text-decoration:none;font-size:var(--f-body)}
+  .s{display:flex;align-items:center;gap:.5rem;min-height:2.4rem;padding:.4rem 0;
+      border-top:1px solid var(--hair);color:var(--text);text-decoration:none;font-size:var(--f-sub)}
   .s .smain{display:flex;flex-direction:column;min-width:0;flex:1}
   .s .sname{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-weight:600}
-  .s .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem}
+  .s .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.02rem}
   .s.past .sname{color:var(--dim);font-weight:500}
-  .s .go{color:var(--dim2);flex:0 0 auto;font-size:1.05rem}
-  .tag{font-size:.65rem;font-weight:700;color:var(--amber);border:1px solid rgba(255,184,77,.4);
-      border-radius:.35rem;padding:.05rem .3rem;margin-left:.4rem;vertical-align:1px}
-  .hint,.none{color:var(--dim2);font-size:var(--f-cap);line-height:1.5;padding:.45rem 0}
-  .evrow{display:flex;justify-content:space-between;gap:.6rem;font-size:var(--f-sub);
-      color:var(--dim2);padding:.35rem 0}
-  .evrow b{font-weight:600;color:var(--dim);min-width:0}
+  .s .go{color:var(--dim2);flex:0 0 auto;font-size:.8rem}
+  .tag{font-size:.58rem;font-weight:700;color:var(--amber);border:1px solid rgba(226,160,63,.4);
+      border-radius:.3rem;padding:0 .25rem;margin-left:.35rem;vertical-align:1px}
+  .hint,.none{color:var(--dim2);font-size:var(--f-cap);line-height:1.5;padding:.35rem 0}
+  .evrow{display:flex;justify-content:space-between;gap:.5rem;font-size:var(--f-cap);
+      color:var(--dim2);padding:.28rem 0}
+  .evrow b{font-weight:500;color:var(--dim);min-width:0}
   .evrow span{flex:0 0 auto;white-space:nowrap}
 
-  /* Toast: a failure says so once, over the thumb, and gets out of the way. */
-  .toast{position:fixed;left:50%;bottom:calc(1.2rem + env(safe-area-inset-bottom));transform:translate(-50%,1rem);
-      z-index:60;max-width:calc(100% - 2.4rem);background:#fff;color:#000;font-size:var(--f-sub);
-      font-weight:600;padding:.75rem 1rem;border-radius:var(--r-sm);opacity:0;
-      transition:opacity .2s,transform .2s;box-shadow:0 .6rem 2rem rgba(0,0,0,.5)}
-  .toast[hidden]{display:none}
+  .toast{position:fixed;left:50%;bottom:calc(1rem + env(safe-area-inset-bottom));transform:translate(-50%,.6rem);
+      z-index:60;max-width:calc(100% - 2rem);background:#fff;color:#000;font-size:var(--f-sub);
+      font-weight:600;padding:.5rem .8rem;border-radius:var(--r-sm);opacity:0;
+      transition:opacity .16s,transform .16s;box-shadow:0 .5rem 1.4rem rgba(0,0,0,.55)}
   .toast.on{opacity:1;transform:translate(-50%,0)}
-  .toast.bad{background:var(--red);color:#1a0503}
+  .toast.bad{background:var(--red);color:#150202}
 
-  /* Panels that are not the main job: quiet until opened. */
-  details.card{background:var(--surface);border-radius:var(--r);padding:0 var(--pad);margin-top:.7rem}
-  details.card summary{display:flex;align-items:center;justify-content:space-between;gap:.6rem;
-      list-style:none;cursor:pointer;min-height:3.4rem;padding:.9rem 0;font-size:var(--f-body);font-weight:600}
+  details.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);
+      padding:0 .7rem;margin-top:.4rem}
+  details.card summary{display:flex;align-items:center;justify-content:space-between;gap:.5rem;
+      list-style:none;cursor:pointer;min-height:2.4rem;padding:.55rem 0;font-size:var(--f-body);font-weight:600}
   details.card summary::-webkit-details-marker{display:none}
-  details.card summary .sh{color:var(--dim2);font-size:var(--f-sub);font-weight:400}
+  details.card summary .sh{color:var(--dim2);font-size:var(--f-cap);font-weight:400}
   details.card[open] summary .sh::after{content:" \2303"}
   details.card:not([open]) summary .sh::after{content:" \2304"}
-  details.card[open]{padding-bottom:1.1rem}
-  details.card h3{font-size:var(--f-cap);font-weight:700;letter-spacing:.09em;text-transform:uppercase;
-      color:var(--dim2);margin:1.4rem 0 .5rem}
-  details.card p{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.5rem 0}
+  details.card[open]{padding-bottom:.7rem}
+  details.card h3{font-size:var(--f-cap);font-weight:600;letter-spacing:.07em;text-transform:uppercase;
+      color:var(--dim2);margin:1rem 0 .35rem}
+  details.card p{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.35rem 0}
   .tip{display:block;width:100%;text-align:left;background:none;border:0;border-top:1px solid var(--hair);
-      padding:.9rem 0 .8rem;cursor:pointer;color:var(--text)}
-  .tip-t{display:block;font-size:var(--f-body);font-weight:700}
-  .tip-d{display:block;font-size:var(--f-sub);color:var(--dim);line-height:1.5;margin-top:.15rem}
-  .tip-cmd{display:flex;align-items:center;justify-content:space-between;gap:.6rem;margin-top:.6rem;
-      background:var(--surface2);border-radius:var(--r-sm);padding:.6rem .7rem;min-height:2.6rem}
+      padding:.6rem 0 .55rem;cursor:pointer;color:var(--text)}
+  .tip-t{display:block;font-size:var(--f-body);font-weight:600}
+  .tip-d{display:block;font-size:var(--f-sub);color:var(--dim);line-height:1.5;margin-top:.1rem}
+  .tip-cmd{display:flex;align-items:center;justify-content:space-between;gap:.5rem;margin-top:.4rem;
+      background:var(--surface2);border-radius:var(--r-sm);padding:.4rem .5rem;min-height:1.9rem}
   .tip-cmd code{min-width:0;overflow-x:auto;white-space:nowrap;background:none;padding:0;
-      font-size:var(--f-sub);color:var(--text)}
-  .tip-copy{font-size:var(--f-cap);font-weight:700;color:var(--dim2);flex:0 0 auto;letter-spacing:.04em}
+      font-size:var(--f-cap);color:var(--text)}
+  .tip-copy{font-size:.6rem;font-weight:700;color:var(--dim2);flex:0 0 auto;letter-spacing:.04em}
   .tip.copied .tip-copy{color:var(--green)}
-  .dev{display:flex;align-items:center;justify-content:space-between;gap:.6rem;
-      padding:.75rem 0;border-top:1px solid var(--hair);font-size:var(--f-body)}
+  .dev{display:flex;align-items:center;justify-content:space-between;gap:.5rem;
+      padding:.5rem 0;border-top:1px solid var(--hair);font-size:var(--f-sub)}
   .dev .sub{color:var(--dim2);font-size:var(--f-cap)}
-  .chk{display:flex;gap:.6rem;font-size:var(--f-sub);padding:.7rem 0;border-top:1px solid var(--hair);line-height:1.5}
+  .chk{display:flex;gap:.5rem;font-size:var(--f-sub);padding:.5rem 0;border-top:1px solid var(--hair);line-height:1.5}
   .chk .mark{color:var(--green);flex:0 0 auto}
   .chk.bad .mark{color:var(--red)}
-  .chk .fix{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.15rem}
-  .toggle{display:flex;align-items:center;gap:.7rem;min-height:var(--tap);color:var(--text);
-      font-size:var(--f-body);cursor:pointer}
-  .toggle input{accent-color:var(--green);width:1.2rem;height:1.2rem;margin:0}
-  pre{background:#0a0b0d;border:1px solid var(--line);border-radius:var(--r-sm);padding:.8rem;
+  .chk .fix{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.1rem}
+  .toggle{display:flex;align-items:center;gap:.5rem;min-height:2.2rem;color:var(--text);
+      font-size:var(--f-sub);cursor:pointer}
+  .toggle input{accent-color:var(--green);width:.95rem;height:.95rem;margin:0}
+  pre{background:var(--bg);border:1px solid var(--line);border-radius:var(--r-sm);padding:.6rem;
       overflow-x:auto;font-size:var(--f-cap);line-height:1.5;white-space:pre;color:var(--dim)}
-  .foot{text-align:center;margin:1.6rem 0 0}
-  .foot a{color:var(--text);font-size:var(--f-body);font-weight:600;text-decoration:none;
-      display:inline-flex;align-items:center;min-height:var(--tap);padding:0 1rem}
+  .foot{text-align:center;margin:1.1rem 0 0}
+  .foot a{color:var(--dim);font-size:var(--f-sub);font-weight:500;text-decoration:none;
+      display:inline-flex;align-items:center;min-height:2.2rem;padding:0 .8rem}
 </style>
 <header id="top">
   <div class="bar">
@@ -1088,6 +1131,22 @@ const launcherPageHTML = `<!doctype html>
   addEventListener('scroll', () => {
     document.getElementById('top').classList.toggle('scrolled', scrollY > 4);
   }, { passive: true });
+
+  // A session's name and state both change while you are looking at them —
+  // Claude renames the session as the work takes shape, a permission prompt
+  // arrives, a session exits. Refresh on a slow tick, only while the page is
+  // actually on screen, and never under an open sheet (it would re-render the
+  // row the thumb is on).
+  const REFRESH_MS = 15000;
+  function autoRefresh() {
+    if (document.visibilityState !== 'visible') return;
+    if (!document.getElementById('sheet').hidden) return;
+    load();
+  }
+  setInterval(autoRefresh, REFRESH_MS);
+  addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') autoRefresh();
+  });
 
   if (!token) {
     list.className = 'empty';
@@ -1319,9 +1378,13 @@ const launcherPageHTML = `<!doctype html>
 
     const main = document.createElement('div');
     main.className = 'main';
-    const name = document.createElement('div');
+    const nameline = document.createElement('div');
+    nameline.className = 'nameline';
+    const name = document.createElement('span');
     name.className = 'name'; name.textContent = ws.id;
-    main.appendChild(name);
+    nameline.appendChild(name);
+    nameline.appendChild(stateChip(ws));
+    main.appendChild(nameline);
     const path = document.createElement('div');
     path.className = 'path'; path.textContent = shortPath(ws.path);
     main.appendChild(path);
@@ -1383,36 +1446,55 @@ const launcherPageHTML = `<!doctype html>
     return b;
   }
 
+  // The state word comes from the daemon (/launch/workspaces), so the phone
+  // and any other client say the same thing about the same workspace.
+  const STATE_LABEL = {
+    live: ws => (ws.live > 1 ? ws.live + ' sessions' : 'live'),
+    attention: () => 'needs you',
+    starting: () => 'starting',
+    blocked: () => 'will not start',
+    stopped: () => 'stopped',
+  };
+
+  function stateChip(ws) {
+    const state = ws.state || (ws.running ? 'starting' : 'stopped');
+    const label = (STATE_LABEL[state] || STATE_LABEL.stopped)(ws);
+    const el = document.createElement('span');
+    el.className = 'state ' + state;
+    el.innerHTML = '<i></i>' + esc(label);
+    return el;
+  }
+
   function statusTags(ws) {
     const el = document.createElement('div');
     el.className = 'tags';
     let any = false;
-    if (ws.live > 0) {
-      const p = document.createElement('span');
-      p.className = 'pill live';
-      p.innerHTML = '<i></i>' + ws.live + ' live';
-      el.appendChild(p); any = true;
-    } else if (ws.running) {
-      const p = document.createElement('span');
-      p.className = 'pill'; p.textContent = 'starting';
-      el.appendChild(p); any = true;
-    }
     const e = ws.lastEvent;
-    if (e && !(ws.running && e.kind === 'started')) {
-      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + e.cause : '')
-        : e.kind === 'attention' ? 'needs you' : e.kind;
-      const s = document.createElement('span');
-      s.className = e.kind === 'attention' ? 'pill warn' : 'why';
-      s.textContent = what + ' ' + fmtWhen(e.at);
-      el.appendChild(s); any = true;
+    if (e && !(ws.running && e.kind === 'started') && e.kind !== 'attention') {
+      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + e.cause : '') : e.kind;
+      const why = document.createElement('span');
+      why.className = 'why';
+      why.textContent = what + ' ' + fmtWhen(e.at);
+      el.appendChild(why); any = true;
     }
     return any ? el : null;
+  }
+
+  // Claude Code owns a session's name after it starts — /rename, a hook, or
+  // its own naming all rewrite the record corgi reads — so this is whatever
+  // the session is called right now, not what corgi called it at start.
+  // nameSource says who last set it; nameSince, when.
+  function nameNote(top) {
+    if (!top.nameSource || top.nameSource === 'user') return '';
+    if (!top.nameSince || !top.startedAt || top.nameSince - top.startedAt < 5000) return '';
+    return 'renamed ' + fmtWhen(top.nameSince);
   }
 
   function topSessionRow(ws) {
     const top = ws.topSession;
     if (!top) return null;
-    const when = [top.where, top.startedAt ? fmtWhen(top.startedAt) : ''].filter(Boolean).join(' · ');
+    const when = [top.where, top.startedAt ? fmtWhen(top.startedAt) : '', nameNote(top)]
+      .filter(Boolean).join(' · ');
     const body = '<i class="sdot"></i><span class="tmain"><span class="tname">' +
       esc(shortSessionName(top.name, ws.id)) + '</span>' +
       '<span class="when">' + esc(when) + '</span></span>';
@@ -1604,6 +1686,13 @@ const launcherPageHTML = `<!doctype html>
     name.dataset.role = 'name';
     name.maxLength = 60;
     field.appendChild(name);
+    // Says what the field actually does: Claude owns the name once the session
+    // is running, so this is the starting one, not the last word.
+    const desc = document.createElement('span');
+    desc.className = 'desc';
+    desc.textContent = 'The name it starts with. Claude renames the session as the work takes ' +
+      'shape, and this list follows it.';
+    field.appendChild(desc);
     box.appendChild(field);
     return box;
   }

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -771,249 +771,185 @@ const launcherPageHTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="dark">
-<meta name="theme-color" content="#000000">
+<meta name="theme-color" content="#0b0d12">
 <title>corgi</title>
 <style>
-  /* Compact by default: this is a list you scan, not a poster. Sizes sit where
-     the old page had them — 11-14px, 30px controls — with the spacing and the
-     hairlines doing the work that bigger type was doing badly. */
-  :root{
-    --bg:#08090a;--surface:#0f1012;--surface2:#16171a;--press:#1d1e22;
-    --line:#212228;--hair:#191a1e;
-    --text:#e9eaec;--dim:#9a9ca4;--dim2:#6b6d76;
-    --green:#4cc38a;--amber:#e2a03f;--red:#f2555a;
-    --r:.6rem;--r-sm:.42rem;--pill:999px;
-    --pad:1rem;
-    --f-h1:1.05rem;--f-row:.875rem;--f-body:.8rem;--f-sub:.74rem;--f-cap:.68rem;
-  }
+  :root{--bg:#0a0b0e;--card:#141519;--card2:#0f1013;--line:#22242b;--hair:#1a1c22;
+      --text:#eceef2;--dim:#8f94a3;--dim2:#63677a;--green:#6ee787;--amber:#ffa657;--red:#ff7b72;
+      --sp1:.25rem;--sp2:.5rem;--sp3:.75rem;--sp4:1rem;--r:.5rem}
   *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
-  /* Flex and grid beat the hidden attribute on specificity; this page toggles
-     controls with .hidden, so it must not. */
+  /* Flex and grid beat the hidden attribute on specificity, and this page
+     toggles controls with .hidden. */
   [hidden]{display:none!important}
   html{-webkit-text-size-adjust:100%}
-  body{margin:0;background:var(--bg);color:var(--text);
-      font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;
-      font-size:var(--f-body);line-height:1.45;-webkit-font-smoothing:antialiased;
-      padding-bottom:calc(1.5rem + env(safe-area-inset-bottom))}
-  h1,h2,h3{margin:0;letter-spacing:-.01em}
-  button,input,select{font-family:inherit}
-  button,a,summary,label,input,[role=button]{touch-action:manipulation}
-  :focus-visible{outline:1px solid var(--dim);outline-offset:2px;border-radius:4px}
-
-  header{position:sticky;top:0;z-index:20;padding:calc(.7rem + env(safe-area-inset-top)) var(--pad) .7rem;
-      background:rgba(8,9,10,.86);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
-      border-bottom:1px solid transparent;transition:border-color .15s}
-  header.scrolled{border-bottom-color:var(--hair)}
-  .bar{display:flex;align-items:center;gap:.55rem;max-width:34rem;margin:0 auto}
-  .logo{width:1.65rem;height:1.65rem;border-radius:.45rem;background:var(--surface2);
-      display:flex;align-items:center;justify-content:center;font-size:.9rem;flex:0 0 auto}
-  .bar .main{min-width:0;flex:1}
-  h1{font-size:var(--f-h1);font-weight:650;line-height:1.2}
-  #host{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem;line-height:1.35}
-  #host .what{color:var(--dim2);border-bottom:1px dotted #33353c;cursor:pointer}
-  #host .down{color:var(--red)}
-  .icon{width:1.9rem;height:1.9rem;border-radius:var(--r-sm);border:1px solid var(--line);flex:0 0 auto;
-      background:var(--surface);color:var(--dim);font-size:.8rem;cursor:pointer;
-      display:flex;align-items:center;justify-content:center}
-  .icon:active{background:var(--press);color:var(--text)}
-  .icon.spin{animation:spin .7s linear infinite}
+  button,a,summary,label,input,.chip,.ws,.top,.s{touch-action:manipulation}
+  body{font-family:-apple-system,system-ui,sans-serif;background:var(--bg);color:var(--text);margin:0;
+      padding-bottom:env(safe-area-inset-bottom);-webkit-font-smoothing:antialiased}
+  header{padding:calc(1.2rem + env(safe-area-inset-top)) 1.2rem .3rem;max-width:34rem;margin:0 auto}
+  .brand{display:flex;align-items:center;gap:.7rem}
+  .brand .who{min-width:0;flex:1}
+  .chip.refresh{flex:0 0 auto;width:2rem;height:2rem;padding:0;display:flex;align-items:center;
+      justify-content:center;font-size:.85rem;color:var(--dim)}
+  .chip.refresh:active{color:var(--text)}
+  .chip.refresh.spin{animation:spin .7s linear infinite}
   @keyframes spin{to{transform:rotate(360deg)}}
-  .hostnote{max-width:34rem;margin:.55rem auto 0;color:var(--dim);font-size:var(--f-sub);line-height:1.5}
-
-  main{max-width:34rem;margin:0 auto;padding:.35rem var(--pad) 0}
-  .sectionlabel{display:flex;align-items:center;gap:.5rem;font-size:var(--f-cap);font-weight:600;
-      letter-spacing:.07em;text-transform:uppercase;color:var(--dim2);margin:.85rem .1rem .4rem}
-
-  .ws{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);
-      padding:.6rem .65rem;margin-bottom:.4rem;cursor:pointer;transition:border-color .12s,background .12s}
-  .ws:active{background:var(--surface2);border-color:#2b2d34}
-  /* Top-aligned: a card with a note or a second line must not leave the
-     avatar and the button floating in the middle of it. */
-  .row{display:flex;align-items:flex-start;gap:.55rem}
-  .ava{width:1.6rem;height:1.6rem;border-radius:.45rem;flex:0 0 auto;margin-top:.05rem;display:flex;align-items:center;
-      justify-content:center;font-size:.66rem;font-weight:700;color:#fff;letter-spacing:.01em;
-      background:linear-gradient(150deg,hsl(var(--h) 38% 36%),hsl(var(--h) 42% 22%))}
-  .ws .main{min-width:0;flex:1}
-  .nameline{display:flex;align-items:center;gap:.4rem;min-width:0}
-  .name{font-size:var(--f-row);font-weight:600;letter-spacing:-.008em;
-      white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .path{color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem;
-      font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
-      white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .tags{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-top:.2rem}
-  .why{color:var(--dim2);font-size:var(--f-cap)}
-  .wnote{color:var(--red);font-size:var(--f-cap);line-height:1.5;margin-top:.45rem}
-
-  /* Status: a dot and a word, the way a list of machines reads fastest. */
-  .state{display:inline-flex;align-items:center;gap:.3rem;font-size:var(--f-cap);font-weight:600;
-      color:var(--dim);flex:0 0 auto}
-  .state i{width:.35rem;height:.35rem;border-radius:50%;background:var(--dim2);flex:0 0 auto}
-  .state.live{color:var(--green)}
-  .state.live i{background:var(--green);animation:pulse 2s ease-in-out infinite}
-  .state.attention{color:var(--amber)}
-  .state.attention i{background:var(--amber);animation:pulse 1.4s ease-in-out infinite}
-  .state.blocked{color:var(--red)}
-  .state.blocked i{background:var(--red)}
-  .state.starting i{background:var(--green);animation:pulse .9s ease-in-out infinite}
+  .logo{width:2.6rem;height:2.6rem;border-radius:.9rem;background:linear-gradient(135deg,#1e2634,#131824);
+      border:1px solid var(--line);display:flex;align-items:center;justify-content:center;font-size:1.35rem;flex:0 0 auto}
+  h1{font-size:1.25rem;margin:0;letter-spacing:.01em}
+  header small{display:block;color:var(--dim);font-size:.78rem;font-weight:400;margin-top:.1rem}
+  header small .what{color:var(--dim);border-bottom:1px dotted var(--line-soft,#3a4152);cursor:pointer}
+  .hostnote{color:var(--dim);font-size:.74rem;line-height:1.5;margin:.45rem 0 0;max-width:30rem}
+  main{padding:.4rem 1.2rem 2.2rem;max-width:34rem;margin:0 auto}
+  .ws{background:var(--card);border:1px solid var(--line);border-radius:.75rem;
+      padding:var(--sp3) var(--sp3) var(--sp2);margin:var(--sp2) 0}
+  .head{display:flex;align-items:center;gap:.7rem}
+  .main{min-width:0;flex:1}
+  .ws .name{font-weight:600;display:flex;align-items:center;gap:.5rem;font-size:.94rem;white-space:nowrap;
+      overflow:hidden;text-overflow:ellipsis;letter-spacing:-.006em}
+  .ws .path{color:var(--dim2);font-size:.7rem;margin-top:.15rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+      white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
+  .ws .path.full{white-space:normal;word-break:break-all}
+  .ws .wnote{color:var(--red);font-size:.72rem;margin-top:.5rem;line-height:1.45}
+  /* The dot carries the state: green live, amber blocking on you, red a start
+     that was refused, grey nothing running. */
+  .dot{width:.55rem;height:.55rem;border-radius:50%;background:#3a4152;flex:0 0 auto}
+  .dot.live{background:var(--green)}
+  .dot.starting{background:var(--green);animation:pulse 1s ease-in-out infinite}
+  .dot.attention{background:var(--amber)}
+  .dot.blocked{background:var(--red)}
   @keyframes pulse{50%{opacity:.3}}
-
-  .btn{height:1.9rem;min-width:3.6rem;padding:0 .7rem;border:1px solid transparent;border-radius:var(--r-sm);
-      font-size:var(--f-sub);font-weight:600;letter-spacing:-.005em;cursor:pointer;flex:0 0 auto;
-      display:inline-flex;align-items:center;justify-content:center;gap:.3rem;
-      background:var(--surface2);border-color:var(--line);color:var(--text);text-decoration:none}
-  .btn:active{background:var(--press)}
-  .btn:disabled{opacity:.45}
-  .btn.primary{background:#fff;border-color:#fff;color:#000}
-  .btn.primary:active{background:#d8d9dc}
-  .btn.block{width:100%;height:2.3rem;font-size:var(--f-body);margin-top:.5rem}
-  .btn.danger{background:none;border-color:rgba(242,85,90,.35);color:var(--red)}
-  .btn.quiet{background:none;border-color:var(--line);color:var(--dim);font-weight:500}
-
-  .cardfoot{display:flex;align-items:center;justify-content:space-between;gap:.5rem;width:100%;
-      margin-top:.5rem;padding:.45rem 0 0;border:0;border-top:1px solid var(--hair);
-      background:none;font-family:inherit;font-size:var(--f-cap);color:var(--dim2);
-      text-align:left;cursor:pointer;min-height:1.6rem}
-  .cardfoot .more{color:var(--dim);flex:0 0 auto}
-  .usage{font-variant-numeric:tabular-nums;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-
-  .top{display:flex;align-items:center;gap:.45rem;margin-top:.5rem;padding:.4rem .5rem;
-      background:var(--surface2);border-radius:var(--r-sm);color:var(--text);
-      text-decoration:none;min-height:2.1rem}
-  .top .tmain{display:flex;flex-direction:column;min-width:0;flex:1}
-  .top .tname{font-size:var(--f-sub);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .top .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.02rem}
-  .top .go{color:var(--dim2);font-size:.8rem;flex:0 0 auto}
-  .top .go.small{font-size:var(--f-cap)}
-  .sdot{width:.35rem;height:.35rem;border-radius:50%;background:var(--green);flex:0 0 auto;
-      animation:pulse 2s ease-in-out infinite}
-
-  .intro{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.15rem .1rem .7rem}
-  .skel{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);height:3.4rem;
-      margin-bottom:.4rem;
-      background-image:linear-gradient(100deg,transparent 20%,rgba(255,255,255,.04) 40%,transparent 60%);
+  .meta{display:flex;align-items:baseline;gap:.4rem;flex-wrap:wrap;margin-top:.25rem;
+      font-size:.73rem;color:var(--dim2)}
+  .meta span + span::before{content:"\00b7";color:var(--dim2);margin-right:.4rem}
+  .meta .live{color:var(--green)}
+  .meta .warn{color:var(--red)}
+  .meta .why{color:var(--dim)}
+  .usage{font-size:.68rem;color:var(--dim2);margin-top:.15rem;
+      font-variant-numeric:tabular-nums;opacity:.85}
+  .actions{display:flex;align-items:center;gap:.4rem;margin-top:.65rem;flex-wrap:wrap}
+  .startbox{flex-basis:100%;display:none;gap:.4rem;margin-top:.5rem}
+  .startbox.on{display:flex}
+  .startbox select,.startbox input{flex:1 1 6rem;min-width:0;background:var(--card2);border:1px solid var(--line);
+      color:var(--text);border-radius:.5rem;padding:.4rem .55rem;font-size:.78rem;font-family:inherit}
+  .evrow{display:flex;justify-content:space-between;gap:.6rem;font-size:.72rem;color:var(--dim);padding:.2rem .1rem}
+  .evrow b{font-weight:600;color:#c9cfda}
+  .dev{display:flex;align-items:center;justify-content:space-between;gap:.6rem;font-size:.8rem;
+      padding:.4rem 0;border-bottom:1px solid var(--line)}
+  .dev:last-child{border-bottom:0}
+  .dev .sub{color:var(--dim2);font-size:.7rem}
+  .dev button{background:none;border:1px solid rgba(255,123,114,.45);color:var(--red);font-size:.7rem;
+      padding:.25rem .6rem;border-radius:.5rem}
+  .chk{display:flex;gap:.5rem;font-size:.78rem;padding:.35rem 0;border-bottom:1px solid var(--line);line-height:1.45}
+  .chk:last-child{border-bottom:0}
+  .chk .fix{color:var(--dim);display:block;font-size:.72rem;margin-top:.15rem}
+  .chk.bad .mark{color:var(--red)}
+  .chk .mark{color:var(--green);flex:0 0 auto}
+  .chip{background:none;border:1px solid var(--line);color:var(--dim);font-size:.72rem;font-weight:500;
+      padding:.32rem .6rem;border-radius:var(--r);cursor:pointer}
+  .chip b{color:var(--text);font-weight:600}
+  .chip.danger{border-color:transparent;color:var(--dim);margin-left:auto}
+  .chip.danger:active{color:var(--red)}
+  .top{display:flex;align-items:center;justify-content:space-between;gap:.6rem;
+      margin-top:var(--sp2);padding:var(--sp2) 0 0;border-top:1px solid var(--hair);
+      font-size:.78rem;color:var(--text);text-decoration:none;min-height:2rem}
+  .top span:first-child{display:flex;align-items:center;flex:1 1 auto;min-width:3rem;overflow:hidden}
+  .tname{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .top .when{color:var(--dim2);font-size:.7rem;flex:0 0 auto;max-width:60%;
+      overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .intro{color:var(--dim);font-size:.8rem;line-height:1.5;margin:.2rem 0 .9rem}
+  .skel{background:var(--card);border:1px solid var(--line);border-radius:.75rem;height:5.2rem;
+      margin:var(--sp2) 0;
+      background-image:linear-gradient(100deg,transparent 20%,rgba(255,255,255,.045) 40%,transparent 60%);
       background-size:220% 100%;animation:sweep 1.2s linear infinite}
   @keyframes sweep{to{background-position:-220% 0}}
-  .msg{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.8rem .1rem}
-  .empty{padding:1.6rem .1rem .6rem}
-  .empty h2{font-size:var(--f-h1);font-weight:650;margin-bottom:.3rem}
-  .empty p{color:var(--dim);font-size:var(--f-sub);line-height:1.6;margin:0}
+  .sessions{margin-top:var(--sp2);border-top:1px solid var(--hair);padding-top:var(--sp2)}
+  .sessions .s{display:flex;align-items:center;justify-content:space-between;gap:.6rem;font-size:.76rem;
+      color:#c9cfda;padding:.45rem .1rem;min-height:2.1rem;text-decoration:none}
+  .sessions .s span:first-child{display:flex;align-items:center;flex:1 1 auto;min-width:3rem;
+      overflow:hidden;color:var(--text)}
+  .sdot{width:.375rem;height:.375rem;border-radius:50%;background:var(--green);margin-right:.5rem;flex:0 0 auto}
+  a.s.past span:first-child{color:var(--dim)}
+  a.s.past .when{color:#5b6274}
+  .sessions .grp{display:flex;align-items:center;gap:.5rem;margin:.6rem .1rem .1rem;color:var(--dim2);
+      font-size:.62rem;font-weight:600;letter-spacing:.08em;text-transform:uppercase}
+  .sessions .grp i{flex:1;height:1px;background:var(--hair)}
+  .sessions .s .when{color:var(--dim2);font-size:.68rem;flex:0 0 auto;max-width:60%;
+      overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .sessions .none,.sessions .hint{color:var(--dim2);font-size:.7rem;line-height:1.45;padding:.2rem 0}
+  .tag{font-size:.6rem;font-weight:700;color:var(--amber);border:1px solid rgba(255,166,87,.4);
+      border-radius:.35rem;padding:.05rem .3rem;margin-left:.45rem;vertical-align:1px;flex:0 0 auto;
+      white-space:nowrap}
+  button{border:0;border-radius:var(--r);padding:.48rem .9rem;font-size:.82rem;font-weight:600;cursor:pointer;
+      background:#1e2027;color:var(--text);transition:transform .05s;flex:0 0 auto}
+  button:active{transform:scale(.97)}
+  button:disabled{opacity:.5}
+  a.open,button.open{display:inline-block;background:var(--green);color:#08110a;text-decoration:none;border:0;
+      padding:.48rem .9rem;border-radius:var(--r);font-weight:600;font-size:.82rem;cursor:pointer;flex:0 0 auto}
+  .msg{color:var(--dim);font-size:.9rem;margin:1rem 0;line-height:1.5}
+  .empty{padding:1.6rem 0 .6rem}
+  .empty h2{font-size:1.05rem;margin:0 0 .3rem;letter-spacing:-.01em}
+  .empty p{color:var(--dim);font-size:.82rem;line-height:1.6;margin:0}
   .err{color:var(--red)}
-  code{background:var(--surface2);padding:.08rem .3rem;border-radius:.3rem;font-size:.92em;
-      font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  code{background:var(--card);border:1px solid var(--line);padding:.1rem .35rem;border-radius:.35rem;font-size:.85em}
+  .tips{margin:1.5rem 0 0;background:var(--card);border:1px solid var(--line);border-radius:.75rem;
+      padding:0 var(--sp3)}
+  .tips summary{display:flex;align-items:center;justify-content:space-between;gap:var(--sp2);
+      list-style:none;cursor:pointer;padding:var(--sp3) 0;
+      font-size:.64rem;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--dim2)}
+  .tips summary::-webkit-details-marker{display:none}
+  .tips-hint{text-transform:none;letter-spacing:0;font-weight:400;font-size:.72rem;color:var(--dim2)}
+  .tips[open] .tips-hint::after{content:" \2303"}
+  .tips:not([open]) .tips-hint::after{content:" \2304"}
+  .tips > .tip:first-of-type{border-top:1px solid var(--hair);padding-top:var(--sp3)}
+  .tips[open]{padding-bottom:var(--sp3)}
+  .tip{display:flex;flex-direction:column;align-items:stretch;gap:.15rem;width:100%;text-align:left;
+      background:none;border:0;border-top:1px solid var(--hair);border-radius:0;
+      padding:var(--sp3) 0 var(--sp2);margin:0;cursor:pointer;font-family:inherit}
 
-  body.locked{overflow:hidden}
-  .sheet{position:fixed;inset:0;z-index:50;display:flex;align-items:flex-end}
-  .scrim{position:absolute;inset:0;background:rgba(0,0,0,.6);opacity:0;transition:opacity .18s;border:0}
-  .sheet.on .scrim{opacity:1}
-  .panel{position:relative;width:100%;max-width:34rem;margin:0 auto;background:var(--surface);
-      border:1px solid var(--line);border-bottom:0;
-      border-radius:.85rem .85rem 0 0;max-height:88vh;overflow-y:auto;-webkit-overflow-scrolling:touch;
-      padding:.3rem var(--pad) calc(.9rem + env(safe-area-inset-bottom));
-      transform:translateY(101%);transition:transform .22s cubic-bezier(.2,.8,.2,1)}
-  .sheet.on .panel{transform:none}
-  @media (prefers-reduced-motion:reduce){
-    .panel,.scrim{transition:none}
-    .skel,.sdot,.state i,.icon.spin{animation:none}
-  }
-  .panel:focus,.panel:focus-visible{outline:none}
-  .grab{display:block;width:2rem;height:.2rem;border-radius:var(--pill);background:#2e3037;
-      border:0;padding:0;margin:.4rem auto .7rem}
-  .sheet h2{font-size:var(--f-h1);font-weight:650}
-  .sheet .sub{color:var(--dim2);font-size:var(--f-cap);margin-top:.1rem;word-break:break-all;
-      font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-  .srow{display:flex;align-items:center;gap:.6rem;width:100%;min-height:2.5rem;padding:.5rem 0;
-      background:none;border:0;border-top:1px solid var(--hair);color:var(--text);
-      font-size:var(--f-body);font-weight:500;text-align:left;cursor:pointer}
-  .srow:first-of-type{margin-top:.6rem}
-  .srow .sval{margin-left:auto;color:var(--dim);flex:0 0 auto}
-  .srow .go{color:var(--dim2);font-size:.85rem;flex:0 0 auto}
-  .srow.bad{color:var(--red)}
-  .srow .desc{display:block;color:var(--dim2);font-size:var(--f-cap);font-weight:400;margin-top:.05rem;
-      line-height:1.45}
-  .field{margin-top:.6rem}
-  .field label{display:block;font-size:var(--f-cap);font-weight:600;letter-spacing:.06em;
-      text-transform:uppercase;color:var(--dim2);margin-bottom:.25rem}
-  .field select,.field input{width:100%;height:2.3rem;background:var(--surface2);border:1px solid var(--line);
-      color:var(--text);border-radius:var(--r-sm);padding:0 .6rem;font-size:var(--f-body)}
-  .field input::placeholder{color:var(--dim2)}
-  .field .desc{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.25rem;line-height:1.45}
-
-  .grp{display:flex;align-items:center;gap:.5rem;margin:.85rem 0 .1rem;color:var(--dim2);
-      font-size:var(--f-cap);font-weight:600;letter-spacing:.07em;text-transform:uppercase}
-  .grp i{flex:1;height:1px;background:var(--hair)}
-  .s{display:flex;align-items:center;gap:.5rem;min-height:2.4rem;padding:.4rem 0;
-      border-top:1px solid var(--hair);color:var(--text);text-decoration:none;font-size:var(--f-sub)}
-  .s .smain{display:flex;flex-direction:column;min-width:0;flex:1}
-  .s .sname{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-weight:600}
-  .s .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.02rem}
-  .s.past .sname{color:var(--dim);font-weight:500}
-  .s .go{color:var(--dim2);flex:0 0 auto;font-size:.8rem}
-  .tag{font-size:.58rem;font-weight:700;color:var(--amber);border:1px solid rgba(226,160,63,.4);
-      border-radius:.3rem;padding:0 .25rem;margin-left:.35rem;vertical-align:1px}
-  .hint,.none{color:var(--dim2);font-size:var(--f-cap);line-height:1.5;padding:.35rem 0}
-  .evrow{display:flex;justify-content:space-between;gap:.5rem;font-size:var(--f-cap);
-      color:var(--dim2);padding:.28rem 0}
-  .evrow b{font-weight:500;color:var(--dim);min-width:0}
-  .evrow span{flex:0 0 auto;white-space:nowrap}
-
-  .toast{position:fixed;left:50%;bottom:calc(1rem + env(safe-area-inset-bottom));transform:translate(-50%,.6rem);
-      z-index:60;max-width:calc(100% - 2rem);background:#fff;color:#000;font-size:var(--f-sub);
-      font-weight:600;padding:.5rem .8rem;border-radius:var(--r-sm);opacity:0;
-      transition:opacity .16s,transform .16s;box-shadow:0 .5rem 1.4rem rgba(0,0,0,.55)}
-  .toast.on{opacity:1;transform:translate(-50%,0)}
-  .toast.bad{background:var(--red);color:#150202}
-
-  details.card{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);
-      padding:0 .7rem;margin-top:.4rem}
-  details.card summary{display:flex;align-items:center;justify-content:space-between;gap:.5rem;
-      list-style:none;cursor:pointer;min-height:2.4rem;padding:.55rem 0;font-size:var(--f-body);font-weight:600}
-  details.card summary::-webkit-details-marker{display:none}
-  details.card summary .sh{color:var(--dim2);font-size:var(--f-cap);font-weight:400}
-  details.card[open] summary .sh::after{content:" \2303"}
-  details.card:not([open]) summary .sh::after{content:" \2304"}
-  details.card[open]{padding-bottom:.7rem}
-  details.card h3{font-size:var(--f-cap);font-weight:600;letter-spacing:.07em;text-transform:uppercase;
-      color:var(--dim2);margin:1rem 0 .35rem}
-  details.card p{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.35rem 0}
-  .tip{display:block;width:100%;text-align:left;background:none;border:0;border-top:1px solid var(--hair);
-      padding:.6rem 0 .55rem;cursor:pointer;color:var(--text)}
-  .tip-t{display:block;font-size:var(--f-body);font-weight:600}
-  .tip-d{display:block;font-size:var(--f-sub);color:var(--dim);line-height:1.5;margin-top:.1rem}
-  .tip-cmd{display:flex;align-items:center;justify-content:space-between;gap:.5rem;margin-top:.4rem;
-      background:var(--surface2);border-radius:var(--r-sm);padding:.4rem .5rem;min-height:1.9rem}
-  .tip-cmd code{min-width:0;overflow-x:auto;white-space:nowrap;background:none;padding:0;
-      font-size:var(--f-cap);color:var(--text)}
-  .tip-copy{font-size:.6rem;font-weight:700;color:var(--dim2);flex:0 0 auto;letter-spacing:.04em}
+  .tip-t{font-size:.84rem;font-weight:600;color:var(--text);letter-spacing:-.005em}
+  .tip-d{font-size:.75rem;color:var(--dim);line-height:1.5}
+  .tip-cmd{display:flex;align-items:center;justify-content:space-between;gap:var(--sp2);
+      margin-top:var(--sp2);background:var(--card2);border-radius:var(--r);padding:.42rem .5rem}
+  .tip-cmd code{min-width:0;overflow-x:auto;white-space:nowrap;font-size:.7rem;color:var(--text);
+      background:none;border:0;padding:0}
+  .tip-copy{font-size:.66rem;font-weight:600;color:var(--dim2);flex:0 0 auto;letter-spacing:.02em}
   .tip.copied .tip-copy{color:var(--green)}
-  .dev{display:flex;align-items:center;justify-content:space-between;gap:.5rem;
-      padding:.5rem 0;border-top:1px solid var(--hair);font-size:var(--f-sub)}
-  .dev .sub{color:var(--dim2);font-size:var(--f-cap)}
-  .chk{display:flex;gap:.5rem;font-size:var(--f-sub);padding:.5rem 0;border-top:1px solid var(--hair);line-height:1.5}
-  .chk .mark{color:var(--green);flex:0 0 auto}
-  .chk.bad .mark{color:var(--red)}
-  .chk .fix{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.1rem}
-  .toggle{display:flex;align-items:center;gap:.5rem;min-height:2.2rem;color:var(--text);
-      font-size:var(--f-sub);cursor:pointer}
-  .toggle input{accent-color:var(--green);width:.95rem;height:.95rem;margin:0}
-  pre{background:var(--bg);border:1px solid var(--line);border-radius:var(--r-sm);padding:.6rem;
-      overflow-x:auto;font-size:var(--f-cap);line-height:1.5;white-space:pre;color:var(--dim)}
-  .foot{text-align:center;margin:1.1rem 0 0}
-  .foot a{color:var(--dim);font-size:var(--f-sub);font-weight:500;text-decoration:none;
-      display:inline-flex;align-items:center;min-height:2.2rem;padding:0 .8rem}
+  .tipnote{color:var(--dim2);font-size:.72rem;margin:var(--sp3) 0 0}
+  details.settings{margin:1.6rem 0 0;background:var(--card2);border:1px solid var(--line);
+      border-radius:1rem;padding:.4rem 1rem}
+  details.settings h3{font-size:.66rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+      color:var(--dim2);margin:1.4rem 0 .4rem}
+  details.settings h3:first-of-type{margin-top:.6rem}
+  details.settings summary{color:var(--dim);font-size:.85rem;cursor:pointer;padding:.5rem 0;list-style:none}
+  details.settings summary::-webkit-details-marker{display:none}
+  details.settings p{color:var(--dim);font-size:.76rem;line-height:1.55}
+  label.toggle{display:flex;align-items:center;gap:.5rem;color:var(--dim);font-size:.78rem;
+      padding:.3rem 0 .7rem;cursor:pointer}
+  label.toggle input{accent-color:var(--green);width:1rem;height:1rem;margin:0}
+  pre{background:var(--bg);border:1px solid var(--line);border-radius:.6rem;padding:.7rem;
+      overflow-x:auto;font-size:.7rem;line-height:1.45;white-space:pre;color:#c9cfda}
+  .toast{position:fixed;left:50%;bottom:calc(1rem + env(safe-area-inset-bottom));
+      transform:translate(-50%,.6rem);z-index:60;max-width:calc(100% - 2rem);
+      background:var(--text);color:#0b0d12;font-size:.78rem;font-weight:600;padding:.5rem .8rem;
+      border-radius:var(--r);opacity:0;transition:opacity .16s,transform .16s;
+      box-shadow:0 .5rem 1.4rem rgba(0,0,0,.55)}
+  .toast.on{opacity:1;transform:translate(-50%,0)}
+  .toast.bad{background:var(--red);color:#1a0503}
+  @media (prefers-reduced-motion:reduce){.toast,.skel,.dot.starting,.chip.refresh.spin{animation:none;transition:none}}
+  .foot{text-align:center;margin-top:1.6rem;font-size:.85rem}
+  .foot a{color:var(--green);text-decoration:none}
 </style>
-<header id="top">
-  <div class="bar">
-    <span class="logo">🐕</span>
-    <div class="main"><h1>corgi</h1><small id="host">your machine</small></div>
-    <button class="icon" id="refresh" aria-label="Refresh" title="Refresh">&#x21bb;</button>
+<header>
+  <div class="brand"><span class="logo">🐕</span>
+    <div class="who"><h1>corgi</h1><small id="host">your machine</small></div>
+    <button class="chip refresh" id="refresh" aria-label="Refresh" title="Refresh">&#x21bb;</button>
   </div>
   <p id="hostnote" class="hostnote" hidden></p>
 </header>
 <main>
-  <div id="list"></div>
-
-  <details class="card" id="tips" hidden>
-    <summary><span>On the laptop</span><span class="sh">setup commands</span></summary>
+  <div id="list" class="msg">Loading…</div>
+  <details class="tips" id="tips" hidden>
+    <summary><span>On the laptop</span><span class="tips-hint">setup commands</span></summary>
     <button class="tip" data-copy="/corgi-remote">
       <span class="tip-t">Set it all up, guided</span>
       <span class="tip-d">With the corgi plugin installed, this skill walks Claude Code through registering the repo, the tunnel and login start.</span>
@@ -1031,7 +967,7 @@ const launcherPageHTML = `<!doctype html>
     </button>
     <button class="tip" data-copy="corgi agent init --config-dir ~/.claude-work">
       <span class="tip-t">Use a second Claude account</span>
-      <span class="tip-d">Give a work repo its own account, then set its <b>Open links in</b> row to <b>chrome</b>.</span>
+      <span class="tip-d">Give a work repo its own account, then set its <b>open in</b> pill to <b>chrome</b>.</span>
       <span class="tip-cmd"><code>corgi agent init --config-dir ~/.claude-work</code><span class="tip-copy">COPY</span></span>
     </button>
     <button class="tip" data-copy="corgi agent install">
@@ -1044,47 +980,38 @@ const launcherPageHTML = `<!doctype html>
       <span class="tip-d">A session waiting on a permission prompt is invisible from here. <b>--all</b> covers every repo in this list. These reach the laptop only — <b>corgi agent notify telegram --token …</b> sends them to this phone too.</span>
       <span class="tip-cmd"><code>corgi agent hooks enable --all</code><span class="tip-copy">COPY</span></span>
     </button>
-    <p class="hint" id="tipmsg">Tap a row to copy its command.</p>
+    <p class="tipnote" id="tipmsg">Tap a row to copy its command.</p>
   </details>
 
-  <details class="card" id="settings" hidden>
-    <summary><span>Settings</span><span class="sh">devices, doctor, connector</span></summary>
+  <details class="settings" id="settings" hidden>
+    <summary>Settings</summary>
 
     <h3>Claude app</h3>
     <p>Add corgi as a custom connector on claude.ai (Settings → Connectors → Add custom) to drive this machine from the Claude app too.</p>
     <pre id="cfg"></pre>
-    <button class="btn block" id="copycfg">Copy connector config</button>
-    <p id="copymsg" class="hint"></p>
+    <button id="copycfg">Copy connector config</button>
+    <p id="copymsg" class="msg"></p>
 
     <h3>This browser</h3>
-    <p>Each card's <b>Open links in</b> row picks where session links open: <b>app</b> deep-links into the Claude app, <b>browser</b> keeps them here, <b>chrome</b> forces Chrome — the one to pick for a repo on a different Claude account. Remembered per workspace, here only.</p>
-    <p><b>Hide</b> tucks a card away when you are showing this screen to someone. Hidden cards collapse into one button; nothing on the machine changes.</p>
+    <p>The <b>open in</b> pill on each card cycles where session links open: <b>app</b> deep-links into the Claude app, <b>browser</b> keeps them here, <b>chrome</b> forces Chrome — the one to pick for a repo on a different Claude account. Remembered per workspace, here only.</p>
+    <p><b>hide</b> tucks a card away when you are showing this screen to someone. Hidden cards collapse into one button; nothing on the machine changes.</p>
     <label class="toggle"><input type="checkbox" id="showbridges"> Show hand-started (bridge) sessions</label>
     <p>A bridge is a session started on the laptop itself. Its claude.ai page shows only what you send from here, so it looks empty at first — the full transcript stays on the laptop.</p>
 
     <h3>Devices</h3>
     <p>Everything that scanned a pairing QR. Revoking one leaves the others working.</p>
-    <div id="devices" class="hint">Loading…</div>
+    <div id="devices" class="msg">Loading…</div>
 
     <h3>If something will not start</h3>
     <p>The same checks as <code>corgi agent doctor</code>, run from here.</p>
-    <button class="btn block" id="rundoctor">Run doctor</button>
+    <button id="rundoctor">Run doctor</button>
     <div id="doctor"></div>
     <p>For a push to this phone when a session needs you, set <code>notifyUrl</code> in the agent config on the laptop. A Discord, Slack or Telegram webhook works as well as an ntfy topic — corgi picks the payload from the host, which matters because ntfy's iOS app is paid. Without it, notifications only reach the laptop.</p>
   </details>
-
-  <p class="foot"><a id="allsessions" target="_blank" rel="noopener">See all your sessions on claude.ai ↗</a></p>
+  <p class="foot">
+    <a id="allsessions" target="_blank" rel="noopener">See all your sessions on claude.ai ↗</a>
+  </p>
 </main>
-
-<div class="sheet" id="sheet" hidden>
-  <button class="scrim" id="scrim" aria-label="Close"></button>
-  <section class="panel" role="dialog" aria-modal="true" aria-labelledby="sheettitle" tabindex="-1">
-    <button class="grab" id="grab" aria-label="Close"></button>
-    <h2 id="sheettitle"></h2>
-    <div class="sub" id="sheetsub"></div>
-    <div id="sheetbody"></div>
-  </section>
-</div>
 <div class="toast" id="toast" hidden></div>
 <script>
   const esc = s => String(s).replace(/[&<>"']/g, c =>
@@ -1102,18 +1029,9 @@ const launcherPageHTML = `<!doctype html>
   // this is a user navigation to the Claude session list, not a loaded asset.
   try { document.getElementById('allsessions').href = 'https://claude.ai/code'; } catch {}
 
-  let lastWorkspaces = [];
-  const openMode = id => { try { return localStorage.getItem('corgi_open_' + id) || 'app'; } catch { return 'app'; } };
-  const setOpenMode = (id, m) => { try { localStorage.setItem('corgi_open_' + id, m); } catch {} };
-  const showBridges = () => { try { return localStorage.getItem('corgi_show_bridges') !== '0'; } catch { return true; } };
-  const setShowBridges = on => { try { localStorage.setItem('corgi_show_bridges', on ? '1' : '0'); } catch {} };
-  const hidden = () => { try { return new Set(JSON.parse(localStorage.getItem('corgi_hidden') || '[]')); } catch { return new Set(); } };
-  const setHidden = s => { try { localStorage.setItem('corgi_hidden', JSON.stringify([...s])); } catch {} };
-  const toggleHidden = id => { const h = hidden(); h.has(id) ? h.delete(id) : h.add(id); setHidden(h); render(lastWorkspaces); };
-  let revealHidden = false;
-
   // One failure, one line, over the thumb — never a red block that pushes the
   // card you were aiming at somewhere else.
+  const REFRESH_MS = 15000;
   let toastTimer = 0;
   function toast(text, bad) {
     const el = document.getElementById('toast');
@@ -1124,52 +1042,61 @@ const launcherPageHTML = `<!doctype html>
     clearTimeout(toastTimer);
     toastTimer = setTimeout(() => {
       el.classList.remove('on');
-      setTimeout(() => { el.hidden = true; }, 220);
+      setTimeout(() => { el.hidden = true; }, 200);
     }, 3600);
   }
 
-  addEventListener('scroll', () => {
-    document.getElementById('top').classList.toggle('scrolled', scrollY > 4);
-  }, { passive: true });
-
-  // A session's name and state both change while you are looking at them —
-  // Claude renames the session as the work takes shape, a permission prompt
-  // arrives, a session exits. Refresh on a slow tick, only while the page is
-  // actually on screen, and never under an open sheet (it would re-render the
-  // row the thumb is on).
-  const REFRESH_MS = 15000;
-  function autoRefresh() {
-    if (document.visibilityState !== 'visible') return;
-    if (!document.getElementById('sheet').hidden) return;
-    load();
-  }
-  setInterval(autoRefresh, REFRESH_MS);
-  addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') autoRefresh();
-  });
+  let lastWorkspaces = [];
+  const openMode = id => { try { return localStorage.getItem('corgi_open_' + id) || 'app'; } catch { return 'app'; } };
+  const setOpenMode = (id, m) => { try { localStorage.setItem('corgi_open_' + id, m); } catch {} };
+  const showBridges = () => { try { return localStorage.getItem('corgi_show_bridges') !== '0'; } catch { return true; } };
+  const hidden = () => { try { return new Set(JSON.parse(localStorage.getItem('corgi_hidden') || '[]')); } catch { return new Set(); } };
+  const setHidden = s => { try { localStorage.setItem('corgi_hidden', JSON.stringify([...s])); } catch {} };
+  const toggleHidden = id => { const h = hidden(); h.has(id) ? h.delete(id) : h.add(id); setHidden(h); render(lastWorkspaces); };
+  let revealHidden = false;
+  const setShowBridges = on => { try { localStorage.setItem('corgi_show_bridges', on ? '1' : '0'); } catch {} };
 
   if (!token) {
     list.className = 'empty';
     list.innerHTML = '<h2>Pair this browser</h2><p>On the laptop run <code>corgi agent up</code> ' +
       'and scan the QR it prints. Then this page lists that machine&#39;s repos and starts ' +
-      'Claude Code sessions on them.</p>';
+      'sessions on them.</p>';
     document.getElementById('refresh').hidden = true;
   } else {
-    initSheet();
     initSettings();
     loadInfo();
     skeleton();
     load();
-    document.getElementById('refresh').onclick = () => {
-      const b = document.getElementById('refresh');
-      b.classList.add('spin');
-      Promise.all([load(), loadInfo()]).finally(() => setTimeout(() => b.classList.remove('spin'), 400));
-    };
+    initRefresh();
   }
 
   function skeleton() {
     list.className = '';
     list.innerHTML = '<div class="skel"></div><div class="skel"></div><div class="skel"></div>';
+  }
+
+  // A session's name and its state both change while you are looking at them:
+  // Claude renames a session as the work takes shape, a permission prompt
+  // arrives, a session exits. Refresh on a slow tick — only while the page is
+  // on screen, and never while a panel is open under the thumb, since
+  // re-rendering would collapse it.
+  function initRefresh() {
+    const btn = document.getElementById('refresh');
+    btn.onclick = () => {
+      btn.classList.add('spin');
+      Promise.all([load(), loadInfo()]).finally(() => setTimeout(() => btn.classList.remove('spin'), 400));
+    };
+    setInterval(autoRefresh, REFRESH_MS);
+    addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') autoRefresh();
+    });
+  }
+
+  function autoRefresh() {
+    if (document.visibilityState !== 'visible') return;
+    const openPanel = [...document.querySelectorAll('.sessions')].some(el => el.style.display !== 'none');
+    if (openPanel || document.querySelector('.startbox.on')) return;
+    load();
   }
 
   function initSettings() {
@@ -1178,9 +1105,9 @@ const launcherPageHTML = `<!doctype html>
       url: location.origin + '/mcp', headers: { Authorization: 'Bearer ' + token } } } }, null, 2);
     document.getElementById('cfg').textContent = connector;
     s.hidden = false;
-    document.getElementById('copycfg').onclick = async () => {
+    document.getElementById('copycfg').onclick = async (e) => {
       const msg = document.getElementById('copymsg');
-      try { await navigator.clipboard.writeText(connector); msg.textContent = '✓ Copied'; toast('Connector config copied'); }
+      try { await navigator.clipboard.writeText(connector); msg.textContent = '✓ Copied'; }
       catch { msg.textContent = 'Long-press the box above to copy.'; }
     };
     const bridges = document.getElementById('showbridges');
@@ -1225,10 +1152,10 @@ const launcherPageHTML = `<!doctype html>
       const r = await fetch('/launch/devices', { headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      const devices = j.devices || [];
-      if (!devices.length) { box.className = 'hint'; box.textContent = 'No devices paired yet.'; return; }
+      const list = j.devices || [];
+      if (!list.length) { box.className = 'msg'; box.textContent = 'No devices paired yet.'; return; }
       box.className = ''; box.innerHTML = '';
-      for (const d of devices) {
+      for (const d of list) {
         const row = document.createElement('div');
         row.className = 'dev';
         const left = document.createElement('div');
@@ -1237,13 +1164,13 @@ const launcherPageHTML = `<!doctype html>
         row.appendChild(left);
         if (!d.current) {
           const b = document.createElement('button');
-          b.className = 'btn danger'; b.textContent = 'Revoke';
+          b.textContent = 'Revoke';
           b.onclick = () => revokeDevice(d.name, b);
           row.appendChild(b);
         }
         box.appendChild(row);
       }
-    } catch (e) { box.className = 'hint err'; box.textContent = '✗ ' + e.message; }
+    } catch (e) { box.className = 'msg err'; box.textContent = '✗ ' + e.message; }
   }
 
   async function revokeDevice(name, btn) {
@@ -1252,14 +1179,13 @@ const launcherPageHTML = `<!doctype html>
       const r = await fetch('/launch/devices?name=' + encodeURIComponent(name), { method: 'DELETE', headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      toast('Revoked ' + name);
       loadDevices();
-    } catch (e) { btn.disabled = false; btn.textContent = 'Revoke'; toast(e.message, true); }
+    } catch (e) { btn.disabled = false; btn.textContent = '✗ ' + e.message; }
   }
 
   async function runDoctor() {
     const box = document.getElementById('doctor');
-    box.className = 'hint'; box.textContent = 'Checking…';
+    box.className = 'msg'; box.textContent = 'Checking…';
     try {
       const r = await fetch('/launch/doctor', { headers: auth });
       const j = await r.json();
@@ -1273,7 +1199,7 @@ const launcherPageHTML = `<!doctype html>
           esc(c.detail || '') + (c.fix ? '<span class="fix">fix: ' + esc(c.fix) + '</span>' : '') + '</span>';
         box.appendChild(el);
       }
-    } catch (e) { box.className = 'hint err'; box.textContent = '✗ ' + e.message; }
+    } catch (e) { box.className = 'msg err'; box.textContent = '✗ ' + e.message; }
   }
 
   async function load() {
@@ -1300,16 +1226,17 @@ const launcherPageHTML = `<!doctype html>
       const el = document.getElementById('host');
       el.textContent = '';
       bits.forEach((bit, i) => {
-        if (i) el.appendChild(document.createTextNode(' · '));
+        if (i) el.appendChild(document.createTextNode(' \u00b7 '));
         if (bit.indexOf('daemon ') === 0) {
           const tap = document.createElement('span');
-          tap.className = 'what' + (j.daemon ? '' : ' down'); tap.textContent = bit;
+          tap.className = 'what'; tap.textContent = bit;
           tap.onclick = () => toggleDaemonNote(j.daemon);
           el.appendChild(tap);
           return;
         }
         el.appendChild(document.createTextNode(bit));
       });
+      if (!j.daemon) el.style.color = 'var(--red)';
     } catch {}
   }
 
@@ -1322,168 +1249,120 @@ const launcherPageHTML = `<!doctype html>
     note.hidden = false;
   }
 
-  // A stable colour per repo: the card you want is found by shape before it is
-  // found by reading, which is the whole point of an avatar.
-  function hue(id) {
-    let h = 0;
-    for (const ch of String(id)) h = (h * 31 + ch.charCodeAt(0)) % 360;
-    return h;
-  }
-
   function render(workspaces) {
     lastWorkspaces = workspaces;
     if (!workspaces.length) {
       list.className = 'empty';
       list.innerHTML = '<h2>No repos yet</h2><p>On the laptop run <code>corgi agent scan ~/dev</code> ' +
-        'to register the stacks it finds, then pull this page down to refresh.</p>';
+        'to register the stacks it finds, then tap refresh.</p>';
       return;
     }
     list.className = '';
     list.innerHTML = '';
     const intro = introLine(workspaces);
     if (intro) list.appendChild(intro);
-    const label = document.createElement('div');
-    label.className = 'sectionlabel';
-    label.textContent = workspaces.length + (workspaces.length === 1 ? ' repo' : ' repos') + ' on this machine';
-    list.appendChild(label);
-
     const hide = hidden();
-    const shown = revealHidden ? workspaces : workspaces.filter(w => !hide.has(w.id));
-    const hiddenCount = workspaces.length - shown.length;
-    for (const ws of shown) list.appendChild(card(ws, hide));
+    const shownWs = revealHidden ? workspaces : workspaces.filter(w => !hide.has(w.id));
+    const hiddenCount = workspaces.length - shownWs.length;
+    for (const ws of shownWs) {
+      const row = document.createElement('div');
+      row.className = 'ws';
+      const head = document.createElement('div');
+      head.className = 'head';
+      const main = document.createElement('div');
+      main.className = 'main';
+      main.innerHTML = '<div class="name"><span class="dot ' + esc(dotState(ws)) + '"></span>' + esc(ws.id) + '</div>';
+      const path = document.createElement('div');
+      path.className = 'path'; path.title = ws.path; path.textContent = shortPath(ws.path);
+      path.onclick = () => {
+        const full = path.classList.toggle('full');
+        path.textContent = full ? ws.path : shortPath(ws.path);
+      };
+      main.appendChild(path);
+      const meta = metaLine(ws);
+      if (meta) main.appendChild(meta);
+      const usage = usageLine(ws);
+      if (usage) main.appendChild(usage);
+      head.appendChild(main);
+      if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
+        head.appendChild(openControl(ws));
+      } else {
+        const b = document.createElement('button');
+        b.textContent = ws.running ? 'Starting…' : (ws.note ? 'Retry' : 'Start');
+        b.disabled = ws.running;
+        b.onclick = () => startSession(ws.id, b);
+        head.appendChild(b);
+      }
+      row.appendChild(head);
+      if (!ws.running && ws.note) {
+        const note = document.createElement('div');
+        note.className = 'wnote'; note.textContent = ws.note;
+        row.appendChild(note);
+      }
+      const actions = document.createElement('div');
+      actions.className = 'actions';
+      const startBox = startOptions(ws);
+      const sessionsBox = document.createElement('div');
+      sessionsBox.className = 'sessions'; sessionsBox.style.display = 'none';
+      const sbtn = document.createElement('button');
+      sbtn.className = 'chip'; sbtn.textContent = sessionsChipLabel(ws);
+      sbtn.onclick = () => toggleSessions(ws, sbtn, sessionsBox);
+      actions.appendChild(sbtn);
+      actions.appendChild(modeSwitch(ws.id));
+      const top = topSessionRow(ws);
+      if (top) row.appendChild(top);
+      if (!ws.running && startBox) {
+        const opts = document.createElement('button');
+        opts.className = 'chip'; opts.textContent = 'options ⌄';
+        opts.onclick = () => { startBox.classList.toggle('on'); };
+        actions.appendChild(opts);
+      }
+      if (ws.running) actions.appendChild(stopControl(ws.id));
+      const hideBtn = document.createElement('button');
+      hideBtn.className = 'chip';
+      hideBtn.title = 'Hide this workspace on this browser';
+      hideBtn.textContent = hide.has(ws.id) ? 'unhide' : 'hide';
+      hideBtn.onclick = () => toggleHidden(ws.id);
+      actions.appendChild(hideBtn);
+      if (startBox) actions.appendChild(startBox);
+      row.appendChild(actions);
+      row.appendChild(sessionsBox);
+      list.appendChild(row);
+    }
     if (hiddenCount || revealHidden) {
       const b = document.createElement('button');
-      b.className = 'btn quiet block';
-      b.textContent = revealHidden ? 'Hide those again' : hiddenCount + ' hidden — show';
+      b.className = 'chip revealer';
+      b.textContent = revealHidden ? 'hide again' : hiddenCount + ' hidden — show';
       b.onclick = () => { revealHidden = !revealHidden; render(lastWorkspaces); };
       list.appendChild(b);
     }
   }
 
-  function card(ws, hide) {
-    const el = document.createElement('article');
-    el.className = 'ws';
-    // Tap anywhere that is not itself a control; the footer button below is the
-    // same door, and the one a keyboard or screen reader can find.
-    el.onclick = () => openSheet(ws);
-
-    const row = document.createElement('div');
-    row.className = 'row';
-    const ava = document.createElement('span');
-    ava.className = 'ava';
-    ava.style.setProperty('--h', hue(ws.id));
-    ava.textContent = String(ws.id || '?').replace(/[^a-zA-Z0-9]/g, '').slice(0, 1).toUpperCase() || '?';
-    ava.setAttribute('aria-hidden', 'true');
-    row.appendChild(ava);
-
-    const main = document.createElement('div');
-    main.className = 'main';
-    const nameline = document.createElement('div');
-    nameline.className = 'nameline';
-    const name = document.createElement('span');
-    name.className = 'name'; name.textContent = ws.id;
-    nameline.appendChild(name);
-    nameline.appendChild(stateChip(ws));
-    main.appendChild(nameline);
-    const path = document.createElement('div');
-    path.className = 'path'; path.textContent = shortPath(ws.path);
-    main.appendChild(path);
-    const tags = statusTags(ws);
-    if (tags) main.appendChild(tags);
-    row.appendChild(main);
-    row.appendChild(primaryAction(ws));
-    el.appendChild(row);
-
-    if (!ws.running && ws.note) {
-      const note = document.createElement('div');
-      note.className = 'wnote'; note.textContent = ws.note;
-      el.appendChild(note);
-    }
-    const top = topSessionRow(ws);
-    if (top) el.appendChild(top);
-
-    const foot = document.createElement('button');
-    foot.className = 'cardfoot';
-    foot.setAttribute('aria-label', ws.id + ' — sessions and options');
-    const left = document.createElement('span');
-    left.className = 'usage';
-    left.textContent = usageText(ws) || (hide.has(ws.id) ? 'hidden on this browser' : sessionsHint(ws));
-    const more = document.createElement('span');
-    more.className = 'more';
-    more.textContent = 'Details ›';
-    foot.appendChild(left); foot.appendChild(more);
-    el.appendChild(foot);
-    return el;
-  }
-
-  // The one white button on the card. Open when there is something to open,
-  // Start when there is not — never both, never neither.
-  function primaryAction(ws) {
-    if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
-      const mode = openMode(ws.id);
-      if (mode === 'browser' || mode === 'chrome') {
-        const b = document.createElement('button');
-        b.className = 'btn primary'; b.textContent = 'Open';
-        b.onclick = (e) => {
-          e.stopPropagation();
-          if (mode === 'chrome') { location.href = chromeUrl(ws.sessionUrl); }
-          else { window.open(ws.sessionUrl, '_blank', 'noopener'); }
-        };
-        return b;
-      }
-      // app mode uses a real anchor tap so iOS deep-links into the Claude app.
-      const a = document.createElement('a');
-      a.className = 'btn primary'; a.href = ws.sessionUrl; a.textContent = 'Open';
-      a.target = '_blank'; a.rel = 'noopener noreferrer';
-      a.onclick = (e) => e.stopPropagation();
-      return a;
-    }
-    const b = document.createElement('button');
-    b.className = 'btn primary';
-    b.textContent = ws.running ? 'Starting…' : (ws.note ? 'Retry' : 'Start');
-    b.disabled = ws.running;
-    b.onclick = (e) => { e.stopPropagation(); startSession(ws.id, b, null); };
-    return b;
-  }
-
-  // The state word comes from the daemon (/launch/workspaces), so the phone
-  // and any other client say the same thing about the same workspace.
-  const STATE_LABEL = {
-    live: ws => (ws.live > 1 ? ws.live + ' sessions' : 'live'),
-    attention: () => 'needs you',
-    starting: () => 'starting',
-    blocked: () => 'will not start',
-    stopped: () => 'stopped',
-  };
-
-  function stateChip(ws) {
-    const state = ws.state || (ws.running ? 'starting' : 'stopped');
-    const label = (STATE_LABEL[state] || STATE_LABEL.stopped)(ws);
-    const el = document.createElement('span');
-    el.className = 'state ' + state;
-    el.innerHTML = '<i></i>' + esc(label);
-    return el;
-  }
-
-  function statusTags(ws) {
+  function introLine(workspaces) {
+    if (workspaces.some(w => (w.live || 0) > 0)) return null;
     const el = document.createElement('div');
-    el.className = 'tags';
-    let any = false;
-    const e = ws.lastEvent;
-    if (e && !(ws.running && e.kind === 'started') && e.kind !== 'attention') {
-      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + e.cause : '') : e.kind;
-      const why = document.createElement('span');
-      why.className = 'why';
-      why.textContent = what + ' ' + fmtWhen(e.at);
-      el.appendChild(why); any = true;
-    }
-    return any ? el : null;
+    el.className = 'intro';
+    el.textContent = 'Tap a repo to start a Claude Code session on that machine. ' +
+      'It runs there with your files and databases; you drive it from here.';
+    return el;
   }
 
-  // Claude Code owns a session's name after it starts — /rename, a hook, or
-  // its own naming all rewrite the record corgi reads — so this is whatever
-  // the session is called right now, not what corgi called it at start.
-  // nameSource says who last set it; nameSince, when.
+  function sessionsChipLabel(ws) {
+    const more = (ws.live || 0) - (ws.topSession ? 1 : 0);
+    return more > 0 ? 'sessions +' + more + ' \u2304' : 'sessions \u2304';
+  }
+
+  // Inside one repo's card the leading workspace name is noise — the card
+  // already says which repo this is, so the branch and the time get the width.
+  function shortSessionName(name, id) {
+    const full = String(name || '');
+    const prefix = id + ' \u00b7 ';
+    return full.indexOf(prefix) === 0 ? full.slice(prefix.length) : full;
+  }
+
+  // Claude Code owns a session's name after it starts — /rename, a hook, or its
+  // own naming all rewrite the record corgi reads — so this row shows what the
+  // session is called right now, and says when that last changed.
   function nameNote(top) {
     if (!top.nameSource || top.nameSource === 'user') return '';
     if (!top.nameSince || !top.startedAt || top.nameSince - top.startedAt < 5000) return '';
@@ -1493,177 +1372,76 @@ const launcherPageHTML = `<!doctype html>
   function topSessionRow(ws) {
     const top = ws.topSession;
     if (!top) return null;
-    const when = [top.where, top.startedAt ? fmtWhen(top.startedAt) : '', nameNote(top)]
-      .filter(Boolean).join(' · ');
-    const body = '<i class="sdot"></i><span class="tmain"><span class="tname">' +
-      esc(shortSessionName(top.name, ws.id)) + '</span>' +
-      '<span class="when">' + esc(when) + '</span></span>';
+    const when = [top.where, top.startedAt ? fmtWhen(top.startedAt) : '']
+      .filter(Boolean).join(' \u00b7 ');
 
     if (!top.url || !safeClaudeUrl(top.url)) {
       const el = document.createElement('div');
       el.className = 'top';
-      el.innerHTML = body + '<span class="go small">local only</span>';
+      el.innerHTML = '<span><i class="sdot"></i><span class="tname">' +
+        esc(shortSessionName(top.name, ws.id)) + '</span></span>' +
+        '<span class="when">' + esc(when) + ' \u00b7 local only</span>';
       return el;
     }
     const el = document.createElement('a');
     el.className = 'top';
     el.href = top.url; el.target = '_blank'; el.rel = 'noopener noreferrer';
-    el.innerHTML = body + '<span class="go">↗</span>';
     const mode = openMode(ws.id);
-    el.onclick = (e) => {
-      e.stopPropagation();
-      if (mode === 'browser') { e.preventDefault(); window.open(top.url, '_blank', 'noopener'); }
-      if (mode === 'chrome') { e.preventDefault(); location.href = chromeUrl(top.url); }
-    };
+    if (mode === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(top.url, '_blank', 'noopener'); };
+    if (mode === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(top.url); };
+    el.innerHTML = '<span><i class="sdot"></i><span class="tname">' +
+      esc(shortSessionName(top.name, ws.id)) + '</span></span>' +
+      '<span class="when">' + esc(when) + ' \u00b7 open \u2197</span>';
     return el;
   }
 
-  // Inside one repo's card the leading workspace name is noise — the card
-  // already says which repo this is, so the branch and time get the width.
-  function shortSessionName(name, id) {
-    const full = String(name || '');
-    const prefix = id + ' · ';
-    return full.indexOf(prefix) === 0 ? full.slice(prefix.length) : full;
+  // The state word comes from the daemon (/launch/workspaces), so the phone
+  // and anything else reading it say the same thing about the same workspace.
+  function dotState(ws) {
+    const state = ws.state || (ws.running ? 'starting' : 'stopped');
+    return state === 'live' || state === 'starting' || state === 'attention' || state === 'blocked'
+      ? state : '';
   }
 
-  function sessionsHint(ws) {
-    const more = (ws.live || 0) - (ws.topSession ? 1 : 0);
-    if (more > 0) return more + ' more session' + (more > 1 ? 's' : '');
-    return ws.running ? 'sessions, options' : 'sessions, account, options';
+  function metaLine(ws) {
+    const bits = [];
+    if (ws.live > 0) bits.push('<span class="live">' + ws.live + ' live</span>');
+    else if (ws.state === 'starting') bits.push('<span class="live">starting</span>');
+    else if (ws.state === 'blocked') bits.push('<span class="warn">will not start</span>');
+    const e = ws.lastEvent;
+    if (e && !(ws.running && e.kind === 'started')) {
+      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + esc(e.cause) : '')
+        : e.kind === 'attention' ? 'needs you'
+        : esc(e.kind);
+      bits.push('<span class="why">' + what + ' ' + esc(fmtWhen(e.at)) + '</span>');
+    }
+    if (!bits.length) return null;
+    const el = document.createElement('div');
+    el.className = 'meta';
+    el.innerHTML = bits.join('');
+    return el;
   }
 
-  function usageText(ws) {
-    if (!ws.usage || !ws.usage.week) return '';
+    function usageLine(ws) {
+    if (!ws.usage || !ws.usage.week) return null;
     const sum = u => (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
     const week = sum(ws.usage.week);
-    if (!week) return '';
-    return fmtTokens(sum(ws.usage.today)) + ' today · ' + fmtTokens(week) + ' this week';
-  }
-
-  function introLine(workspaces) {
-    if (workspaces.some(w => (w.live || 0) > 0)) return null;
+    if (!week) return null;
     const el = document.createElement('div');
-    el.className = 'intro';
-    el.textContent = 'Tap Start to run a Claude Code session on that machine. ' +
-      'It works there with your files and databases; you drive it from here.';
+    el.className = 'usage';
+    el.title = 'tokens today / this week';
+    el.textContent = fmtTokens(sum(ws.usage.today)) + ' today \u00b7 ' + fmtTokens(week) + ' this week';
     return el;
   }
 
-  function shortPath(p) {
-    const parts = String(p || '').split('/').filter(Boolean);
-    return parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
-  }
-
-  /* ---- the bottom sheet: every secondary control, one thumb away ---- */
-
-  let sheetWs = null;
-
-  function initSheet() {
-    const sheet = document.getElementById('sheet');
-    const close = (e) => { e.stopPropagation(); closeSheet(); };
-    document.getElementById('scrim').onclick = close;
-    document.getElementById('grab').onclick = close;
-    addEventListener('keydown', (e) => { if (e.key === 'Escape') closeSheet(); });
-    sheet.addEventListener('click', (e) => { if (e.target === sheet) closeSheet(); });
-  }
-
-  function closeSheet() {
-    const sheet = document.getElementById('sheet');
-    if (sheet.hidden) return;
-    sheet.classList.remove('on');
-    sheetWs = null;
-    document.body.classList.remove('locked');
-    setTimeout(() => { sheet.hidden = true; }, 240);
-  }
-
-  function openSheet(ws) {
-    sheetWs = ws.id;
-    const sheet = document.getElementById('sheet');
-    document.getElementById('sheettitle').textContent = ws.id;
-    document.getElementById('sheetsub').textContent = ws.path || '';
-    const body = document.getElementById('sheetbody');
-    body.innerHTML = '';
-
-    // What you came for first: start it, or open what is already running.
-    if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
-      const open = primaryAction(ws);
-      open.classList.add('block');
-      open.textContent = 'Open the running session ↗';
-      body.appendChild(open);
-    } else if (!ws.running) {
-      const box = startOptions(ws);
-      if (box) body.appendChild(box);
-      const b = document.createElement('button');
-      b.className = 'btn primary block';
-      b.textContent = ws.note ? 'Try starting again' : 'Start a session';
-      b.onclick = (e) => { e.stopPropagation(); startSession(ws.id, b, box); };
-      body.appendChild(b);
-    }
-
-    body.appendChild(sheetRow('Open links in', openMode(ws.id), () => {
-      const order = ['app', 'browser', 'chrome'];
-      setOpenMode(ws.id, order[(order.indexOf(openMode(ws.id)) + 1) % order.length]);
-      render(lastWorkspaces);
-      openSheet(lastWorkspaces.find(w => w.id === ws.id) || ws);
-    }, 'app deep-links into the Claude app, browser stays here, chrome forces Chrome'));
-
-    const isHidden = hidden().has(ws.id);
-    body.appendChild(sheetRow(isHidden ? 'Unhide this repo' : 'Hide from this browser', '', () => {
-      toggleHidden(ws.id);
-      closeSheet();
-    }, 'Nothing on the machine changes — this browser only'));
-
-    if (ws.running) {
-      const stop = sheetRow('Stop the session', '', (row) => stopSession(ws.id, row), '');
-      stop.classList.add('bad');
-      body.appendChild(stop);
-    }
-
-    const sessions = document.createElement('div');
-    body.appendChild(sessions);
-    loadSessions(ws, sessions);
-
-    sheet.hidden = false;
-    document.body.classList.add('locked');
-    requestAnimationFrame(() => {
-      sheet.classList.add('on');
-      const panel = sheet.querySelector('.panel');
-      panel.scrollTop = 0;
-      panel.focus({ preventScroll: true });
-    });
-  }
-
-  function sheetRow(label, value, onTap, desc) {
-    const b = document.createElement('button');
-    b.className = 'srow';
-    const main = document.createElement('span');
-    main.innerHTML = esc(label) + (desc ? '<span class="desc">' + esc(desc) + '</span>' : '');
-    b.appendChild(main);
-    if (value) {
-      const v = document.createElement('span');
-      v.className = 'sval'; v.textContent = value;
-      b.appendChild(v);
-    }
-    const go = document.createElement('span');
-    go.className = 'go'; go.textContent = '›';
-    if (!value) go.style.marginLeft = 'auto';
-    b.appendChild(go);
-    b.onclick = (e) => { e.stopPropagation(); onTap(b); };
-    return b;
-  }
-
-  // The start options are built even when the sheet is closed again: Start
-  // reads them, so a profile chosen before tapping still applies.
+  // The start options are built even when collapsed: Start reads them, so a
+  // profile chosen before opening the panel still applies.
   function startOptions(ws) {
     if (ws.running) return null;
     const box = document.createElement('div');
     box.className = 'startbox';
     if ((ws.profiles || []).length) {
-      const field = document.createElement('div');
-      field.className = 'field';
-      field.innerHTML = '<label for="prof-' + esc(ws.id) + '">Claude account</label>';
       const sel = document.createElement('select');
-      sel.id = 'prof-' + ws.id;
       sel.dataset.role = 'profile';
       const none = document.createElement('option');
       none.value = ''; none.textContent = 'default account';
@@ -1673,32 +1451,24 @@ const launcherPageHTML = `<!doctype html>
         o.value = p; o.textContent = p;
         sel.appendChild(o);
       }
-      field.appendChild(sel);
-      box.appendChild(field);
+      box.appendChild(sel);
     }
-    const field = document.createElement('div');
-    field.className = 'field';
-    field.innerHTML = '<label for="name-' + esc(ws.id) + '">Session name</label>';
     const name = document.createElement('input');
-    name.id = 'name-' + ws.id;
-    name.type = 'text';
-    name.placeholder = 'what is it for? (optional)';
-    name.dataset.role = 'name';
+    name.type = 'text'; name.placeholder = 'session name (optional)'; name.dataset.role = 'name';
     name.maxLength = 60;
-    field.appendChild(name);
-    // Says what the field actually does: Claude owns the name once the session
-    // is running, so this is the starting one, not the last word.
-    const desc = document.createElement('span');
-    desc.className = 'desc';
-    desc.textContent = 'The name it starts with. Claude renames the session as the work takes ' +
-      'shape, and this list follows it.';
-    field.appendChild(desc);
-    box.appendChild(field);
+    box.appendChild(name);
     return box;
   }
 
-  async function loadSessions(ws, box) {
-    box.innerHTML = '<div class="grp"><span>sessions</span><i></i></div><div class="none">Loading…</div>';
+  function shortPath(p) {
+    const parts = String(p || '').split('/').filter(Boolean);
+    return parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
+  }
+
+  async function toggleSessions(ws, btn, box) {
+    if (box.style.display !== 'none') { box.style.display = 'none'; btn.textContent = 'sessions \u2304'; return; }
+    box.style.display = ''; btn.textContent = 'sessions \u2303';
+    box.innerHTML = '';
     const group = (label) => {
       const el = document.createElement('div');
       el.className = 'grp';
@@ -1712,19 +1482,18 @@ const launcherPageHTML = `<!doctype html>
       const m = openMode(ws.id);
       if (m === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
       if (m === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(url); };
-      const tag = o.bridge ? '<span class="tag">bridge</span>' : '';
-      const text = o.label ? esc(o.label) : esc(url.split('/').pop().slice(0, 14)) + '…';
+      const tag = o.bridge ? '<span class="tag" title="Hand-started on the laptop \u2014 its web page may look empty">bridge</span>' : '';
+      const text = o.label ? esc(o.label) : esc(url.split('/').pop().slice(0, 14)) + '\u2026';
       const dot = o.past ? '' : '<i class="sdot"></i>';
-      el.innerHTML = dot + '<span class="smain"><span class="sname">' + text + tag + '</span>' +
-        '<span class="when">' + esc(o.when || '') + '</span></span>' +
-        '<span class="go">' + (o.past ? '↻' : '↗') + '</span>';
+      el.innerHTML = '<span>' + dot + '<span class="tname">' + text + '</span>' + tag + '</span>' +
+        '<span class="when">' + esc(o.when || '') + (o.past ? 'reopen' : 'open \u2197') + '</span>';
       box.appendChild(el);
     };
     const renderLocal = (label, when) => {
       const el = document.createElement('div');
       el.className = 's';
-      el.innerHTML = '<i class="sdot"></i><span class="smain"><span class="sname">' + esc(label) + '</span>' +
-        '<span class="when">' + esc(when) + ' · local only</span></span>';
+      el.innerHTML = '<span><i class="sdot"></i><span class="tname">' + esc(label) +
+        '</span></span><span class="when">' + esc(when) + ' \u00b7 local only</span>';
       box.appendChild(el);
     };
     const note = (text) => {
@@ -1732,12 +1501,14 @@ const launcherPageHTML = `<!doctype html>
       el.className = 'hint'; el.textContent = text;
       box.appendChild(el);
     };
+    const info = document.createElement('div');
+    info.className = 'none'; info.textContent = 'Loading\u2026';
+    box.appendChild(info);
     try {
       const r = await fetch('/launch/sessions?workspace=' + encodeURIComponent(ws.id), { headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      if (sheetWs !== ws.id) return; // the sheet moved on while this was in flight
-      box.innerHTML = '';
+      info.remove();
 
       const running = j.sessions || [];
       const bridges = (j.links || []).filter(safeClaudeUrl);
@@ -1751,7 +1522,7 @@ const launcherPageHTML = `<!doctype html>
         if (!safeClaudeUrl(url) || alive.has(url) || seen.has(url)) return;
         seen.add(url); older.push({ url: url, when: when });
       };
-      for (const h of (j.history || [])) if (h) addOlder(h.url, fmtWhen(h.at));
+      for (const h of (j.history || [])) if (h) addOlder(h.url, fmtWhen(h.at) + ' \u00b7 ');
       for (const url of (ws.sessionLinks || []).slice().reverse()) addOlder(url, '');
 
       let localOnly = 0;
@@ -1760,10 +1531,13 @@ const launcherPageHTML = `<!doctype html>
       if (liveCount) group('live now');
       for (const sess of running) {
         const where = whereLabel(sess);
-        const when = where + ' · ' + fmtWhen(sess.startedAt);
+        const when = where + ' \u00b7 ' + fmtWhen(sess.startedAt);
         if (sess.url && safeClaudeUrl(sess.url) && !seen.has(sess.url)) {
           seen.add(sess.url);
-          renderLink(sess.url, { label: shortSessionName(sess.name, ws.id), when: when });
+          renderLink(sess.url, {
+            label: shortSessionName(sess.name, ws.id),
+            when: [when, nameNote(sess)].filter(Boolean).join(' \u00b7 ') + ' \u00b7 ',
+          });
           continue;
         }
         localOnly++;
@@ -1780,14 +1554,13 @@ const launcherPageHTML = `<!doctype html>
       }
       if (localOnly) note('local only = running on the laptop with no web link yet; type /remote-control in that session to reach it from here.');
       if (bridgeRows) note('bridge = started by hand on the laptop; its page shows only what you send from it.');
-      if (bridgeHidden) note(bridgeHidden + ' bridge session' + (bridgeHidden > 1 ? 's' : '') + ' hidden — enable in Settings.');
+      if (bridgeHidden) note(bridgeHidden + ' bridge session' + (bridgeHidden > 1 ? 's' : '') + ' hidden \u2014 enable in Settings.');
 
       if (older.length) {
-        group('earlier · not running');
+        group('earlier \u00b7 not running');
         for (const row of older) renderLink(row.url, { past: true, when: row.when });
       }
       if (!liveCount && !older.length && !evs.length) {
-        group('sessions');
         const none = document.createElement('div');
         none.className = 'none'; none.textContent = 'No sessions yet for this workspace.';
         box.appendChild(none);
@@ -1797,16 +1570,11 @@ const launcherPageHTML = `<!doctype html>
       for (const ev of evs) {
         const el = document.createElement('div');
         el.className = 'evrow';
-        const what = ev.kind + (ev.cause ? ' · ' + ev.cause : '') + (ev.reason ? ' — ' + ev.reason : '');
+        const what = ev.kind + (ev.cause ? ' \u00b7 ' + ev.cause : '') + (ev.reason ? ' \u2014 ' + ev.reason : '');
         el.innerHTML = '<b>' + esc(what.slice(0, 90)) + '</b><span>' + esc(fmtWhen(ev.at)) + '</span>';
         box.appendChild(el);
       }
-    } catch (e) {
-      if (sheetWs !== ws.id) return;
-      box.innerHTML = '';
-      group('sessions');
-      note('✗ ' + e.message);
-    }
+    } catch (e) { info.textContent = '\u2717 ' + e.message; }
   }
 
   function whereLabel(sess) {
@@ -1838,27 +1606,61 @@ const launcherPageHTML = `<!doctype html>
   // Safari or the Claude app's webview.
   const chromeUrl = u => u.replace(/^https:\/\//, 'googlechromes://');
 
-  async function stopSession(id, btn) {
-    btn.disabled = true;
-    btn.querySelector('span').textContent = 'Stopping…';
-    try {
-      const r = await fetch('/launch/stop', { method: 'POST', headers: auth,
-        body: JSON.stringify({ workspace: id }) });
-      const j = await r.json();
-      if (!r.ok) throw new Error(j.error || r.status);
-      closeSheet();
-      toast('Stopping ' + id + '…');
-      setTimeout(load, 1200);
-    } catch (e) {
-      btn.disabled = false;
-      btn.querySelector('span').textContent = 'Stop the session';
-      toast(e.message, true);
+  // app mode uses a real anchor tap so iOS deep-links into the Claude app;
+  // browser mode opens via JS, which keeps the session in this browser; chrome
+  // mode forces Chrome via its URL scheme (right for a workspace signed into a
+  // different Claude account than the app — e.g. work vs personal).
+  function openControl(ws) {
+    const mode = openMode(ws.id);
+    if (mode === 'browser' || mode === 'chrome') {
+      const b = document.createElement('button');
+      b.className = 'open'; b.textContent = 'Open';
+      b.onclick = () => {
+        if (mode === 'chrome') { location.href = chromeUrl(ws.sessionUrl); }
+        else { window.open(ws.sessionUrl, '_blank', 'noopener'); }
+      };
+      return b;
     }
+    const a = document.createElement('a');
+    a.className = 'open'; a.href = ws.sessionUrl; a.textContent = 'Open';
+    a.target = '_blank'; a.rel = 'noopener noreferrer';
+    return a;
   }
 
-  async function startSession(id, btn, box) {
-    const label = btn.textContent;
+  function modeSwitch(id) {
+    const order = ['app', 'browser', 'chrome'];
+    const cur = openMode(id);
+    const b = document.createElement('button');
+    b.className = 'chip';
+    b.title = 'Where session links open — tap to change';
+    b.innerHTML = 'open in <b>' + esc(cur) + '</b> ▾';
+    b.onclick = () => { setOpenMode(id, order[(order.indexOf(cur) + 1) % order.length]); render(lastWorkspaces); };
+    return b;
+  }
+
+  function stopControl(id) {
+    const b = document.createElement('button');
+    b.className = 'chip danger'; b.textContent = 'Stop';
+    b.onclick = async () => {
+      b.disabled = true; b.textContent = 'Stopping…';
+      try {
+        const r = await fetch('/launch/stop', { method: 'POST', headers: auth,
+          body: JSON.stringify({ workspace: id }) });
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.error || r.status);
+        toast('Stopping ' + id + '…');
+        setTimeout(load, 1200);
+      } catch (e) {
+        b.disabled = false; b.textContent = 'Stop';
+        toast(e.message, true);
+      }
+    };
+    return b;
+  }
+
+  async function startSession(id, btn) {
     btn.disabled = true; btn.textContent = 'Starting…';
+    const box = btn.closest('.ws').querySelector('.startbox');
     const pick = (role) => {
       const el = box && box.querySelector('[data-role="' + role + '"]');
       return el ? el.value.trim() : '';
@@ -1868,16 +1670,14 @@ const launcherPageHTML = `<!doctype html>
         body: JSON.stringify({ workspace: id, profile: pick('profile'), name: pick('name') }) });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      closeSheet();
       toast('Starting ' + id + '…');
-      // Show it as starting straight away: the list is the same surface the
-      // Start button lives on, and a card still offering Start invites a
-      // second one before the daemon has answered the first.
-      const w = lastWorkspaces.find(x => x.id === id);
-      if (w) { w.running = true; w.note = ''; render(lastWorkspaces); }
+      // Show it as starting straight away: a card still offering Start invites
+      // a second one before the daemon has answered the first.
+      const ws = lastWorkspaces.find(w => w.id === id);
+      if (ws) { ws.running = true; ws.state = 'starting'; ws.note = ''; render(lastWorkspaces); }
       poll(id, 0);
     } catch (e) {
-      btn.disabled = false; btn.textContent = label;
+      btn.disabled = false; btn.textContent = 'Retry';
       toast(e.message, true);
     }
   }

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -730,149 +730,247 @@ const launcherPageHTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="dark">
-<meta name="theme-color" content="#0b0d12">
+<meta name="theme-color" content="#000000">
 <title>corgi</title>
 <style>
-  :root{--bg:#0a0b0e;--card:#141519;--card2:#0f1013;--line:#22242b;--hair:#1a1c22;
-      --text:#eceef2;--dim:#8f94a3;--dim2:#63677a;--green:#6ee787;--amber:#ffa657;--red:#ff7b72;
-      --sp1:.25rem;--sp2:.5rem;--sp3:.75rem;--sp4:1rem;--r:.5rem}
+  /* One scale, one contrast ladder. Sizes are the ones a thumb and an arm's
+     length of daylight need — this page is read on a phone, outdoors, in a
+     hurry, so nothing here is smaller than 12px or shorter than 44px. */
+  :root{
+    --bg:#000;--surface:#101114;--surface2:#191a1e;--press:#212227;
+    --line:#26272c;--hair:#1c1d21;
+    --text:#fff;--dim:#a3a6ad;--dim2:#74777f;
+    --green:#3ddc91;--amber:#ffb84d;--red:#ff6f61;
+    --r:18px;--r-sm:12px;--pill:999px;
+    --tap:48px;--pad:20px;
+    --f-title:1.45rem;--f-row:1.06rem;--f-body:.95rem;--f-sub:.82rem;--f-cap:.75rem;
+  }
   *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
+  /* Flex and grid beat the hidden attribute on specificity; this page toggles
+     controls with .hidden, so it must not. */
+  [hidden]{display:none!important}
   html{-webkit-text-size-adjust:100%}
-  button,a,summary,label,input,.chip,.ws,.top,.s{touch-action:manipulation}
-  body{font-family:-apple-system,system-ui,sans-serif;background:var(--bg);color:var(--text);margin:0;
-      padding-bottom:env(safe-area-inset-bottom);-webkit-font-smoothing:antialiased}
-  header{padding:calc(1.2rem + env(safe-area-inset-top)) 1.2rem .3rem;max-width:34rem;margin:0 auto}
-  .brand{display:flex;align-items:center;gap:.7rem}
-  .logo{width:2.6rem;height:2.6rem;border-radius:.9rem;background:linear-gradient(135deg,#1e2634,#131824);
-      border:1px solid var(--line);display:flex;align-items:center;justify-content:center;font-size:1.35rem;flex:0 0 auto}
-  h1{font-size:1.25rem;margin:0;letter-spacing:.01em}
-  header small{display:block;color:var(--dim);font-size:.78rem;font-weight:400;margin-top:.1rem}
-  header small .what{color:var(--dim);border-bottom:1px dotted var(--line-soft,#3a4152);cursor:pointer}
-  .hostnote{color:var(--dim);font-size:.74rem;line-height:1.5;margin:.45rem 0 0;max-width:30rem}
-  main{padding:.4rem 1.2rem 2.2rem;max-width:34rem;margin:0 auto}
-  .ws{background:var(--card);border:1px solid var(--line);border-radius:.75rem;
-      padding:var(--sp3) var(--sp3) var(--sp2);margin:var(--sp2) 0}
-  .head{display:flex;align-items:center;gap:.7rem}
-  .main{min-width:0;flex:1}
-  .ws .name{font-weight:600;display:flex;align-items:center;gap:.5rem;font-size:.94rem;white-space:nowrap;
-      overflow:hidden;text-overflow:ellipsis;letter-spacing:-.006em}
-  .ws .path{color:var(--dim2);font-size:.7rem;margin-top:.15rem;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
-      white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
-  .ws .path.full{white-space:normal;word-break:break-all}
-  .ws .wnote{color:var(--red);font-size:.72rem;margin-top:.5rem;line-height:1.45}
-  .dot{width:.55rem;height:.55rem;border-radius:50%;background:#3a4152;flex:0 0 auto}
-  .dot.on{background:var(--green)}
-  .meta{display:flex;align-items:baseline;gap:.4rem;flex-wrap:wrap;margin-top:.25rem;
-      font-size:.73rem;color:var(--dim2)}
-  .meta span + span::before{content:"\00b7";color:var(--dim2);margin-right:.4rem}
-  .meta .live{color:var(--green)}
-  .meta .why{color:var(--dim)}
-  .usage{font-size:.68rem;color:var(--dim2);margin-top:.15rem;
-      font-variant-numeric:tabular-nums;opacity:.85}
-  .actions{display:flex;align-items:center;gap:.4rem;margin-top:.65rem;flex-wrap:wrap}
-  .startbox{flex-basis:100%;display:none;gap:.4rem;margin-top:.5rem}
-  .startbox.on{display:flex}
-  .startbox select,.startbox input{flex:1 1 6rem;min-width:0;background:var(--card2);border:1px solid var(--line);
-      color:var(--text);border-radius:.5rem;padding:.4rem .55rem;font-size:.78rem;font-family:inherit}
-  .evrow{display:flex;justify-content:space-between;gap:.6rem;font-size:.72rem;color:var(--dim);padding:.2rem .1rem}
-  .evrow b{font-weight:600;color:#c9cfda}
-  .dev{display:flex;align-items:center;justify-content:space-between;gap:.6rem;font-size:.8rem;
-      padding:.4rem 0;border-bottom:1px solid var(--line)}
-  .dev:last-child{border-bottom:0}
-  .dev .sub{color:var(--dim2);font-size:.7rem}
-  .dev button{background:none;border:1px solid rgba(255,123,114,.45);color:var(--red);font-size:.7rem;
-      padding:.25rem .6rem;border-radius:.5rem}
-  .chk{display:flex;gap:.5rem;font-size:.78rem;padding:.35rem 0;border-bottom:1px solid var(--line);line-height:1.45}
-  .chk:last-child{border-bottom:0}
-  .chk .fix{color:var(--dim);display:block;font-size:.72rem;margin-top:.15rem}
-  .chk.bad .mark{color:var(--red)}
-  .chk .mark{color:var(--green);flex:0 0 auto}
-  .chip{background:none;border:1px solid var(--line);color:var(--dim);font-size:.72rem;font-weight:500;
-      padding:.32rem .6rem;border-radius:var(--r);cursor:pointer}
-  .chip b{color:var(--text);font-weight:600}
-  .chip.danger{border-color:transparent;color:var(--dim);margin-left:auto}
-  .chip.danger:active{color:var(--red)}
-  .top{display:flex;align-items:center;justify-content:space-between;gap:.6rem;
-      margin-top:var(--sp2);padding:var(--sp2) 0 0;border-top:1px solid var(--hair);
-      font-size:.78rem;color:var(--text);text-decoration:none;min-height:2rem}
-  .top span:first-child{display:flex;align-items:center;min-width:0;overflow:hidden;
-      text-overflow:ellipsis;white-space:nowrap}
-  .top .when{color:var(--dim2);font-size:.7rem;flex:0 0 auto}
-  .intro{color:var(--dim);font-size:.8rem;line-height:1.5;margin:.2rem 0 .9rem}
-  .sessions{margin-top:var(--sp2);border-top:1px solid var(--hair);padding-top:var(--sp2)}
-  .sessions .s{display:flex;align-items:center;justify-content:space-between;gap:.6rem;font-size:.76rem;
-      color:#c9cfda;padding:.45rem .1rem;min-height:2.1rem;text-decoration:none}
-  .sessions .s span:first-child{display:flex;align-items:center;min-width:0;overflow:hidden;
-      text-overflow:ellipsis;white-space:nowrap;color:var(--text)}
-  .sdot{width:.375rem;height:.375rem;border-radius:50%;background:var(--green);margin-right:.5rem;flex:0 0 auto}
-  a.s.past span:first-child{color:var(--dim)}
-  a.s.past .when{color:#5b6274}
-  .sessions .grp{display:flex;align-items:center;gap:.5rem;margin:.6rem .1rem .1rem;color:var(--dim2);
-      font-size:.62rem;font-weight:600;letter-spacing:.08em;text-transform:uppercase}
-  .sessions .grp i{flex:1;height:1px;background:var(--hair)}
-  .sessions .s .when{color:var(--dim2);font-size:.68rem;flex:0 0 auto}
-  .sessions .none,.sessions .hint{color:var(--dim2);font-size:.7rem;line-height:1.45;padding:.2rem 0}
-  .tag{font-size:.6rem;font-weight:700;color:var(--amber);border:1px solid rgba(255,166,87,.4);
-      border-radius:.35rem;padding:.05rem .3rem;margin-left:.45rem;vertical-align:1px}
-  button{border:0;border-radius:var(--r);padding:.48rem .9rem;font-size:.82rem;font-weight:600;cursor:pointer;
-      background:#1e2027;color:var(--text);transition:transform .05s;flex:0 0 auto}
-  button:active{transform:scale(.97)}
-  button:disabled{opacity:.5}
-  a.open,button.open{display:inline-block;background:var(--green);color:#08110a;text-decoration:none;border:0;
-      padding:.48rem .9rem;border-radius:var(--r);font-weight:600;font-size:.82rem;cursor:pointer;flex:0 0 auto}
-  .msg{color:var(--dim);font-size:.9rem;margin:1rem 0;line-height:1.5}
-  .err{color:var(--red)}
-  code{background:var(--card);border:1px solid var(--line);padding:.1rem .35rem;border-radius:.35rem;font-size:.85em}
-  .tips{margin:1.5rem 0 0;background:var(--card);border:1px solid var(--line);border-radius:.75rem;
-      padding:0 var(--sp3)}
-  .tips summary{display:flex;align-items:center;justify-content:space-between;gap:var(--sp2);
-      list-style:none;cursor:pointer;padding:var(--sp3) 0;
-      font-size:.64rem;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--dim2)}
-  .tips summary::-webkit-details-marker{display:none}
-  .tips-hint{text-transform:none;letter-spacing:0;font-weight:400;font-size:.72rem;color:var(--dim2)}
-  .tips[open] .tips-hint::after{content:" \2303"}
-  .tips:not([open]) .tips-hint::after{content:" \2304"}
-  .tips > .tip:first-of-type{border-top:1px solid var(--hair);padding-top:var(--sp3)}
-  .tips[open]{padding-bottom:var(--sp3)}
-  .tip{display:flex;flex-direction:column;align-items:stretch;gap:.15rem;width:100%;text-align:left;
-      background:none;border:0;border-top:1px solid var(--hair);border-radius:0;
-      padding:var(--sp3) 0 var(--sp2);margin:0;cursor:pointer;font-family:inherit}
+  body{margin:0;background:var(--bg);color:var(--text);
+      font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;
+      font-size:var(--f-body);line-height:1.45;-webkit-font-smoothing:antialiased;
+      padding-bottom:calc(2rem + env(safe-area-inset-bottom))}
+  h1,h2,h3{margin:0;letter-spacing:-.02em}
+  button,input,select{font-family:inherit}
+  button,a,summary,label,input,[role=button]{touch-action:manipulation}
+  :focus-visible{outline:2px solid var(--text);outline-offset:2px;border-radius:6px}
 
-  .tip-t{font-size:.84rem;font-weight:600;color:var(--text);letter-spacing:-.005em}
-  .tip-d{font-size:.75rem;color:var(--dim);line-height:1.5}
-  .tip-cmd{display:flex;align-items:center;justify-content:space-between;gap:var(--sp2);
-      margin-top:var(--sp2);background:var(--card2);border-radius:var(--r);padding:.42rem .5rem}
-  .tip-cmd code{min-width:0;overflow-x:auto;white-space:nowrap;font-size:.7rem;color:var(--text);
-      background:none;border:0;padding:0}
-  .tip-copy{font-size:.66rem;font-weight:600;color:var(--dim2);flex:0 0 auto;letter-spacing:.02em}
+  /* Header: stays put, so the machine you are driving is never off-screen. */
+  header{position:sticky;top:0;z-index:20;padding:calc(.85rem + env(safe-area-inset-top)) var(--pad) .85rem;
+      background:rgba(0,0,0,.78);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+      border-bottom:1px solid transparent;transition:border-color .2s}
+  header.scrolled{border-bottom-color:var(--hair)}
+  .bar{display:flex;align-items:center;gap:.75rem;max-width:34rem;margin:0 auto}
+  .logo{width:2.5rem;height:2.5rem;border-radius:.85rem;background:var(--surface2);
+      display:flex;align-items:center;justify-content:center;font-size:1.3rem;flex:0 0 auto}
+  .bar .main{min-width:0;flex:1}
+  h1{font-size:var(--f-title);font-weight:800;line-height:1.1}
+  #host{display:block;color:var(--dim);font-size:var(--f-sub);margin-top:.1rem;line-height:1.35}
+  #host .what{color:var(--dim);border-bottom:1px dotted var(--dim2);cursor:pointer}
+  #host .down{color:var(--red)}
+  .icon{width:var(--tap);height:var(--tap);border-radius:var(--pill);border:0;flex:0 0 auto;
+      background:var(--surface2);color:var(--text);font-size:1.15rem;cursor:pointer;
+      display:flex;align-items:center;justify-content:center}
+  .icon:active{background:var(--press)}
+  .icon.spin{animation:spin .8s linear infinite}
+  @keyframes spin{to{transform:rotate(360deg)}}
+  .hostnote{max-width:34rem;margin:.7rem auto 0;color:var(--dim);font-size:var(--f-sub);line-height:1.5}
+
+  main{max-width:34rem;margin:0 auto;padding:.5rem var(--pad) 0}
+  .sectionlabel{font-size:var(--f-cap);font-weight:700;letter-spacing:.09em;text-transform:uppercase;
+      color:var(--dim2);margin:1.1rem .15rem .55rem}
+
+  /* A workspace is one card: identity on the left, the one action on the
+     right, everything else a tap into the sheet. */
+  .ws{background:var(--surface);border-radius:var(--r);padding:.9rem;margin-bottom:.7rem;
+      cursor:pointer;transition:background .12s}
+  .ws:active{background:var(--surface2)}
+  .row{display:flex;align-items:center;gap:.8rem}
+  .ava{width:3rem;height:3rem;border-radius:.95rem;flex:0 0 auto;display:flex;align-items:center;
+      justify-content:center;font-size:1.15rem;font-weight:700;color:#fff;letter-spacing:-.02em;
+      background:linear-gradient(150deg,hsl(var(--h) 42% 34%),hsl(var(--h) 46% 20%))}
+  .ws .main{min-width:0;flex:1}
+  .name{font-size:var(--f-row);font-weight:700;letter-spacing:-.015em;
+      white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .path{color:var(--dim2);font-size:var(--f-sub);margin-top:.05rem;
+      font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+      white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .tags{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-top:.35rem}
+  .pill{display:inline-flex;align-items:center;gap:.3rem;height:1.4rem;padding:0 .5rem;
+      border-radius:var(--pill);font-size:var(--f-cap);font-weight:700;letter-spacing:.01em;
+      background:var(--surface2);color:var(--dim)}
+  .pill.live{background:rgba(61,220,145,.14);color:var(--green)}
+  .pill.warn{background:rgba(255,111,97,.14);color:var(--red)}
+  .pill i{width:.4rem;height:.4rem;border-radius:50%;background:currentColor;
+      animation:pulse 2s ease-in-out infinite}
+  @keyframes pulse{50%{opacity:.35}}
+  .why{color:var(--dim2);font-size:var(--f-sub)}
+  .wnote{color:var(--red);font-size:var(--f-sub);line-height:1.5;margin-top:.6rem}
+
+  /* Buttons: exactly one white one per card — Uber's rule, and the reason you
+     never have to read a card twice to know what tapping it does. */
+  .btn{height:2.65rem;min-width:5.2rem;padding:0 1.05rem;border:0;border-radius:var(--r-sm);
+      font-size:var(--f-body);font-weight:700;letter-spacing:-.01em;cursor:pointer;flex:0 0 auto;
+      display:inline-flex;align-items:center;justify-content:center;gap:.35rem;
+      background:var(--surface2);color:var(--text);text-decoration:none;transition:transform .06s}
+  .btn:active{transform:scale(.97)}
+  .btn:disabled{opacity:.45}
+  .btn.primary{background:#fff;color:#000}
+  .btn.block{width:100%;height:3.4rem;font-size:1.02rem;margin-top:.7rem}
+  .btn.danger{background:rgba(255,111,97,.13);color:var(--red)}
+  .btn.quiet{background:none;color:var(--dim);font-weight:600}
+
+  .cardfoot{display:flex;align-items:center;justify-content:space-between;gap:.6rem;width:100%;
+      margin-top:.7rem;padding:.65rem 0 0;border:0;border-top:1px solid var(--hair);
+      background:none;font-family:inherit;font-size:var(--f-sub);color:var(--dim2);
+      text-align:left;cursor:pointer;min-height:2.4rem}
+  .cardfoot .more{color:var(--dim);font-weight:600;flex:0 0 auto}
+  .usage{font-variant-numeric:tabular-nums}
+
+  /* The live session gets its own row: it is the thing you came here to open. */
+  .top{display:flex;align-items:center;gap:.6rem;margin-top:.7rem;padding:.6rem .7rem;
+      background:var(--surface2);border-radius:var(--r-sm);color:var(--text);
+      text-decoration:none;min-height:2.9rem}
+  .top .tmain{display:flex;flex-direction:column;min-width:0;flex:1}
+  .top .tname{font-size:var(--f-body);font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .top .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem}
+  .top .go{color:var(--dim);font-size:1.1rem;flex:0 0 auto}
+  .top .go.small{font-size:var(--f-cap);color:var(--dim2)}
+  .sdot{width:.45rem;height:.45rem;border-radius:50%;background:var(--green);flex:0 0 auto;
+      animation:pulse 2s ease-in-out infinite}
+
+  .intro{color:var(--dim);font-size:var(--f-body);line-height:1.55;margin:.2rem .15rem 1rem}
+  .skel{background:var(--surface);border-radius:var(--r);height:5.6rem;margin-bottom:.7rem;
+      background-image:linear-gradient(100deg,transparent 20%,rgba(255,255,255,.05) 40%,transparent 60%);
+      background-size:220% 100%;animation:sweep 1.3s linear infinite}
+  @keyframes sweep{to{background-position:-220% 0}}
+  .msg{color:var(--dim);font-size:var(--f-body);line-height:1.55;margin:1rem .15rem}
+  .empty{padding:2.4rem .15rem 1rem}
+  .empty h2{font-size:1.35rem;font-weight:800;margin-bottom:.5rem}
+  .empty p{color:var(--dim);font-size:var(--f-body);line-height:1.6;margin:0}
+  .err{color:var(--red)}
+  code{background:var(--surface2);padding:.12rem .4rem;border-radius:.4rem;font-size:.9em}
+
+  /* Bottom sheet: every secondary control lives here, so the list stays one
+     line of thought. Reachable with a thumb, dismissed with one. */
+  body.locked{overflow:hidden}
+  .sheet{position:fixed;inset:0;z-index:50;display:flex;align-items:flex-end}
+  .sheet[hidden]{display:none}
+  .scrim{position:absolute;inset:0;background:rgba(0,0,0,.65);opacity:0;transition:opacity .22s;border:0}
+  .sheet.on .scrim{opacity:1}
+  .panel{position:relative;width:100%;max-width:34rem;margin:0 auto;background:var(--surface);
+      border-radius:1.4rem 1.4rem 0 0;max-height:90vh;overflow-y:auto;-webkit-overflow-scrolling:touch;
+      padding:.4rem var(--pad) calc(1.1rem + env(safe-area-inset-bottom));
+      transform:translateY(101%);transition:transform .26s cubic-bezier(.2,.8,.2,1)}
+  .sheet.on .panel{transform:none}
+  @media (prefers-reduced-motion:reduce){
+    .panel,.scrim{transition:none}
+    .skel,.sdot,.pill i,.icon.spin{animation:none}
+  }
+  .panel:focus,.panel:focus-visible{outline:none}
+  .grab{display:block;width:2.4rem;height:.25rem;border-radius:var(--pill);background:#3a3c42;
+      border:0;padding:0;margin:.5rem auto .9rem}
+  .sheet h2{font-size:1.25rem;font-weight:800}
+  .sheet .sub{color:var(--dim2);font-size:var(--f-sub);margin-top:.15rem;word-break:break-all;
+      font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  .srow{display:flex;align-items:center;gap:.8rem;width:100%;min-height:3.4rem;padding:.7rem 0;
+      background:none;border:0;border-top:1px solid var(--hair);color:var(--text);
+      font-size:var(--f-body);font-weight:600;text-align:left;cursor:pointer}
+  .srow:first-of-type{margin-top:.9rem}
+  .srow .sval{margin-left:auto;color:var(--dim);font-weight:500;flex:0 0 auto}
+  .srow .go{color:var(--dim2);font-size:1.05rem;flex:0 0 auto}
+  .srow.bad{color:var(--red)}
+  .srow .desc{display:block;color:var(--dim2);font-size:var(--f-cap);font-weight:400;margin-top:.1rem}
+  .field{margin-top:.9rem}
+  .field label{display:block;font-size:var(--f-cap);font-weight:700;letter-spacing:.07em;
+      text-transform:uppercase;color:var(--dim2);margin-bottom:.35rem}
+  .field select,.field input{width:100%;height:3rem;background:var(--surface2);border:1px solid var(--line);
+      color:var(--text);border-radius:var(--r-sm);padding:0 .8rem;font-size:var(--f-body)}
+  .field input::placeholder{color:var(--dim2)}
+
+  /* Session lists inside the sheet. */
+  .grp{display:flex;align-items:center;gap:.6rem;margin:1.1rem 0 .2rem;color:var(--dim2);
+      font-size:var(--f-cap);font-weight:700;letter-spacing:.09em;text-transform:uppercase}
+  .grp i{flex:1;height:1px;background:var(--hair)}
+  .s{display:flex;align-items:center;gap:.6rem;min-height:3rem;padding:.55rem 0;
+      border-top:1px solid var(--hair);color:var(--text);text-decoration:none;font-size:var(--f-body)}
+  .s .smain{display:flex;flex-direction:column;min-width:0;flex:1}
+  .s .sname{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-weight:600}
+  .s .when{color:var(--dim2);font-size:var(--f-cap);margin-top:.05rem}
+  .s.past .sname{color:var(--dim);font-weight:500}
+  .s .go{color:var(--dim2);flex:0 0 auto;font-size:1.05rem}
+  .tag{font-size:.65rem;font-weight:700;color:var(--amber);border:1px solid rgba(255,184,77,.4);
+      border-radius:.35rem;padding:.05rem .3rem;margin-left:.4rem;vertical-align:1px}
+  .hint,.none{color:var(--dim2);font-size:var(--f-cap);line-height:1.5;padding:.45rem 0}
+  .evrow{display:flex;justify-content:space-between;gap:.6rem;font-size:var(--f-sub);
+      color:var(--dim2);padding:.35rem 0}
+  .evrow b{font-weight:600;color:var(--dim);min-width:0}
+  .evrow span{flex:0 0 auto;white-space:nowrap}
+
+  /* Toast: a failure says so once, over the thumb, and gets out of the way. */
+  .toast{position:fixed;left:50%;bottom:calc(1.2rem + env(safe-area-inset-bottom));transform:translate(-50%,1rem);
+      z-index:60;max-width:calc(100% - 2.4rem);background:#fff;color:#000;font-size:var(--f-sub);
+      font-weight:600;padding:.75rem 1rem;border-radius:var(--r-sm);opacity:0;
+      transition:opacity .2s,transform .2s;box-shadow:0 .6rem 2rem rgba(0,0,0,.5)}
+  .toast[hidden]{display:none}
+  .toast.on{opacity:1;transform:translate(-50%,0)}
+  .toast.bad{background:var(--red);color:#1a0503}
+
+  /* Panels that are not the main job: quiet until opened. */
+  details.card{background:var(--surface);border-radius:var(--r);padding:0 var(--pad);margin-top:.7rem}
+  details.card summary{display:flex;align-items:center;justify-content:space-between;gap:.6rem;
+      list-style:none;cursor:pointer;min-height:3.4rem;padding:.9rem 0;font-size:var(--f-body);font-weight:600}
+  details.card summary::-webkit-details-marker{display:none}
+  details.card summary .sh{color:var(--dim2);font-size:var(--f-sub);font-weight:400}
+  details.card[open] summary .sh::after{content:" \2303"}
+  details.card:not([open]) summary .sh::after{content:" \2304"}
+  details.card[open]{padding-bottom:1.1rem}
+  details.card h3{font-size:var(--f-cap);font-weight:700;letter-spacing:.09em;text-transform:uppercase;
+      color:var(--dim2);margin:1.4rem 0 .5rem}
+  details.card p{color:var(--dim);font-size:var(--f-sub);line-height:1.55;margin:.5rem 0}
+  .tip{display:block;width:100%;text-align:left;background:none;border:0;border-top:1px solid var(--hair);
+      padding:.9rem 0 .8rem;cursor:pointer;color:var(--text)}
+  .tip-t{display:block;font-size:var(--f-body);font-weight:700}
+  .tip-d{display:block;font-size:var(--f-sub);color:var(--dim);line-height:1.5;margin-top:.15rem}
+  .tip-cmd{display:flex;align-items:center;justify-content:space-between;gap:.6rem;margin-top:.6rem;
+      background:var(--surface2);border-radius:var(--r-sm);padding:.6rem .7rem;min-height:2.6rem}
+  .tip-cmd code{min-width:0;overflow-x:auto;white-space:nowrap;background:none;padding:0;
+      font-size:var(--f-sub);color:var(--text)}
+  .tip-copy{font-size:var(--f-cap);font-weight:700;color:var(--dim2);flex:0 0 auto;letter-spacing:.04em}
   .tip.copied .tip-copy{color:var(--green)}
-  .tipnote{color:var(--dim2);font-size:.72rem;margin:var(--sp3) 0 0}
-  details.settings{margin:1.6rem 0 0;background:var(--card2);border:1px solid var(--line);
-      border-radius:1rem;padding:.4rem 1rem}
-  details.settings h3{font-size:.66rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
-      color:var(--dim2);margin:1.4rem 0 .4rem}
-  details.settings h3:first-of-type{margin-top:.6rem}
-  details.settings summary{color:var(--dim);font-size:.85rem;cursor:pointer;padding:.5rem 0;list-style:none}
-  details.settings summary::-webkit-details-marker{display:none}
-  details.settings p{color:var(--dim);font-size:.76rem;line-height:1.55}
-  label.toggle{display:flex;align-items:center;gap:.5rem;color:var(--dim);font-size:.78rem;
-      padding:.3rem 0 .7rem;cursor:pointer}
-  label.toggle input{accent-color:var(--green);width:1rem;height:1rem;margin:0}
-  pre{background:var(--bg);border:1px solid var(--line);border-radius:.6rem;padding:.7rem;
-      overflow-x:auto;font-size:.7rem;line-height:1.45;white-space:pre;color:#c9cfda}
-  .foot{text-align:center;margin-top:1.6rem;font-size:.85rem}
-  .foot a{color:var(--green);text-decoration:none}
+  .dev{display:flex;align-items:center;justify-content:space-between;gap:.6rem;
+      padding:.75rem 0;border-top:1px solid var(--hair);font-size:var(--f-body)}
+  .dev .sub{color:var(--dim2);font-size:var(--f-cap)}
+  .chk{display:flex;gap:.6rem;font-size:var(--f-sub);padding:.7rem 0;border-top:1px solid var(--hair);line-height:1.5}
+  .chk .mark{color:var(--green);flex:0 0 auto}
+  .chk.bad .mark{color:var(--red)}
+  .chk .fix{display:block;color:var(--dim2);font-size:var(--f-cap);margin-top:.15rem}
+  .toggle{display:flex;align-items:center;gap:.7rem;min-height:var(--tap);color:var(--text);
+      font-size:var(--f-body);cursor:pointer}
+  .toggle input{accent-color:var(--green);width:1.2rem;height:1.2rem;margin:0}
+  pre{background:#0a0b0d;border:1px solid var(--line);border-radius:var(--r-sm);padding:.8rem;
+      overflow-x:auto;font-size:var(--f-cap);line-height:1.5;white-space:pre;color:var(--dim)}
+  .foot{text-align:center;margin:1.6rem 0 0}
+  .foot a{color:var(--text);font-size:var(--f-body);font-weight:600;text-decoration:none;
+      display:inline-flex;align-items:center;min-height:var(--tap);padding:0 1rem}
 </style>
-<header>
-  <div class="brand"><span class="logo">🐕</span>
-    <div><h1>corgi</h1><small id="host">your machine</small>
-      <p id="hostnote" class="hostnote" hidden></p></div>
+<header id="top">
+  <div class="bar">
+    <span class="logo">🐕</span>
+    <div class="main"><h1>corgi</h1><small id="host">your machine</small></div>
+    <button class="icon" id="refresh" aria-label="Refresh" title="Refresh">&#x21bb;</button>
   </div>
+  <p id="hostnote" class="hostnote" hidden></p>
 </header>
 <main>
-  <div id="list" class="msg">Loading…</div>
-  <details class="tips" id="tips" hidden>
-    <summary><span>On the laptop</span><span class="tips-hint">setup commands</span></summary>
+  <div id="list"></div>
+
+  <details class="card" id="tips" hidden>
+    <summary><span>On the laptop</span><span class="sh">setup commands</span></summary>
     <button class="tip" data-copy="/corgi-remote">
       <span class="tip-t">Set it all up, guided</span>
       <span class="tip-d">With the corgi plugin installed, this skill walks Claude Code through registering the repo, the tunnel and login start.</span>
@@ -890,7 +988,7 @@ const launcherPageHTML = `<!doctype html>
     </button>
     <button class="tip" data-copy="corgi agent init --config-dir ~/.claude-work">
       <span class="tip-t">Use a second Claude account</span>
-      <span class="tip-d">Give a work repo its own account, then set its <b>open in</b> pill to <b>chrome</b>.</span>
+      <span class="tip-d">Give a work repo its own account, then set its <b>Open links in</b> row to <b>chrome</b>.</span>
       <span class="tip-cmd"><code>corgi agent init --config-dir ~/.claude-work</code><span class="tip-copy">COPY</span></span>
     </button>
     <button class="tip" data-copy="corgi agent install">
@@ -903,38 +1001,48 @@ const launcherPageHTML = `<!doctype html>
       <span class="tip-d">A session waiting on a permission prompt is invisible from here. <b>--all</b> covers every repo in this list. These reach the laptop only — <b>corgi agent notify telegram --token …</b> sends them to this phone too.</span>
       <span class="tip-cmd"><code>corgi agent hooks enable --all</code><span class="tip-copy">COPY</span></span>
     </button>
-    <p class="tipnote" id="tipmsg">Tap a row to copy its command.</p>
+    <p class="hint" id="tipmsg">Tap a row to copy its command.</p>
   </details>
 
-  <details class="settings" id="settings" hidden>
-    <summary>Settings</summary>
+  <details class="card" id="settings" hidden>
+    <summary><span>Settings</span><span class="sh">devices, doctor, connector</span></summary>
 
     <h3>Claude app</h3>
     <p>Add corgi as a custom connector on claude.ai (Settings → Connectors → Add custom) to drive this machine from the Claude app too.</p>
     <pre id="cfg"></pre>
-    <button id="copycfg">Copy connector config</button>
-    <p id="copymsg" class="msg"></p>
+    <button class="btn block" id="copycfg">Copy connector config</button>
+    <p id="copymsg" class="hint"></p>
 
     <h3>This browser</h3>
-    <p>The <b>open in</b> pill on each card cycles where session links open: <b>app</b> deep-links into the Claude app, <b>browser</b> keeps them here, <b>chrome</b> forces Chrome — the one to pick for a repo on a different Claude account. Remembered per workspace, here only.</p>
-    <p><b>hide</b> tucks a card away when you are showing this screen to someone. Hidden cards collapse into one button; nothing on the machine changes.</p>
+    <p>Each card's <b>Open links in</b> row picks where session links open: <b>app</b> deep-links into the Claude app, <b>browser</b> keeps them here, <b>chrome</b> forces Chrome — the one to pick for a repo on a different Claude account. Remembered per workspace, here only.</p>
+    <p><b>Hide</b> tucks a card away when you are showing this screen to someone. Hidden cards collapse into one button; nothing on the machine changes.</p>
     <label class="toggle"><input type="checkbox" id="showbridges"> Show hand-started (bridge) sessions</label>
     <p>A bridge is a session started on the laptop itself. Its claude.ai page shows only what you send from here, so it looks empty at first — the full transcript stays on the laptop.</p>
 
     <h3>Devices</h3>
     <p>Everything that scanned a pairing QR. Revoking one leaves the others working.</p>
-    <div id="devices" class="msg">Loading…</div>
+    <div id="devices" class="hint">Loading…</div>
 
     <h3>If something will not start</h3>
     <p>The same checks as <code>corgi agent doctor</code>, run from here.</p>
-    <button id="rundoctor">Run doctor</button>
+    <button class="btn block" id="rundoctor">Run doctor</button>
     <div id="doctor"></div>
     <p>For a push to this phone when a session needs you, set <code>notifyUrl</code> in the agent config on the laptop. A Discord, Slack or Telegram webhook works as well as an ntfy topic — corgi picks the payload from the host, which matters because ntfy's iOS app is paid. Without it, notifications only reach the laptop.</p>
   </details>
-  <p class="foot">
-    <a id="allsessions" target="_blank" rel="noopener">See all your sessions on claude.ai ↗</a>
-  </p>
+
+  <p class="foot"><a id="allsessions" target="_blank" rel="noopener">See all your sessions on claude.ai ↗</a></p>
 </main>
+
+<div class="sheet" id="sheet" hidden>
+  <button class="scrim" id="scrim" aria-label="Close"></button>
+  <section class="panel" role="dialog" aria-modal="true" aria-labelledby="sheettitle" tabindex="-1">
+    <button class="grab" id="grab" aria-label="Close"></button>
+    <h2 id="sheettitle"></h2>
+    <div class="sub" id="sheetsub"></div>
+    <div id="sheetbody"></div>
+  </section>
+</div>
+<div class="toast" id="toast" hidden></div>
 <script>
   const esc = s => String(s).replace(/[&<>"']/g, c =>
     ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
@@ -955,20 +1063,54 @@ const launcherPageHTML = `<!doctype html>
   const openMode = id => { try { return localStorage.getItem('corgi_open_' + id) || 'app'; } catch { return 'app'; } };
   const setOpenMode = (id, m) => { try { localStorage.setItem('corgi_open_' + id, m); } catch {} };
   const showBridges = () => { try { return localStorage.getItem('corgi_show_bridges') !== '0'; } catch { return true; } };
+  const setShowBridges = on => { try { localStorage.setItem('corgi_show_bridges', on ? '1' : '0'); } catch {} };
   const hidden = () => { try { return new Set(JSON.parse(localStorage.getItem('corgi_hidden') || '[]')); } catch { return new Set(); } };
   const setHidden = s => { try { localStorage.setItem('corgi_hidden', JSON.stringify([...s])); } catch {} };
   const toggleHidden = id => { const h = hidden(); h.has(id) ? h.delete(id) : h.add(id); setHidden(h); render(lastWorkspaces); };
   let revealHidden = false;
-  const setShowBridges = on => { try { localStorage.setItem('corgi_show_bridges', on ? '1' : '0'); } catch {} };
+
+  // One failure, one line, over the thumb — never a red block that pushes the
+  // card you were aiming at somewhere else.
+  let toastTimer = 0;
+  function toast(text, bad) {
+    const el = document.getElementById('toast');
+    el.textContent = text;
+    el.className = 'toast' + (bad ? ' bad' : '');
+    el.hidden = false;
+    requestAnimationFrame(() => el.classList.add('on'));
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      el.classList.remove('on');
+      setTimeout(() => { el.hidden = true; }, 220);
+    }, 3600);
+  }
+
+  addEventListener('scroll', () => {
+    document.getElementById('top').classList.toggle('scrolled', scrollY > 4);
+  }, { passive: true });
 
   if (!token) {
-    list.className = 'msg';
-    list.innerHTML = 'Not paired on this browser yet. On your laptop run ' +
-      '<code>corgi agent up</code> and scan the QR to pair, then come back here.';
+    list.className = 'empty';
+    list.innerHTML = '<h2>Pair this browser</h2><p>On the laptop run <code>corgi agent up</code> ' +
+      'and scan the QR it prints. Then this page lists that machine&#39;s repos and starts ' +
+      'Claude Code sessions on them.</p>';
+    document.getElementById('refresh').hidden = true;
   } else {
+    initSheet();
     initSettings();
     loadInfo();
+    skeleton();
     load();
+    document.getElementById('refresh').onclick = () => {
+      const b = document.getElementById('refresh');
+      b.classList.add('spin');
+      Promise.all([load(), loadInfo()]).finally(() => setTimeout(() => b.classList.remove('spin'), 400));
+    };
+  }
+
+  function skeleton() {
+    list.className = '';
+    list.innerHTML = '<div class="skel"></div><div class="skel"></div><div class="skel"></div>';
   }
 
   function initSettings() {
@@ -977,9 +1119,9 @@ const launcherPageHTML = `<!doctype html>
       url: location.origin + '/mcp', headers: { Authorization: 'Bearer ' + token } } } }, null, 2);
     document.getElementById('cfg').textContent = connector;
     s.hidden = false;
-    document.getElementById('copycfg').onclick = async (e) => {
+    document.getElementById('copycfg').onclick = async () => {
       const msg = document.getElementById('copymsg');
-      try { await navigator.clipboard.writeText(connector); msg.textContent = '✓ Copied'; }
+      try { await navigator.clipboard.writeText(connector); msg.textContent = '✓ Copied'; toast('Connector config copied'); }
       catch { msg.textContent = 'Long-press the box above to copy.'; }
     };
     const bridges = document.getElementById('showbridges');
@@ -1024,10 +1166,10 @@ const launcherPageHTML = `<!doctype html>
       const r = await fetch('/launch/devices', { headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      const list = j.devices || [];
-      if (!list.length) { box.className = 'msg'; box.textContent = 'No devices paired yet.'; return; }
+      const devices = j.devices || [];
+      if (!devices.length) { box.className = 'hint'; box.textContent = 'No devices paired yet.'; return; }
       box.className = ''; box.innerHTML = '';
-      for (const d of list) {
+      for (const d of devices) {
         const row = document.createElement('div');
         row.className = 'dev';
         const left = document.createElement('div');
@@ -1036,13 +1178,13 @@ const launcherPageHTML = `<!doctype html>
         row.appendChild(left);
         if (!d.current) {
           const b = document.createElement('button');
-          b.textContent = 'Revoke';
+          b.className = 'btn danger'; b.textContent = 'Revoke';
           b.onclick = () => revokeDevice(d.name, b);
           row.appendChild(b);
         }
         box.appendChild(row);
       }
-    } catch (e) { box.className = 'msg err'; box.textContent = '✗ ' + e.message; }
+    } catch (e) { box.className = 'hint err'; box.textContent = '✗ ' + e.message; }
   }
 
   async function revokeDevice(name, btn) {
@@ -1051,13 +1193,14 @@ const launcherPageHTML = `<!doctype html>
       const r = await fetch('/launch/devices?name=' + encodeURIComponent(name), { method: 'DELETE', headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
+      toast('Revoked ' + name);
       loadDevices();
-    } catch (e) { btn.disabled = false; btn.textContent = '✗ ' + e.message; }
+    } catch (e) { btn.disabled = false; btn.textContent = 'Revoke'; toast(e.message, true); }
   }
 
   async function runDoctor() {
     const box = document.getElementById('doctor');
-    box.className = 'msg'; box.textContent = 'Checking…';
+    box.className = 'hint'; box.textContent = 'Checking…';
     try {
       const r = await fetch('/launch/doctor', { headers: auth });
       const j = await r.json();
@@ -1071,7 +1214,7 @@ const launcherPageHTML = `<!doctype html>
           esc(c.detail || '') + (c.fix ? '<span class="fix">fix: ' + esc(c.fix) + '</span>' : '') + '</span>';
         box.appendChild(el);
       }
-    } catch (e) { box.className = 'msg err'; box.textContent = '✗ ' + e.message; }
+    } catch (e) { box.className = 'hint err'; box.textContent = '✗ ' + e.message; }
   }
 
   async function load() {
@@ -1098,17 +1241,16 @@ const launcherPageHTML = `<!doctype html>
       const el = document.getElementById('host');
       el.textContent = '';
       bits.forEach((bit, i) => {
-        if (i) el.appendChild(document.createTextNode(' \u00b7 '));
+        if (i) el.appendChild(document.createTextNode(' · '));
         if (bit.indexOf('daemon ') === 0) {
           const tap = document.createElement('span');
-          tap.className = 'what'; tap.textContent = bit;
+          tap.className = 'what' + (j.daemon ? '' : ' down'); tap.textContent = bit;
           tap.onclick = () => toggleDaemonNote(j.daemon);
           el.appendChild(tap);
           return;
         }
         el.appendChild(document.createTextNode(bit));
       });
-      if (!j.daemon) el.style.color = 'var(--red)';
     } catch {}
   }
 
@@ -1121,168 +1263,325 @@ const launcherPageHTML = `<!doctype html>
     note.hidden = false;
   }
 
+  // A stable colour per repo: the card you want is found by shape before it is
+  // found by reading, which is the whole point of an avatar.
+  function hue(id) {
+    let h = 0;
+    for (const ch of String(id)) h = (h * 31 + ch.charCodeAt(0)) % 360;
+    return h;
+  }
+
   function render(workspaces) {
     lastWorkspaces = workspaces;
     if (!workspaces.length) {
-      list.className = 'msg';
-      list.innerHTML = 'No workspaces registered. On the laptop: <code>corgi agent scan ~/dev</code>.';
+      list.className = 'empty';
+      list.innerHTML = '<h2>No repos yet</h2><p>On the laptop run <code>corgi agent scan ~/dev</code> ' +
+        'to register the stacks it finds, then pull this page down to refresh.</p>';
       return;
     }
     list.className = '';
     list.innerHTML = '';
     const intro = introLine(workspaces);
     if (intro) list.appendChild(intro);
+    const label = document.createElement('div');
+    label.className = 'sectionlabel';
+    label.textContent = workspaces.length + (workspaces.length === 1 ? ' repo' : ' repos') + ' on this machine';
+    list.appendChild(label);
+
     const hide = hidden();
-    const shownWs = revealHidden ? workspaces : workspaces.filter(w => !hide.has(w.id));
-    const hiddenCount = workspaces.length - shownWs.length;
-    for (const ws of shownWs) {
-      const row = document.createElement('div');
-      row.className = 'ws';
-      const head = document.createElement('div');
-      head.className = 'head';
-      const main = document.createElement('div');
-      main.className = 'main';
-      main.innerHTML = '<div class="name"><span class="dot' + (ws.running ? ' on' : '') + '"></span>' + esc(ws.id) + '</div>';
-      const path = document.createElement('div');
-      path.className = 'path'; path.title = ws.path; path.textContent = shortPath(ws.path);
-      path.onclick = () => {
-        const full = path.classList.toggle('full');
-        path.textContent = full ? ws.path : shortPath(ws.path);
-      };
-      main.appendChild(path);
-      const meta = metaLine(ws);
-      if (meta) main.appendChild(meta);
-      const usage = usageLine(ws);
-      if (usage) main.appendChild(usage);
-      head.appendChild(main);
-      if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
-        head.appendChild(openControl(ws));
-      } else {
-        const b = document.createElement('button');
-        b.textContent = ws.running ? 'Starting…' : (ws.note ? 'Retry' : 'Start');
-        b.disabled = ws.running;
-        b.onclick = () => startSession(ws.id, b);
-        head.appendChild(b);
-      }
-      row.appendChild(head);
-      if (!ws.running && ws.note) {
-        const note = document.createElement('div');
-        note.className = 'wnote'; note.textContent = ws.note;
-        row.appendChild(note);
-      }
-      const actions = document.createElement('div');
-      actions.className = 'actions';
-      const startBox = startOptions(ws);
-      const sessionsBox = document.createElement('div');
-      sessionsBox.className = 'sessions'; sessionsBox.style.display = 'none';
-      const sbtn = document.createElement('button');
-      sbtn.className = 'chip'; sbtn.textContent = sessionsChipLabel(ws);
-      sbtn.onclick = () => toggleSessions(ws, sbtn, sessionsBox);
-      actions.appendChild(sbtn);
-      actions.appendChild(modeSwitch(ws.id));
-      const top = topSessionRow(ws);
-      if (top) row.appendChild(top);
-      if (!ws.running && startBox) {
-        const opts = document.createElement('button');
-        opts.className = 'chip'; opts.textContent = 'options ⌄';
-        opts.onclick = () => { startBox.classList.toggle('on'); };
-        actions.appendChild(opts);
-      }
-      if (ws.running) actions.appendChild(stopControl(ws.id));
-      const hideBtn = document.createElement('button');
-      hideBtn.className = 'chip';
-      hideBtn.title = 'Hide this workspace on this browser';
-      hideBtn.textContent = hide.has(ws.id) ? 'unhide' : 'hide';
-      hideBtn.onclick = () => toggleHidden(ws.id);
-      actions.appendChild(hideBtn);
-      if (startBox) actions.appendChild(startBox);
-      row.appendChild(actions);
-      row.appendChild(sessionsBox);
-      list.appendChild(row);
-    }
+    const shown = revealHidden ? workspaces : workspaces.filter(w => !hide.has(w.id));
+    const hiddenCount = workspaces.length - shown.length;
+    for (const ws of shown) list.appendChild(card(ws, hide));
     if (hiddenCount || revealHidden) {
       const b = document.createElement('button');
-      b.className = 'chip revealer';
-      b.textContent = revealHidden ? 'hide again' : hiddenCount + ' hidden — show';
+      b.className = 'btn quiet block';
+      b.textContent = revealHidden ? 'Hide those again' : hiddenCount + ' hidden — show';
       b.onclick = () => { revealHidden = !revealHidden; render(lastWorkspaces); };
       list.appendChild(b);
     }
+  }
+
+  function card(ws, hide) {
+    const el = document.createElement('article');
+    el.className = 'ws';
+    // Tap anywhere that is not itself a control; the footer button below is the
+    // same door, and the one a keyboard or screen reader can find.
+    el.onclick = () => openSheet(ws);
+
+    const row = document.createElement('div');
+    row.className = 'row';
+    const ava = document.createElement('span');
+    ava.className = 'ava';
+    ava.style.setProperty('--h', hue(ws.id));
+    ava.textContent = String(ws.id || '?').replace(/[^a-zA-Z0-9]/g, '').slice(0, 1).toUpperCase() || '?';
+    ava.setAttribute('aria-hidden', 'true');
+    row.appendChild(ava);
+
+    const main = document.createElement('div');
+    main.className = 'main';
+    const name = document.createElement('div');
+    name.className = 'name'; name.textContent = ws.id;
+    main.appendChild(name);
+    const path = document.createElement('div');
+    path.className = 'path'; path.textContent = shortPath(ws.path);
+    main.appendChild(path);
+    const tags = statusTags(ws);
+    if (tags) main.appendChild(tags);
+    row.appendChild(main);
+    row.appendChild(primaryAction(ws));
+    el.appendChild(row);
+
+    if (!ws.running && ws.note) {
+      const note = document.createElement('div');
+      note.className = 'wnote'; note.textContent = ws.note;
+      el.appendChild(note);
+    }
+    const top = topSessionRow(ws);
+    if (top) el.appendChild(top);
+
+    const foot = document.createElement('button');
+    foot.className = 'cardfoot';
+    foot.setAttribute('aria-label', ws.id + ' — sessions and options');
+    const left = document.createElement('span');
+    left.className = 'usage';
+    left.textContent = usageText(ws) || (hide.has(ws.id) ? 'hidden on this browser' : sessionsHint(ws));
+    const more = document.createElement('span');
+    more.className = 'more';
+    more.textContent = 'Details ›';
+    foot.appendChild(left); foot.appendChild(more);
+    el.appendChild(foot);
+    return el;
+  }
+
+  // The one white button on the card. Open when there is something to open,
+  // Start when there is not — never both, never neither.
+  function primaryAction(ws) {
+    if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
+      const mode = openMode(ws.id);
+      if (mode === 'browser' || mode === 'chrome') {
+        const b = document.createElement('button');
+        b.className = 'btn primary'; b.textContent = 'Open';
+        b.onclick = (e) => {
+          e.stopPropagation();
+          if (mode === 'chrome') { location.href = chromeUrl(ws.sessionUrl); }
+          else { window.open(ws.sessionUrl, '_blank', 'noopener'); }
+        };
+        return b;
+      }
+      // app mode uses a real anchor tap so iOS deep-links into the Claude app.
+      const a = document.createElement('a');
+      a.className = 'btn primary'; a.href = ws.sessionUrl; a.textContent = 'Open';
+      a.target = '_blank'; a.rel = 'noopener noreferrer';
+      a.onclick = (e) => e.stopPropagation();
+      return a;
+    }
+    const b = document.createElement('button');
+    b.className = 'btn primary';
+    b.textContent = ws.running ? 'Starting…' : (ws.note ? 'Retry' : 'Start');
+    b.disabled = ws.running;
+    b.onclick = (e) => { e.stopPropagation(); startSession(ws.id, b, null); };
+    return b;
+  }
+
+  function statusTags(ws) {
+    const el = document.createElement('div');
+    el.className = 'tags';
+    let any = false;
+    if (ws.live > 0) {
+      const p = document.createElement('span');
+      p.className = 'pill live';
+      p.innerHTML = '<i></i>' + ws.live + ' live';
+      el.appendChild(p); any = true;
+    } else if (ws.running) {
+      const p = document.createElement('span');
+      p.className = 'pill'; p.textContent = 'starting';
+      el.appendChild(p); any = true;
+    }
+    const e = ws.lastEvent;
+    if (e && !(ws.running && e.kind === 'started')) {
+      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + e.cause : '')
+        : e.kind === 'attention' ? 'needs you' : e.kind;
+      const s = document.createElement('span');
+      s.className = e.kind === 'attention' ? 'pill warn' : 'why';
+      s.textContent = what + ' ' + fmtWhen(e.at);
+      el.appendChild(s); any = true;
+    }
+    return any ? el : null;
+  }
+
+  function topSessionRow(ws) {
+    const top = ws.topSession;
+    if (!top) return null;
+    const when = [top.where, top.startedAt ? fmtWhen(top.startedAt) : ''].filter(Boolean).join(' · ');
+    const body = '<i class="sdot"></i><span class="tmain"><span class="tname">' +
+      esc(shortSessionName(top.name, ws.id)) + '</span>' +
+      '<span class="when">' + esc(when) + '</span></span>';
+
+    if (!top.url || !safeClaudeUrl(top.url)) {
+      const el = document.createElement('div');
+      el.className = 'top';
+      el.innerHTML = body + '<span class="go small">local only</span>';
+      return el;
+    }
+    const el = document.createElement('a');
+    el.className = 'top';
+    el.href = top.url; el.target = '_blank'; el.rel = 'noopener noreferrer';
+    el.innerHTML = body + '<span class="go">↗</span>';
+    const mode = openMode(ws.id);
+    el.onclick = (e) => {
+      e.stopPropagation();
+      if (mode === 'browser') { e.preventDefault(); window.open(top.url, '_blank', 'noopener'); }
+      if (mode === 'chrome') { e.preventDefault(); location.href = chromeUrl(top.url); }
+    };
+    return el;
+  }
+
+  // Inside one repo's card the leading workspace name is noise — the card
+  // already says which repo this is, so the branch and time get the width.
+  function shortSessionName(name, id) {
+    const full = String(name || '');
+    const prefix = id + ' · ';
+    return full.indexOf(prefix) === 0 ? full.slice(prefix.length) : full;
+  }
+
+  function sessionsHint(ws) {
+    const more = (ws.live || 0) - (ws.topSession ? 1 : 0);
+    if (more > 0) return more + ' more session' + (more > 1 ? 's' : '');
+    return ws.running ? 'sessions, options' : 'sessions, account, options';
+  }
+
+  function usageText(ws) {
+    if (!ws.usage || !ws.usage.week) return '';
+    const sum = u => (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
+    const week = sum(ws.usage.week);
+    if (!week) return '';
+    return fmtTokens(sum(ws.usage.today)) + ' today · ' + fmtTokens(week) + ' this week';
   }
 
   function introLine(workspaces) {
     if (workspaces.some(w => (w.live || 0) > 0)) return null;
     const el = document.createElement('div');
     el.className = 'intro';
-    el.textContent = 'Tap a repo to start a Claude Code session on that machine. ' +
-      'It runs there with your files and databases; you drive it from here.';
+    el.textContent = 'Tap Start to run a Claude Code session on that machine. ' +
+      'It works there with your files and databases; you drive it from here.';
     return el;
   }
 
-  function sessionsChipLabel(ws) {
-    const more = (ws.live || 0) - (ws.topSession ? 1 : 0);
-    return more > 0 ? 'sessions +' + more + ' \u2304' : 'sessions \u2304';
+  function shortPath(p) {
+    const parts = String(p || '').split('/').filter(Boolean);
+    return parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
   }
 
-  function topSessionRow(ws) {
-    const top = ws.topSession;
-    if (!top) return null;
-    const when = [top.where, top.startedAt ? fmtWhen(top.startedAt) : ''].filter(Boolean).join(' \u00b7 ');
+  /* ---- the bottom sheet: every secondary control, one thumb away ---- */
 
-    if (!top.url || !safeClaudeUrl(top.url)) {
-      const el = document.createElement('div');
-      el.className = 'top';
-      el.innerHTML = '<span><i class="sdot"></i>' + esc(top.name) + '</span>' +
-        '<span class="when">' + esc(when) + ' \u00b7 local only</span>';
-      return el;
+  let sheetWs = null;
+
+  function initSheet() {
+    const sheet = document.getElementById('sheet');
+    const close = (e) => { e.stopPropagation(); closeSheet(); };
+    document.getElementById('scrim').onclick = close;
+    document.getElementById('grab').onclick = close;
+    addEventListener('keydown', (e) => { if (e.key === 'Escape') closeSheet(); });
+    sheet.addEventListener('click', (e) => { if (e.target === sheet) closeSheet(); });
+  }
+
+  function closeSheet() {
+    const sheet = document.getElementById('sheet');
+    if (sheet.hidden) return;
+    sheet.classList.remove('on');
+    sheetWs = null;
+    document.body.classList.remove('locked');
+    setTimeout(() => { sheet.hidden = true; }, 240);
+  }
+
+  function openSheet(ws) {
+    sheetWs = ws.id;
+    const sheet = document.getElementById('sheet');
+    document.getElementById('sheettitle').textContent = ws.id;
+    document.getElementById('sheetsub').textContent = ws.path || '';
+    const body = document.getElementById('sheetbody');
+    body.innerHTML = '';
+
+    // What you came for first: start it, or open what is already running.
+    if (ws.sessionUrl && safeClaudeUrl(ws.sessionUrl)) {
+      const open = primaryAction(ws);
+      open.classList.add('block');
+      open.textContent = 'Open the running session ↗';
+      body.appendChild(open);
+    } else if (!ws.running) {
+      const box = startOptions(ws);
+      if (box) body.appendChild(box);
+      const b = document.createElement('button');
+      b.className = 'btn primary block';
+      b.textContent = ws.note ? 'Try starting again' : 'Start a session';
+      b.onclick = (e) => { e.stopPropagation(); startSession(ws.id, b, box); };
+      body.appendChild(b);
     }
-    const el = document.createElement('a');
-    el.className = 'top';
-    el.href = top.url; el.target = '_blank'; el.rel = 'noopener noreferrer';
-    const mode = openMode(ws.id);
-    if (mode === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(top.url, '_blank', 'noopener'); };
-    if (mode === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(top.url); };
-    el.innerHTML = '<span><i class="sdot"></i>' + esc(top.name) + '</span>' +
-      '<span class="when">' + esc(when) + ' \u00b7 open \u2197</span>';
-    return el;
-  }
 
-  function metaLine(ws) {
-    const bits = [];
-    if (ws.live > 0) bits.push('<span class="live">' + ws.live + ' live</span>');
-    const e = ws.lastEvent;
-    if (e && !(ws.running && e.kind === 'started')) {
-      const what = e.kind === 'exited' ? 'exited' + (e.cause ? ' ' + esc(e.cause) : '')
-        : e.kind === 'attention' ? 'needs you'
-        : esc(e.kind);
-      bits.push('<span class="why">' + what + ' ' + esc(fmtWhen(e.at)) + '</span>');
+    body.appendChild(sheetRow('Open links in', openMode(ws.id), () => {
+      const order = ['app', 'browser', 'chrome'];
+      setOpenMode(ws.id, order[(order.indexOf(openMode(ws.id)) + 1) % order.length]);
+      render(lastWorkspaces);
+      openSheet(lastWorkspaces.find(w => w.id === ws.id) || ws);
+    }, 'app deep-links into the Claude app, browser stays here, chrome forces Chrome'));
+
+    const isHidden = hidden().has(ws.id);
+    body.appendChild(sheetRow(isHidden ? 'Unhide this repo' : 'Hide from this browser', '', () => {
+      toggleHidden(ws.id);
+      closeSheet();
+    }, 'Nothing on the machine changes — this browser only'));
+
+    if (ws.running) {
+      const stop = sheetRow('Stop the session', '', (row) => stopSession(ws.id, row), '');
+      stop.classList.add('bad');
+      body.appendChild(stop);
     }
-    if (!bits.length) return null;
-    const el = document.createElement('div');
-    el.className = 'meta';
-    el.innerHTML = bits.join('');
-    return el;
+
+    const sessions = document.createElement('div');
+    body.appendChild(sessions);
+    loadSessions(ws, sessions);
+
+    sheet.hidden = false;
+    document.body.classList.add('locked');
+    requestAnimationFrame(() => {
+      sheet.classList.add('on');
+      const panel = sheet.querySelector('.panel');
+      panel.scrollTop = 0;
+      panel.focus({ preventScroll: true });
+    });
   }
 
-    function usageLine(ws) {
-    if (!ws.usage || !ws.usage.week) return null;
-    const sum = u => (u.input || 0) + (u.output || 0) + (u.cacheRead || 0) + (u.cacheWrite || 0);
-    const week = sum(ws.usage.week);
-    if (!week) return null;
-    const el = document.createElement('div');
-    el.className = 'usage';
-    el.title = 'tokens today / this week';
-    el.textContent = fmtTokens(sum(ws.usage.today)) + ' today \u00b7 ' + fmtTokens(week) + ' this week';
-    return el;
+  function sheetRow(label, value, onTap, desc) {
+    const b = document.createElement('button');
+    b.className = 'srow';
+    const main = document.createElement('span');
+    main.innerHTML = esc(label) + (desc ? '<span class="desc">' + esc(desc) + '</span>' : '');
+    b.appendChild(main);
+    if (value) {
+      const v = document.createElement('span');
+      v.className = 'sval'; v.textContent = value;
+      b.appendChild(v);
+    }
+    const go = document.createElement('span');
+    go.className = 'go'; go.textContent = '›';
+    if (!value) go.style.marginLeft = 'auto';
+    b.appendChild(go);
+    b.onclick = (e) => { e.stopPropagation(); onTap(b); };
+    return b;
   }
 
-  // The start options are built even when collapsed: Start reads them, so a
-  // profile chosen before opening the panel still applies.
+  // The start options are built even when the sheet is closed again: Start
+  // reads them, so a profile chosen before tapping still applies.
   function startOptions(ws) {
     if (ws.running) return null;
     const box = document.createElement('div');
     box.className = 'startbox';
     if ((ws.profiles || []).length) {
+      const field = document.createElement('div');
+      field.className = 'field';
+      field.innerHTML = '<label for="prof-' + esc(ws.id) + '">Claude account</label>';
       const sel = document.createElement('select');
+      sel.id = 'prof-' + ws.id;
       sel.dataset.role = 'profile';
       const none = document.createElement('option');
       none.value = ''; none.textContent = 'default account';
@@ -1292,24 +1591,25 @@ const launcherPageHTML = `<!doctype html>
         o.value = p; o.textContent = p;
         sel.appendChild(o);
       }
-      box.appendChild(sel);
+      field.appendChild(sel);
+      box.appendChild(field);
     }
+    const field = document.createElement('div');
+    field.className = 'field';
+    field.innerHTML = '<label for="name-' + esc(ws.id) + '">Session name</label>';
     const name = document.createElement('input');
-    name.type = 'text'; name.placeholder = 'session name (optional)'; name.dataset.role = 'name';
+    name.id = 'name-' + ws.id;
+    name.type = 'text';
+    name.placeholder = 'what is it for? (optional)';
+    name.dataset.role = 'name';
     name.maxLength = 60;
-    box.appendChild(name);
+    field.appendChild(name);
+    box.appendChild(field);
     return box;
   }
 
-  function shortPath(p) {
-    const parts = String(p || '').split('/').filter(Boolean);
-    return parts.length > 2 ? '…/' + parts.slice(-2).join('/') : p;
-  }
-
-  async function toggleSessions(ws, btn, box) {
-    if (box.style.display !== 'none') { box.style.display = 'none'; btn.textContent = 'sessions \u2304'; return; }
-    box.style.display = ''; btn.textContent = 'sessions \u2303';
-    box.innerHTML = '';
+  async function loadSessions(ws, box) {
+    box.innerHTML = '<div class="grp"><span>sessions</span><i></i></div><div class="none">Loading…</div>';
     const group = (label) => {
       const el = document.createElement('div');
       el.className = 'grp';
@@ -1323,17 +1623,19 @@ const launcherPageHTML = `<!doctype html>
       const m = openMode(ws.id);
       if (m === 'browser') el.onclick = (e) => { e.preventDefault(); window.open(url, '_blank', 'noopener'); };
       if (m === 'chrome') el.onclick = (e) => { e.preventDefault(); location.href = chromeUrl(url); };
-      const tag = o.bridge ? '<span class="tag" title="Hand-started on the laptop \u2014 its web page may look empty">bridge</span>' : '';
-      const text = o.label ? esc(o.label) : esc(url.split('/').pop().slice(0, 14)) + '\u2026';
+      const tag = o.bridge ? '<span class="tag">bridge</span>' : '';
+      const text = o.label ? esc(o.label) : esc(url.split('/').pop().slice(0, 14)) + '…';
       const dot = o.past ? '' : '<i class="sdot"></i>';
-      el.innerHTML = '<span>' + dot + text + tag + '</span><span class="when">' + esc(o.when || '') +
-        (o.past ? 'reopen' : 'open \u2197') + '</span>';
+      el.innerHTML = dot + '<span class="smain"><span class="sname">' + text + tag + '</span>' +
+        '<span class="when">' + esc(o.when || '') + '</span></span>' +
+        '<span class="go">' + (o.past ? '↻' : '↗') + '</span>';
       box.appendChild(el);
     };
     const renderLocal = (label, when) => {
       const el = document.createElement('div');
       el.className = 's';
-      el.innerHTML = '<span><i class="sdot"></i>' + esc(label) + '</span><span class="when">' + esc(when) + ' \u00b7 local only</span>';
+      el.innerHTML = '<i class="sdot"></i><span class="smain"><span class="sname">' + esc(label) + '</span>' +
+        '<span class="when">' + esc(when) + ' · local only</span></span>';
       box.appendChild(el);
     };
     const note = (text) => {
@@ -1341,14 +1643,12 @@ const launcherPageHTML = `<!doctype html>
       el.className = 'hint'; el.textContent = text;
       box.appendChild(el);
     };
-    const info = document.createElement('div');
-    info.className = 'none'; info.textContent = 'Loading\u2026';
-    box.appendChild(info);
     try {
       const r = await fetch('/launch/sessions?workspace=' + encodeURIComponent(ws.id), { headers: auth });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
-      info.remove();
+      if (sheetWs !== ws.id) return; // the sheet moved on while this was in flight
+      box.innerHTML = '';
 
       const running = j.sessions || [];
       const bridges = (j.links || []).filter(safeClaudeUrl);
@@ -1362,7 +1662,7 @@ const launcherPageHTML = `<!doctype html>
         if (!safeClaudeUrl(url) || alive.has(url) || seen.has(url)) return;
         seen.add(url); older.push({ url: url, when: when });
       };
-      for (const h of (j.history || [])) if (h) addOlder(h.url, fmtWhen(h.at) + ' \u00b7 ');
+      for (const h of (j.history || [])) if (h) addOlder(h.url, fmtWhen(h.at));
       for (const url of (ws.sessionLinks || []).slice().reverse()) addOlder(url, '');
 
       let localOnly = 0;
@@ -1371,14 +1671,14 @@ const launcherPageHTML = `<!doctype html>
       if (liveCount) group('live now');
       for (const sess of running) {
         const where = whereLabel(sess);
-        const when = where + ' \u00b7 ' + fmtWhen(sess.startedAt);
+        const when = where + ' · ' + fmtWhen(sess.startedAt);
         if (sess.url && safeClaudeUrl(sess.url) && !seen.has(sess.url)) {
           seen.add(sess.url);
-          renderLink(sess.url, { label: sess.name, when: when + ' \u00b7 ' });
+          renderLink(sess.url, { label: shortSessionName(sess.name, ws.id), when: when });
           continue;
         }
         localOnly++;
-        renderLocal(sess.name || 'session', when);
+        renderLocal(shortSessionName(sess.name, ws.id) || 'session', when);
       }
       let bridgeRows = 0;
       let bridgeHidden = 0;
@@ -1391,13 +1691,14 @@ const launcherPageHTML = `<!doctype html>
       }
       if (localOnly) note('local only = running on the laptop with no web link yet; type /remote-control in that session to reach it from here.');
       if (bridgeRows) note('bridge = started by hand on the laptop; its page shows only what you send from it.');
-      if (bridgeHidden) note(bridgeHidden + ' bridge session' + (bridgeHidden > 1 ? 's' : '') + ' hidden \u2014 enable in Settings.');
+      if (bridgeHidden) note(bridgeHidden + ' bridge session' + (bridgeHidden > 1 ? 's' : '') + ' hidden — enable in Settings.');
 
       if (older.length) {
-        group('earlier \u00b7 not running');
+        group('earlier · not running');
         for (const row of older) renderLink(row.url, { past: true, when: row.when });
       }
       if (!liveCount && !older.length && !evs.length) {
+        group('sessions');
         const none = document.createElement('div');
         none.className = 'none'; none.textContent = 'No sessions yet for this workspace.';
         box.appendChild(none);
@@ -1407,11 +1708,16 @@ const launcherPageHTML = `<!doctype html>
       for (const ev of evs) {
         const el = document.createElement('div');
         el.className = 'evrow';
-        const what = ev.kind + (ev.cause ? ' \u00b7 ' + ev.cause : '') + (ev.reason ? ' \u2014 ' + ev.reason : '');
+        const what = ev.kind + (ev.cause ? ' · ' + ev.cause : '') + (ev.reason ? ' — ' + ev.reason : '');
         el.innerHTML = '<b>' + esc(what.slice(0, 90)) + '</b><span>' + esc(fmtWhen(ev.at)) + '</span>';
         box.appendChild(el);
       }
-    } catch (e) { info.textContent = '\u2717 ' + e.message; }
+    } catch (e) {
+      if (sheetWs !== ws.id) return;
+      box.innerHTML = '';
+      group('sessions');
+      note('✗ ' + e.message);
+    }
   }
 
   function whereLabel(sess) {
@@ -1443,62 +1749,27 @@ const launcherPageHTML = `<!doctype html>
   // Safari or the Claude app's webview.
   const chromeUrl = u => u.replace(/^https:\/\//, 'googlechromes://');
 
-  // app mode uses a real anchor tap so iOS deep-links into the Claude app;
-  // browser mode opens via JS, which keeps the session in this browser; chrome
-  // mode forces Chrome via its URL scheme (right for a workspace signed into a
-  // different Claude account than the app — e.g. work vs personal).
-  function openControl(ws) {
-    const mode = openMode(ws.id);
-    if (mode === 'browser' || mode === 'chrome') {
-      const b = document.createElement('button');
-      b.className = 'open'; b.textContent = 'Open';
-      b.onclick = () => {
-        if (mode === 'chrome') { location.href = chromeUrl(ws.sessionUrl); }
-        else { window.open(ws.sessionUrl, '_blank', 'noopener'); }
-      };
-      return b;
+  async function stopSession(id, btn) {
+    btn.disabled = true;
+    btn.querySelector('span').textContent = 'Stopping…';
+    try {
+      const r = await fetch('/launch/stop', { method: 'POST', headers: auth,
+        body: JSON.stringify({ workspace: id }) });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || r.status);
+      closeSheet();
+      toast('Stopping ' + id + '…');
+      setTimeout(load, 1200);
+    } catch (e) {
+      btn.disabled = false;
+      btn.querySelector('span').textContent = 'Stop the session';
+      toast(e.message, true);
     }
-    const a = document.createElement('a');
-    a.className = 'open'; a.href = ws.sessionUrl; a.textContent = 'Open';
-    a.target = '_blank'; a.rel = 'noopener noreferrer';
-    return a;
   }
 
-  function modeSwitch(id) {
-    const order = ['app', 'browser', 'chrome'];
-    const cur = openMode(id);
-    const b = document.createElement('button');
-    b.className = 'chip';
-    b.title = 'Where session links open — tap to change';
-    b.innerHTML = 'open in <b>' + esc(cur) + '</b> ▾';
-    b.onclick = () => { setOpenMode(id, order[(order.indexOf(cur) + 1) % order.length]); render(lastWorkspaces); };
-    return b;
-  }
-
-  function stopControl(id) {
-    const b = document.createElement('button');
-    b.className = 'chip danger'; b.textContent = 'Stop';
-    b.onclick = async () => {
-      b.disabled = true; b.textContent = 'Stopping…';
-      try {
-        const r = await fetch('/launch/stop', { method: 'POST', headers: auth,
-          body: JSON.stringify({ workspace: id }) });
-        const j = await r.json();
-        if (!r.ok) throw new Error(j.error || r.status);
-        setTimeout(load, 1200);
-      } catch (e) {
-        b.disabled = false; b.textContent = 'Stop';
-        const err = document.createElement('div');
-        err.className = 'msg err'; err.textContent = '✗ ' + e.message;
-        b.parentElement.appendChild(err);
-      }
-    };
-    return b;
-  }
-
-  async function startSession(id, btn) {
+  async function startSession(id, btn, box) {
+    const label = btn.textContent;
     btn.disabled = true; btn.textContent = 'Starting…';
-    const box = btn.closest('.ws').querySelector('.startbox');
     const pick = (role) => {
       const el = box && box.querySelector('[data-role="' + role + '"]');
       return el ? el.value.trim() : '';
@@ -1508,12 +1779,17 @@ const launcherPageHTML = `<!doctype html>
         body: JSON.stringify({ workspace: id, profile: pick('profile'), name: pick('name') }) });
       const j = await r.json();
       if (!r.ok) throw new Error(j.error || r.status);
+      closeSheet();
+      toast('Starting ' + id + '…');
+      // Show it as starting straight away: the list is the same surface the
+      // Start button lives on, and a card still offering Start invites a
+      // second one before the daemon has answered the first.
+      const w = lastWorkspaces.find(x => x.id === id);
+      if (w) { w.running = true; w.note = ''; render(lastWorkspaces); }
       poll(id, 0);
     } catch (e) {
-      btn.disabled = false; btn.textContent = 'Retry';
-      const err = document.createElement('div');
-      err.className = 'msg err'; err.textContent = '✗ ' + e.message;
-      btn.parentElement.appendChild(err);
+      btn.disabled = false; btn.textContent = label;
+      toast(e.message, true);
     }
   }
 
@@ -1525,7 +1801,11 @@ const launcherPageHTML = `<!doctype html>
       const ws = (j.workspaces || []).find(w => w.id === id);
       // Got the link, or the daemon reported why it won't start — either way, stop
       // polling and re-render so the reason (or the Open button) shows.
-      if (ws && (ws.sessionUrl || (!ws.running && ws.note))) { render(j.workspaces); return; }
+      if (ws && (ws.sessionUrl || (!ws.running && ws.note))) {
+        render(j.workspaces);
+        if (ws.note && !ws.running) toast(ws.note, true);
+        return;
+      }
     } catch {}
     setTimeout(() => poll(id, n + 1), 1000);
   }

--- a/cmd/mcp_launcher_test.go
+++ b/cmd/mcp_launcher_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -176,6 +177,60 @@ func TestTopSessionCarriesTheLiveName(t *testing.T) {
 	if top.NameSource != "auto" || top.NameSince != 1700000001000 {
 		t.Errorf("nameSource/nameSince = %q/%d, want them passed through so the page can say it was renamed",
 			top.NameSource, top.NameSince)
+	}
+}
+
+func TestLaunchStateReportsADisabledWorkspace(t *testing.T) {
+	// A workspace the daemon gave up on looked exactly like a stopped one, so
+	// Start was the tap that appeared to do nothing.
+	if got := launchState(launchWorkspace{Disabled: true}); got != "disabled" {
+		t.Errorf("state = %q, want disabled", got)
+	}
+	if got := launchState(launchWorkspace{Disabled: true, Running: true, Live: 2}); got != "disabled" {
+		t.Errorf("state = %q; disabled outranks a live session — it is the thing to explain", got)
+	}
+}
+
+func TestSessionProcessIsLiveRejectsARecycledPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("start times are only read from /proc")
+	}
+	mine := os.Getpid()
+	started, ok := processStartTicks(mine)
+	if !ok || started == "" {
+		t.Fatalf("this process's start time must be readable, got %q ok=%v", started, ok)
+	}
+	if !sessionProcessIsLive(claudeSession{PID: mine, ProcStart: started}) {
+		t.Error("a record whose start time matches the live process is live")
+	}
+	// The record outlived the machine and something else now holds its pid:
+	// a live pid alone made a finished session show as live.
+	if sessionProcessIsLive(claudeSession{PID: mine, ProcStart: "1"}) {
+		t.Error("a start time that does not match must not pass for the same process")
+	}
+	// No recorded start time (an older CLI) keeps the old behaviour.
+	if !sessionProcessIsLive(claudeSession{PID: mine}) {
+		t.Error("without a recorded start time a live pid is still the best answer")
+	}
+	if sessionProcessIsLive(claudeSession{PID: 0}) {
+		t.Error("pid 0 is not a session")
+	}
+}
+
+func TestSessionWaitingForOnlyAnswersWhenClaudeSaid(t *testing.T) {
+	for name, tc := range map[string]struct {
+		sess claudeSession
+		want string
+	}{
+		"nothing recorded":      {claudeSession{}, ""},
+		"a named block":         {claudeSession{WaitingFor: "input needed"}, "input needed"},
+		"waiting without a why": {claudeSession{Status: "waiting"}, "your answer"},
+		"a blocked tempo":       {claudeSession{Tempo: "blocked"}, "your answer"},
+		"busy is not waiting":   {claudeSession{Status: "busy"}, ""},
+	} {
+		if got := sessionWaitingFor(tc.sess); got != tc.want {
+			t.Errorf("%s: waitingFor = %q, want %q", name, got, tc.want)
+		}
 	}
 }
 

--- a/cmd/mcp_launcher_test.go
+++ b/cmd/mcp_launcher_test.go
@@ -111,23 +111,28 @@ func TestLauncherPageKeepsThePhoneControlsItNeeds(t *testing.T) {
 	rec := httptest.NewRecorder()
 	launcherPageHandler(rec, httptest.NewRequest(http.MethodGet, "/app", nil))
 	body := rec.Body.String()
-	// The redesign moved these into the details sheet; losing any of them
-	// silently would take a control off the phone altogether.
 	for what, want := range map[string]string{
-		"the details sheet":            "function openSheet(",
-		"start options in the sheet":   "data-role=\"' + role + '\"",
-		"the where-links-open control": "Open links in",
-		"hiding a card":                "Hide from this browser",
+		"the sessions panel":           "toggleSessions(",
+		"start options":                "data-role=\"' + role + '\"",
+		"the where-links-open control": "modeSwitch(",
+		"hiding a card":                "corgi_hidden",
 		"stopping a session":           "/launch/stop",
+		"the state on the dot":         "dotState(",
+		"the live session name":        "nameNote(",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("the launcher must keep %s (%q)", what, want)
 		}
 	}
 	// A control toggled with the hidden attribute must actually disappear:
-	// every flex rule on this page outranks the attribute without it.
+	// a flex display rule outranks the attribute without this.
 	if !strings.Contains(body, "[hidden]{display:none!important}") {
-		t.Error("the launcher must force [hidden] over its flex display rules")
+		t.Error("the launcher must force [hidden] over its display rules")
+	}
+	// The refresh tick reads the session records again, which is how a session
+	// Claude renamed shows its new name here without a reload.
+	if !strings.Contains(body, "REFRESH_MS") {
+		t.Error("the launcher must refresh itself while it is on screen")
 	}
 }
 

--- a/cmd/mcp_launcher_test.go
+++ b/cmd/mcp_launcher_test.go
@@ -107,6 +107,30 @@ func TestLauncherPageIsSelfContainedAndUsesTheStoredToken(t *testing.T) {
 	}
 }
 
+func TestLauncherPageKeepsThePhoneControlsItNeeds(t *testing.T) {
+	rec := httptest.NewRecorder()
+	launcherPageHandler(rec, httptest.NewRequest(http.MethodGet, "/app", nil))
+	body := rec.Body.String()
+	// The redesign moved these into the details sheet; losing any of them
+	// silently would take a control off the phone altogether.
+	for what, want := range map[string]string{
+		"the details sheet":            "function openSheet(",
+		"start options in the sheet":   "data-role=\"' + role + '\"",
+		"the where-links-open control": "Open links in",
+		"hiding a card":                "Hide from this browser",
+		"stopping a session":           "/launch/stop",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the launcher must keep %s (%q)", what, want)
+		}
+	}
+	// A control toggled with the hidden attribute must actually disappear:
+	// every flex rule on this page outranks the attribute without it.
+	if !strings.Contains(body, "[hidden]{display:none!important}") {
+		t.Error("the launcher must force [hidden] over its flex display rules")
+	}
+}
+
 func TestBuildLaunchWorkspacesSurfacesADiagnostic(t *testing.T) {
 	reg := &workspace.Registry{}
 	reg.Upsert(workspace.Workspace{ID: "acme", AbsPath: "/dev/acme", Status: workspace.StatusOK})

--- a/cmd/mcp_launcher_test.go
+++ b/cmd/mcp_launcher_test.go
@@ -131,6 +131,49 @@ func TestLauncherPageKeepsThePhoneControlsItNeeds(t *testing.T) {
 	}
 }
 
+func TestLaunchStateNamesWhatTheCardLeadsWith(t *testing.T) {
+	attention := &launchLastEvent{Kind: "attention"}
+	exited := &launchLastEvent{Kind: "exited", Cause: "network timeout"}
+	for name, tc := range map[string]struct {
+		row  launchWorkspace
+		want string
+	}{
+		"a refused start is blocked":      {launchWorkspace{Note: "not logged in"}, "blocked"},
+		"a blocking prompt outranks live": {launchWorkspace{Running: true, Live: 1, LastEvent: attention}, "attention"},
+		"a live session is live":          {launchWorkspace{Running: true, Live: 2, LastEvent: exited}, "live"},
+		"supervised with no session yet":  {launchWorkspace{Running: true}, "starting"},
+		"nothing running is stopped":      {launchWorkspace{LastEvent: exited}, "stopped"},
+		// A session someone started on the laptop is live even though the
+		// daemon is not supervising the workspace.
+		"an unsupervised session is live": {launchWorkspace{Live: 1}, "live"},
+	} {
+		if got := launchState(tc.row); got != tc.want {
+			t.Errorf("%s: state = %q, want %q", name, got, tc.want)
+		}
+	}
+}
+
+func TestTopSessionCarriesTheLiveName(t *testing.T) {
+	// Claude Code rewrites name/nameSource/nameSince in its own session record
+	// when the session is renamed; the launcher must pass that through rather
+	// than the name corgi started it with.
+	top := newestLiveSession([]claudeSession{{
+		Name: "Trim the launcher type scale", NameSource: "auto", NameSince: 1700000001000,
+		StartedAt: 1700000000000, Kind: "interactive", Entrypoint: "sdk-cli",
+		URL: "https://claude.ai/code/session_abc",
+	}})
+	if top == nil {
+		t.Fatal("a session with a URL must become the top session")
+	}
+	if top.Name != "Trim the launcher type scale" {
+		t.Errorf("name = %q, want the session's current name", top.Name)
+	}
+	if top.NameSource != "auto" || top.NameSince != 1700000001000 {
+		t.Errorf("nameSource/nameSince = %q/%d, want them passed through so the page can say it was renamed",
+			top.NameSource, top.NameSince)
+	}
+}
+
 func TestBuildLaunchWorkspacesSurfacesADiagnostic(t *testing.T) {
 	reg := &workspace.Registry{}
 	reg.Upsert(workspace.Workspace{ID: "acme", AbsPath: "/dev/acme", Status: workspace.StatusOK})

--- a/cmd/mcp_pairing.go
+++ b/cmd/mcp_pairing.go
@@ -121,18 +121,27 @@ const pairClosedHTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>corgi pairing</title>
+<meta name="color-scheme" content="dark">
+<meta name="theme-color" content="#000000">
 <style>
-  body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e8e8e8;
-       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}
-  main{max-width:22rem;width:100%;padding:2rem}
-  h1{font-size:1.3rem;margin:0 0 .3rem}
-  p{color:#9aa0a6;font-size:.9rem;margin:.2rem 0 1.2rem;line-height:1.5}
-  code{background:#1a1d23;padding:.15rem .35rem;border-radius:.3rem}
-  a.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;
-      padding:.7rem 1.1rem;border-radius:.6rem;font-weight:600}
+  /* Same ladder as the launcher: black ground, one white action, thumb-sized. */
+  *{box-sizing:border-box}
+  body{font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;background:#000;color:#fff;
+       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;
+       -webkit-font-smoothing:antialiased;padding:calc(1.5rem + env(safe-area-inset-top)) 1.25rem
+       calc(1.5rem + env(safe-area-inset-bottom))}
+  main{max-width:24rem;width:100%}
+  .logo{width:3rem;height:3rem;border-radius:1rem;background:#191a1e;display:flex;align-items:center;
+      justify-content:center;font-size:1.6rem;margin-bottom:1.1rem}
+  h1{font-size:1.5rem;font-weight:800;letter-spacing:-.02em;margin:0 0 .5rem;line-height:1.2}
+  p{color:#a3a6ad;font-size:.95rem;margin:.4rem 0 1.2rem;line-height:1.55}
+  code{background:#191a1e;padding:.15rem .4rem;border-radius:.4rem;font-size:.9em}
+  a.open{display:flex;align-items:center;justify-content:center;background:#fff;color:#000;
+      text-decoration:none;height:3.4rem;border-radius:.75rem;font-weight:700;font-size:1.02rem}
 </style>
 <main>
-  <h1>🐕 This pairing link is closed</h1>
+  <div class="logo">🐕</div>
+  <h1>This pairing link is closed</h1>
   <p id="msg">Pairing links work once and expire after ten minutes.</p>
   <p id="paired" hidden>This phone is already paired with this machine.</p>
   <a id="app" class="open" href="/app" hidden>Open the launcher</a>
@@ -154,30 +163,41 @@ const pairPageHTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Pair with corgi</title>
+<meta name="color-scheme" content="dark">
+<meta name="theme-color" content="#000000">
 <style>
-  body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e8e8e8;
-       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}
-  main{max-width:22rem;width:100%;padding:2rem}
-  h1{font-size:1.3rem;margin:0 0 .3rem}
-  p{color:#9aa0a6;font-size:.9rem;margin:.2rem 0 1.2rem}
-  input,button{width:100%;box-sizing:border-box;font-size:1rem;padding:.7rem .8rem;border-radius:.6rem}
-  input{border:1px solid #333;background:#1a1d23;color:#e8e8e8;margin-bottom:.8rem}
-  button{border:0;background:#e8e8e8;color:#0f1115;font-weight:600;cursor:pointer}
-  button:disabled{opacity:.5}
-  #out{margin-top:1rem;font-size:.85rem}
-  .ok{color:#7ee787}.err{color:#ff7b72;word-break:break-word}
-  code{background:#1a1d23;padding:.15rem .35rem;border-radius:.3rem}
-  pre{background:#1a1d23;border:1px solid #333;border-radius:.5rem;padding:.8rem;
-      overflow-x:auto;font-size:.78rem;line-height:1.4;white-space:pre;margin:.6rem 0}
-  #copy{margin-bottom:.4rem}
-  a.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;
-      padding:.7rem 1.1rem;border-radius:.6rem;font-weight:600}
+  /* Same ladder as the launcher: black ground, one white action, thumb-sized. */
+  *{box-sizing:border-box}
+  body{font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;background:#000;color:#fff;
+       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;
+       -webkit-font-smoothing:antialiased;padding:calc(1.5rem + env(safe-area-inset-top)) 1.25rem
+       calc(1.5rem + env(safe-area-inset-bottom))}
+  main{max-width:24rem;width:100%}
+  .logo{width:3rem;height:3rem;border-radius:1rem;background:#191a1e;display:flex;align-items:center;
+      justify-content:center;font-size:1.6rem;margin-bottom:1.1rem}
+  h1{font-size:1.5rem;font-weight:800;letter-spacing:-.02em;margin:0 0 .5rem;line-height:1.2}
+  p{color:#a3a6ad;font-size:.95rem;margin:.4rem 0 1.4rem;line-height:1.55}
+  label{display:block;font-size:.75rem;font-weight:700;letter-spacing:.09em;text-transform:uppercase;
+      color:#74777f;margin-bottom:.4rem}
+  input,button{width:100%;font-size:1.02rem;border-radius:.75rem;font-family:inherit}
+  input{height:3.4rem;border:1px solid #26272c;background:#191a1e;color:#fff;padding:0 .9rem;margin-bottom:1rem}
+  input::placeholder{color:#74777f}
+  button{height:3.4rem;border:0;background:#fff;color:#000;font-weight:700;cursor:pointer}
+  button:active{transform:scale(.99)}
+  button:disabled{opacity:.45}
+  #out{margin-top:1.2rem;font-size:.95rem;line-height:1.55}
+  .ok{color:#3ddc91}.err{color:#ff6f61;word-break:break-word}
+  code{background:#191a1e;padding:.15rem .4rem;border-radius:.4rem;font-size:.9em}
+  a.open{display:flex;align-items:center;justify-content:center;background:#fff;color:#000;
+      text-decoration:none;height:3.4rem;border-radius:.75rem;font-weight:700;margin-top:.8rem}
 </style>
 <main>
-  <h1>🐕 Pair with corgi</h1>
-  <p>Name this device, tap pair. The code came along in the QR you scanned.</p>
+  <div class="logo">🐕</div>
+  <h1>Pair with corgi</h1>
+  <p>Name this device and tap pair. The code came along in the QR you scanned.</p>
+  <label for="device">Device name</label>
   <input id="device" placeholder="my-phone" autocomplete="off" autocapitalize="none">
-  <button id="go">Pair</button>
+  <button id="go">Pair this device</button>
   <div id="out"></div>
 </main>
 <script>
@@ -204,7 +224,7 @@ const pairPageHTML = `<!doctype html>
       location.replace('/app');
     } catch (e) {
       out.innerHTML = '<span class="err">✗ ' + esc(e.message) + '</span>';
-      btn.disabled = false; btn.textContent = 'Pair';
+      btn.disabled = false; btn.textContent = 'Pair this device';
     }
   };
 </script>

--- a/cmd/mcp_pairing.go
+++ b/cmd/mcp_pairing.go
@@ -121,27 +121,18 @@ const pairClosedHTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>corgi pairing</title>
-<meta name="color-scheme" content="dark">
-<meta name="theme-color" content="#000000">
 <style>
-  /* Same ladder as the launcher: black ground, one white action, thumb-sized. */
-  *{box-sizing:border-box}
-  body{font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;background:#000;color:#fff;
-       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;
-       -webkit-font-smoothing:antialiased;padding:calc(1.5rem + env(safe-area-inset-top)) 1.25rem
-       calc(1.5rem + env(safe-area-inset-bottom))}
-  main{max-width:24rem;width:100%}
-  .logo{width:3rem;height:3rem;border-radius:1rem;background:#191a1e;display:flex;align-items:center;
-      justify-content:center;font-size:1.6rem;margin-bottom:1.1rem}
-  h1{font-size:1.5rem;font-weight:800;letter-spacing:-.02em;margin:0 0 .5rem;line-height:1.2}
-  p{color:#a3a6ad;font-size:.95rem;margin:.4rem 0 1.2rem;line-height:1.55}
-  code{background:#191a1e;padding:.15rem .4rem;border-radius:.4rem;font-size:.9em}
-  a.open{display:flex;align-items:center;justify-content:center;background:#fff;color:#000;
-      text-decoration:none;height:3.4rem;border-radius:.75rem;font-weight:700;font-size:1.02rem}
+  body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e8e8e8;
+       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}
+  main{max-width:22rem;width:100%;padding:2rem}
+  h1{font-size:1.3rem;margin:0 0 .3rem}
+  p{color:#9aa0a6;font-size:.9rem;margin:.2rem 0 1.2rem;line-height:1.5}
+  code{background:#1a1d23;padding:.15rem .35rem;border-radius:.3rem}
+  a.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;
+      padding:.7rem 1.1rem;border-radius:.6rem;font-weight:600}
 </style>
 <main>
-  <div class="logo">🐕</div>
-  <h1>This pairing link is closed</h1>
+  <h1>🐕 This pairing link is closed</h1>
   <p id="msg">Pairing links work once and expire after ten minutes.</p>
   <p id="paired" hidden>This phone is already paired with this machine.</p>
   <a id="app" class="open" href="/app" hidden>Open the launcher</a>
@@ -163,41 +154,30 @@ const pairPageHTML = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Pair with corgi</title>
-<meta name="color-scheme" content="dark">
-<meta name="theme-color" content="#000000">
 <style>
-  /* Same ladder as the launcher: black ground, one white action, thumb-sized. */
-  *{box-sizing:border-box}
-  body{font-family:-apple-system,system-ui,"Segoe UI",Roboto,sans-serif;background:#000;color:#fff;
-       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;
-       -webkit-font-smoothing:antialiased;padding:calc(1.5rem + env(safe-area-inset-top)) 1.25rem
-       calc(1.5rem + env(safe-area-inset-bottom))}
-  main{max-width:24rem;width:100%}
-  .logo{width:3rem;height:3rem;border-radius:1rem;background:#191a1e;display:flex;align-items:center;
-      justify-content:center;font-size:1.6rem;margin-bottom:1.1rem}
-  h1{font-size:1.5rem;font-weight:800;letter-spacing:-.02em;margin:0 0 .5rem;line-height:1.2}
-  p{color:#a3a6ad;font-size:.95rem;margin:.4rem 0 1.4rem;line-height:1.55}
-  label{display:block;font-size:.75rem;font-weight:700;letter-spacing:.09em;text-transform:uppercase;
-      color:#74777f;margin-bottom:.4rem}
-  input,button{width:100%;font-size:1.02rem;border-radius:.75rem;font-family:inherit}
-  input{height:3.4rem;border:1px solid #26272c;background:#191a1e;color:#fff;padding:0 .9rem;margin-bottom:1rem}
-  input::placeholder{color:#74777f}
-  button{height:3.4rem;border:0;background:#fff;color:#000;font-weight:700;cursor:pointer}
-  button:active{transform:scale(.99)}
-  button:disabled{opacity:.45}
-  #out{margin-top:1.2rem;font-size:.95rem;line-height:1.55}
-  .ok{color:#3ddc91}.err{color:#ff6f61;word-break:break-word}
-  code{background:#191a1e;padding:.15rem .4rem;border-radius:.4rem;font-size:.9em}
-  a.open{display:flex;align-items:center;justify-content:center;background:#fff;color:#000;
-      text-decoration:none;height:3.4rem;border-radius:.75rem;font-weight:700;margin-top:.8rem}
+  body{font-family:-apple-system,system-ui,sans-serif;background:#0f1115;color:#e8e8e8;
+       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}
+  main{max-width:22rem;width:100%;padding:2rem}
+  h1{font-size:1.3rem;margin:0 0 .3rem}
+  p{color:#9aa0a6;font-size:.9rem;margin:.2rem 0 1.2rem}
+  input,button{width:100%;box-sizing:border-box;font-size:1rem;padding:.7rem .8rem;border-radius:.6rem}
+  input{border:1px solid #333;background:#1a1d23;color:#e8e8e8;margin-bottom:.8rem}
+  button{border:0;background:#e8e8e8;color:#0f1115;font-weight:600;cursor:pointer}
+  button:disabled{opacity:.5}
+  #out{margin-top:1rem;font-size:.85rem}
+  .ok{color:#7ee787}.err{color:#ff7b72;word-break:break-word}
+  code{background:#1a1d23;padding:.15rem .35rem;border-radius:.3rem}
+  pre{background:#1a1d23;border:1px solid #333;border-radius:.5rem;padding:.8rem;
+      overflow-x:auto;font-size:.78rem;line-height:1.4;white-space:pre;margin:.6rem 0}
+  #copy{margin-bottom:.4rem}
+  a.open{display:inline-block;background:#7ee787;color:#0f1115;text-decoration:none;
+      padding:.7rem 1.1rem;border-radius:.6rem;font-weight:600}
 </style>
 <main>
-  <div class="logo">🐕</div>
-  <h1>Pair with corgi</h1>
-  <p>Name this device and tap pair. The code came along in the QR you scanned.</p>
-  <label for="device">Device name</label>
+  <h1>🐕 Pair with corgi</h1>
+  <p>Name this device, tap pair. The code came along in the QR you scanned.</p>
   <input id="device" placeholder="my-phone" autocomplete="off" autocapitalize="none">
-  <button id="go">Pair this device</button>
+  <button id="go">Pair</button>
   <div id="out"></div>
 </main>
 <script>
@@ -224,7 +204,7 @@ const pairPageHTML = `<!doctype html>
       location.replace('/app');
     } catch (e) {
       out.innerHTML = '<span class="err">✗ ' + esc(e.message) + '</span>';
-      btn.disabled = false; btn.textContent = 'Pair this device';
+      btn.disabled = false; btn.textContent = 'Pair';
     }
   };
 </script>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.23"
+var APP_VERSION = "1.21.24"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.24"
+var APP_VERSION = "1.21.25"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.26"
+var APP_VERSION = "1.21.27"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.27"
+var APP_VERSION = "1.21.28"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.25"
+var APP_VERSION = "1.21.26"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -111,27 +111,28 @@ the phone paired across restarts; the quick tunnel does not.
 
 ### What the launcher looks like
 
-One card per repo, one button on each: **Open** when a session is already up,
-**Start** when it is not — never both. Next to the repo name is the one word
-that matters, with a dot in front of it:
+One card per repo: a dot, the repo, its path, what it is doing, what it has
+cost, and the running session on its own row — tap that row and the
+conversation opens. The green button on the right is **Open** when a session
+is up and **Start** when it is not. Under it sit the controls that change
+something: `sessions` (the full list and timeline for that workspace),
+`open in` (app / browser / chrome), `options` (account and starting name),
+`Stop`, `hide`.
 
-| state | what it means |
+The dot is the state, and the line under the path spells it out:
+
+| dot | state |
 |---|---|
-| `live` | a session is running (`N sessions` when there is more than one) |
-| `needs you` | a permission prompt or a question is blocking it |
-| `starting` | supervised, no session has registered yet |
-| `will not start` | the daemon refused, and the reason is on the card |
-| `stopped` | nothing running here |
-
-Below it, the running session's own row opens the conversation in one tap.
-Everything else is behind **Details**: tap the card and a sheet comes up from
-the bottom with the session name and account to start under, where links
-should open, hide, stop, and the full session list and timeline for that
-workspace.
+| green | a session is running (`N live`) |
+| green, pulsing | `starting` — supervised, nothing registered yet |
+| amber | `needs you` — a permission prompt or a question is blocking it |
+| red | `will not start` — the daemon refused, and the reason is on the card |
+| grey | nothing running here |
 
 The list refreshes itself every 15 seconds while the page is on screen, so a
 name, a state or a session that changed on the machine shows up without a
-reload — and it holds still while a sheet is open.
+reload. It holds still while a `sessions` or `options` panel is open, so a
+refresh never collapses the panel under your thumb.
 
 ### A launcher URL that never changes
 
@@ -315,9 +316,8 @@ which no local probe can know:
 corgi agent session start acme --name "fix login redirect"
 ```
 
-The launcher asks for it too — tap a card to open its details sheet, where
-**Session name** sits above **Start a session** — and `corgi_session_start`
-takes a `name`.
+The launcher asks for it too — the `options` chip on a stopped card — and
+`corgi_session_start` takes a `name`.
 
 ### The timeline
 
@@ -356,8 +356,8 @@ which is why the totals are large — that is the real traffic against the windo
 
 ### Hiding a workspace on the phone
 
-Open a card's details sheet and tap **Hide from this browser**. Hidden cards
-collapse into one `N hidden — show` button. It is stored in that browser only and changes nothing on the machine —
+Each card has a **hide** chip. Hidden cards collapse into one `N hidden — show`
+button. It is stored in that browser only and changes nothing on the machine —
 it exists for the moment someone else is looking at your screen. To actually
 stop supervising a workspace, set `autostart: false` for it instead.
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -109,6 +109,19 @@ token-protected either way, so serving it on the local network is not serving it
 to the internet. The middle two rows keep a fixed origin, which is what keeps
 the phone paired across restarts; the quick tunnel does not.
 
+### What the launcher looks like
+
+One card per repo, and one white button on each: **Open** when a session is
+already up, **Start** when it is not — never both. The card carries the repo,
+its path, a green *N live* pill, the last thing that happened, and a row for
+the running session that opens the conversation in one tap.
+
+Everything else is behind **Details**: tap the card and a sheet comes up from
+the bottom with the session name and account to start under, where links
+should open, hide, stop, and the full session list and timeline for that
+workspace. Nothing that changes the machine is more than two taps away, and
+nothing that does not is competing for the first one.
+
 ### A launcher URL that never changes
 
 The default is a Cloudflare **quick tunnel**: free, no signup — and a **new random
@@ -279,8 +292,9 @@ which no local probe can know:
 corgi agent session start acme --name "fix login redirect"
 ```
 
-The launcher's start form has the same optional field, and
-`corgi_session_start` takes a `name`.
+The launcher asks for it too — tap a card to open its details sheet, where
+**Session name** sits above **Start a session** — and `corgi_session_start`
+takes a `name`.
 
 ### The timeline
 
@@ -319,8 +333,8 @@ which is why the totals are large — that is the real traffic against the windo
 
 ### Hiding a workspace on the phone
 
-Each card has a **hide** chip. Hidden cards collapse into one `N hidden — show`
-button. It is stored in that browser only and changes nothing on the machine —
+Open a card's details sheet and tap **Hide from this browser**. Hidden cards
+collapse into one `N hidden — show` button. It is stored in that browser only and changes nothing on the machine —
 it exists for the moment someone else is looking at your screen. To actually
 stop supervising a workspace, set `autostart: false` for it instead.
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -111,13 +111,13 @@ the phone paired across restarts; the quick tunnel does not.
 
 ### What the launcher looks like
 
-One card per repo: a dot, the repo, its path, what it is doing, what it has
-cost, and the running session on its own row — tap that row and the
-conversation opens. The green button on the right is **Open** when a session
-is up and **Start** when it is not. Under it sit the controls that change
-something: `sessions` (the full list and timeline for that workspace),
-`open in` (app / browser / chrome), `options` (account and starting name),
-`Stop`, `hide`.
+One card per repo: a dot, the repo, the checkout under it, what it is doing,
+what it has cost, and the running session on its own row — tap that row and
+the conversation opens. The green button on the right is **Open** when a
+session is up and **Start** when it is not. Under it sit the controls that
+change something: `sessions` (the full list, the timeline, and everything the
+daemon knows about that workspace), `open in` (app / browser / chrome),
+`options` (account and starting name), `Stop`, `hide`.
 
 The dot is the state, and the line under the path spells it out:
 
@@ -127,7 +127,20 @@ The dot is the state, and the line under the path spells it out:
 | green, pulsing | `starting` — supervised, nothing registered yet |
 | amber | `needs you` — a permission prompt or a question is blocking it |
 | red | `will not start` — the daemon refused, and the reason is on the card |
+| red | `disabled after repeated failures` — the daemon stopped retrying |
 | grey | nothing running here |
+
+That line also carries what the laptop always knew and the phone did not: how
+long the session has been up, how many restarts it took, which account it runs
+under, and — when Claude Code says so — what it is **waiting** for (*waiting:
+allow or deny the edit*). Next to the path is the branch, with a `*` when the
+checkout has uncommitted work, which is the fastest way to tell two clones of
+the same repo apart.
+
+The `sessions` panel ends with **this workspace**: checkout, account,
+how long it has been supervised and what started it, restarts and the last
+exit cause, whether the machine is being held awake for it, and its pid. The
+same facts `corgi agent status` prints on the laptop.
 
 The list refreshes itself every 15 seconds while the page is on screen, so a
 name, a state or a session that changed on the machine shows up without a

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -255,6 +255,33 @@ can never set it. Treat the value as a secret — a Telegram token lets anyone
 post as that bot, so never paste it into a chat, a commit or an issue. If one
 leaks, `/revoke` in @BotFather issues a new one; the chat id does not change.
 
+### What a session is called
+
+Every supervised session carries a name into claude.ai/code's list. The
+workspace id alone is not enough — four rows called `corgi` say nothing about
+which one to open — so corgi composes the branch it started on and the clock
+time with it:
+
+```
+corgi · fix/login-redirect · 18:55
+corgi (work) · main · 09:02
+```
+
+The profile appears only when the session runs under one. The branch is
+dropped for a checkout on a detached HEAD, or a workspace that is not a git
+repository, and is the part shortened when the name would run past the 60
+characters claude.ai shows.
+
+Name a session yourself and that wins — it says what the session is *for*,
+which no local probe can know:
+
+```bash
+corgi agent session start acme --name "fix login redirect"
+```
+
+The launcher's start form has the same optional field, and
+`corgi_session_start` takes a `name`.
+
 ### The timeline
 
 Every start, exit (with its classified cause), disable, and captured session

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -111,16 +111,27 @@ the phone paired across restarts; the quick tunnel does not.
 
 ### What the launcher looks like
 
-One card per repo, and one white button on each: **Open** when a session is
-already up, **Start** when it is not — never both. The card carries the repo,
-its path, a green *N live* pill, the last thing that happened, and a row for
-the running session that opens the conversation in one tap.
+One card per repo, one button on each: **Open** when a session is already up,
+**Start** when it is not — never both. Next to the repo name is the one word
+that matters, with a dot in front of it:
 
+| state | what it means |
+|---|---|
+| `live` | a session is running (`N sessions` when there is more than one) |
+| `needs you` | a permission prompt or a question is blocking it |
+| `starting` | supervised, no session has registered yet |
+| `will not start` | the daemon refused, and the reason is on the card |
+| `stopped` | nothing running here |
+
+Below it, the running session's own row opens the conversation in one tap.
 Everything else is behind **Details**: tap the card and a sheet comes up from
 the bottom with the session name and account to start under, where links
 should open, hide, stop, and the full session list and timeline for that
-workspace. Nothing that changes the machine is more than two taps away, and
-nothing that does not is competing for the first one.
+workspace.
+
+The list refreshes itself every 15 seconds while the page is on screen, so a
+name, a state or a session that changed on the machine shows up without a
+reload — and it holds still while a sheet is open.
 
 ### A launcher URL that never changes
 
@@ -284,6 +295,18 @@ The profile appears only when the session runs under one. The branch is
 dropped for a checkout on a detached HEAD, or a workspace that is not a git
 repository, and is the part shortened when the name would run past the 60
 characters claude.ai shows.
+
+That is the name it **starts** with. After that the name belongs to Claude
+Code, which keeps its own record of it (`<configDir>/sessions/<pid>.json`,
+with a `nameSource` saying who last set it — `user` for one someone typed,
+`derived` or `auto` for one Claude picked, `hook` for one a hook set). A
+session renamed in flight — by `/rename`, by a hook, or by Claude as the work
+takes shape — is renamed in corgi's list too: the launcher reads that record
+on every refresh and shows the current name, with *renamed 4m ago* beside it.
+
+What corgi cannot do is rename a session on claude.ai after the fact: the name
+in that list is the one remote control registered at start, which is why the
+starting name is worth composing well.
 
 Name a session yourself and that wins — it says what the session is *for*,
 which no local probe can know:

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win, and measuring and reducing the cyclomatic complexity of changed code (a gate the stories and review skills apply to every diff).",
-  "version": "1.21.27",
+  "version": "1.21.28",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win, and measuring and reducing the cyclomatic complexity of changed code (a gate the stories and review skills apply to every diff).",
-  "version": "1.21.25",
+  "version": "1.21.26",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win, and measuring and reducing the cyclomatic complexity of changed code (a gate the stories and review skills apply to every diff).",
-  "version": "1.21.26",
+  "version": "1.21.27",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win, and measuring and reducing the cyclomatic complexity of changed code (a gate the stories and review skills apply to every diff).",
-  "version": "1.21.24",
+  "version": "1.21.25",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win, and measuring and reducing the cyclomatic complexity of changed code (a gate the stories and review skills apply to every diff).",
-  "version": "1.21.23",
+  "version": "1.21.24",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/utils/repostate.go
+++ b/utils/repostate.go
@@ -67,3 +67,18 @@ func resolveBaseRef(dir, base string) (string, bool) {
 func RepoHead(dir string) (string, error) {
 	return gitOut(dir, gitRevParse, "HEAD")
 }
+
+// CurrentBranch reads just the branch a checkout is on: no network, and none
+// of ProbeRepoState's status scan, which walks the whole worktree. Returns ""
+// for a directory that is not a git repository and for a detached HEAD, where
+// there is no branch name to show.
+func CurrentBranch(dir string) string {
+	if dir == "" || !isGitRepo(dir) {
+		return ""
+	}
+	branch, err := gitOut(dir, gitRevParse, gitAbbrevRef, "HEAD")
+	if err != nil || branch == "HEAD" {
+		return ""
+	}
+	return branch
+}


### PR DESCRIPTION
Two changes to what the phone shows, in order.

## 1. Sessions were all called the same thing

A supervised session took the workspace id as its whole name, so the list showed several rows called `corgi` (and several called `idid`) with nothing to tell them apart.

The composed default now carries the branch the session started on and the clock time, plus the profile when the session runs under one:

```
corgi · fix/login-redirect · 18:55
corgi (work) · main · 09:02
```

- Branch dropped for a detached HEAD or a workspace that is not a git checkout.
- Branch is also the part shortened when the name would run past the 60 characters claude.ai shows — the id says which workspace and the clock says which run, so neither may be lost.
- A name passed from the phone, `corgi agent session start --name`, or `corgi_session_start` still wins outright: it says what the session is *for*, which no local probe can know. The MCP tool description now nudges a caller to pass one.
- `utils.CurrentBranch` reads the branch alone: no network, and none of `ProbeRepoState`'s status scan, which walks the whole worktree.

Covered on both paths: autostart at `corgi agent serve`, and an on-demand remote start (re-resolved per command, so its name is fresh).

## 2. The launcher asked the phone to read, not to act

11px labels, a micro-dot for status, and five chips per card — sessions, open in, options, hide, stop — none of them the thing you opened the page to do.

Rebuilt on the rule a ride-hailing app follows: **one card per repo, one white button on it, everything else one tap deeper.**

- Cards carry a per-repo avatar, the repo, its path, a green *N live* pill and the last event; the running session gets its own row that opens the conversation. Nothing on the card is under 12px or 44px tall.
- One primary button per card: **Open** when there is a session to open, **Start** when there is not — never both, never neither.
- **Details** opens a bottom sheet: session name and account to start under, where links open, hide, stop, and that workspace's full session list and timeline. The chip row is gone.
- Starting says so at once — the card goes to *Starting…* before the daemon answers, so a second tap cannot queue a second session — and failures land in a toast instead of a red block that shifts the card you were aiming at.
- Skeleton rows while the list loads; real empty states for *not paired* and *no repos*; the machine line no longer truncates away `daemon up`.
- Inside a repo's own card, a session name's leading workspace prefix is trimmed — the card already says which repo it is, so the branch and time get the width. (This is what ties the two halves of the PR together.)
- The pairing pages got the same ladder: black ground, one white action.

Bugs found and fixed while rendering it: `[hidden]` lost to the flex display rules, so the refresh button stayed visible when unpaired; the session row ran its name and time together on one line; activity timestamps wrapped mid-phrase.

Semantics and a11y: the card is no longer a `role=button` wrapped around other buttons — the footer is a real button, which is what a keyboard and a screen reader reach. Escape and the scrim close the sheet, the page behind it does not scroll, and `prefers-reduced-motion` drops the animation.

Nothing about the endpoints, the device token, `safeClaudeUrl` gating, `rel=noopener`, or the escaping changed, and the page is still a single self-contained string with no external assets.

## Tests

- `cmd/agent_session_name_test.go` — branch + clock, the profile, a non-git workspace, a branch too long to fit, an id that leaves no room for one.
- `cmd/agent_remote_resolver_test.go` — the resolver names a session by branch; a phone-supplied name still wins.
- `cmd/mcp_launcher_test.go` — the controls that moved into the sheet are still on the page, and `[hidden]` still beats the display rules.

`go build ./...`, `go vet ./cmd/... ./utils/...` and `go test ./cmd` pass. The 6 failures in `./utils` are pre-existing on `main` in this container (`gh` not installed; one test that needs a non-root user) — verified by stashing.

The rebuilt page was driven in a real browser at iPhone size: list, sheet, start-with-options, hide, mode cycling, toast, Escape-to-close and the unpaired state all render with no console or page errors.

## Version

Patch bumps: `1.21.23` → `1.21.25` (`cmd/root.go` and the plugin manifest), one per change.