### PR TITLE
agent: name sessions after what you ask them, and finish the recycled-pid check on macOS

### DIFF
--- a/cmd/agent_hook_title.go
+++ b/cmd/agent_hook_title.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"unicode"
+)
+
+// The session title corgi composes at start — "corgi · fix/login · 18:55" —
+// answers "which machine, which checkout, when". It cannot answer the question
+// you actually scan the list for, which is what the session is *doing*, because
+// nothing knows that until you say it.
+//
+// Claude Code takes a title from a UserPromptSubmit hook, so the first thing
+// you ask becomes the name: "corgi · fix the login redirect". After that the
+// title is left alone — a session renamed on every prompt would flicker
+// through "ok", "continue", "now the tests", and a name that changes under you
+// is worse than a dull one.
+//
+// This is deliberately conservative. The field is in the CLI's own hook schema
+// but not in the published hooks reference, so a CLI that ignores it must lose
+// nothing: the hook prints a title and exits 0, never blocks a prompt, and
+// never fails a turn.
+
+// titleHookOutput is the shape Claude Code reads back from the hook.
+type titleHookOutput struct {
+	HookSpecificOutput titleHookSpecific `json:"hookSpecificOutput"`
+}
+
+type titleHookSpecific struct {
+	HookEventName string `json:"hookEventName"`
+	SessionTitle  string `json:"sessionTitle"`
+}
+
+// titleHookInput is the part of the hook payload this reads. Everything else
+// in it — the transcript path, the session id, the cwd — is deliberately
+// ignored: the less of a prompt this touches, the less there is to leak.
+type titleHookInput struct {
+	Prompt       string `json:"prompt"`
+	SessionTitle string `json:"session_title"`
+	Event        string `json:"hook_event_name"`
+}
+
+// maxTitleLen matches the cap on a name typed from the phone, which is what
+// claude.ai's list has room for.
+const maxTitleLen = 60
+
+func runAgentTitleHook(workspaceID string, stdin io.Reader, stdout io.Writer) {
+	title, ok := titleFromPrompt(workspaceID, stdin)
+	if !ok {
+		return
+	}
+	// A hook that cannot write its answer has still not harmed the turn.
+	_ = json.NewEncoder(stdout).Encode(titleHookOutput{
+		HookSpecificOutput: titleHookSpecific{
+			HookEventName: "UserPromptSubmit",
+			SessionTitle:  title,
+		},
+	})
+}
+
+func titleFromPrompt(workspaceID string, stdin io.Reader) (string, bool) {
+	if stdin == nil {
+		return "", false
+	}
+	data, err := io.ReadAll(io.LimitReader(stdin, 64<<10))
+	if err != nil {
+		return "", false
+	}
+	var in titleHookInput
+	if json.Unmarshal(data, &in) != nil {
+		return "", false
+	}
+	ask := firstAsk(in.Prompt)
+	if ask == "" {
+		return "", false
+	}
+	if !titleIsStillCorgis(in.SessionTitle, workspaceID) {
+		// Somebody named this session, or the first prompt already named it.
+		// Either way it is not corgi's to overwrite.
+		return "", false
+	}
+	prefix := strings.TrimSpace(workspaceID)
+	if prefix == "" {
+		return clipTitle(ask, maxTitleLen), true
+	}
+	// The workspace stays in front: claude.ai lists every session you have
+	// running, on every machine, and "fix the login redirect" alone does not
+	// say where. corgi's own list trims the prefix back off, since the card it
+	// sits on has already said which repo this is.
+	prefix += " · "
+	return prefix + clipTitle(ask, maxTitleLen-len([]rune(prefix))), true
+}
+
+// firstAsk reduces a prompt to the one line worth putting in a list: the first
+// non-empty line, without a leading slash command, control characters or
+// runaway whitespace. An empty result means "nothing worth renaming for".
+func firstAsk(prompt string) string {
+	for _, line := range strings.Split(prompt, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "/") {
+			// A slash command is corgi's cue that the turn is a command, not a
+			// description of the work.
+			continue
+		}
+		line = strings.Map(func(r rune) rune {
+			if unicode.IsControl(r) {
+				return ' '
+			}
+			return r
+		}, line)
+		line = strings.Join(strings.Fields(line), " ")
+		if !worthTitling(line) {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+// continuations are the prompts that carry a turn forward without describing
+// it. Naming a session "yes" helps nobody.
+var continuations = map[string]bool{
+	"yes": true, "y": true, "no": true, "n": true, "ok": true, "okay": true,
+	"go": true, "go on": true, "continue": true, "carry on": true, "keep going": true,
+	"next": true, "do it": true, "fix it": true, "try again": true, "retry": true,
+	"stop": true, "thanks": true, "ty": true, "please": true, "run it": true,
+}
+
+func worthTitling(line string) bool {
+	if len([]rune(line)) < 12 {
+		return false
+	}
+	return !continuations[strings.ToLower(strings.TrimRight(line, ".!?"))]
+}
+
+// titleIsStillCorgis says whether the current title is one nobody chose: the
+// name corgi started the session with, or the one Claude Code derives from the
+// directory (workspace-3e). Anything else — a name typed from the phone, or
+// the one this hook already wrote — was a decision, and is left alone.
+//
+// The tell is the clock: every name corgi composes ends in one
+// (workspace · branch · 18:55), and no title made from an ask does. Matching
+// the prefix alone would make "corgi · fix the login redirect" look like
+// corgi's own name, and the session would be renamed on every prompt.
+func titleIsStillCorgis(title, workspaceID string) bool {
+	title = strings.TrimSpace(title)
+	id := strings.TrimSpace(workspaceID)
+	if title == "" {
+		return true
+	}
+	if id == "" {
+		return false
+	}
+	if title == id {
+		return true
+	}
+	if strings.HasPrefix(title, id+" · ") || strings.HasPrefix(title, id+" (") {
+		return endsWithClock(title)
+	}
+	// Claude Code's own derived name: the directory with a short suffix.
+	rest, cut := strings.CutPrefix(title, id+"-")
+	return cut && rest != "" && len(rest) <= 4 && isShortSuffix(rest)
+}
+
+// endsWithClock matches the HH:MM every composed name ends with.
+func endsWithClock(title string) bool {
+	r := []rune(title)
+	if len(r) < 5 {
+		return false
+	}
+	tail := r[len(r)-5:]
+	return unicode.IsDigit(tail[0]) && unicode.IsDigit(tail[1]) &&
+		tail[2] == ':' && unicode.IsDigit(tail[3]) && unicode.IsDigit(tail[4])
+}
+
+func isShortSuffix(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLower(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func clipTitle(s string, max int) string {
+	if max < 8 {
+		max = 8
+	}
+	r := []rune(strings.TrimSpace(s))
+	if len(r) <= max {
+		return string(r)
+	}
+	return strings.TrimSpace(string(r[:max-1])) + "…"
+}
+
+// titleHookStdin is a seam for the tests: the real hook reads the payload
+// Claude Code pipes in.
+var titleHookStdin io.Reader = os.Stdin

--- a/cmd/agent_hook_title_test.go
+++ b/cmd/agent_hook_title_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func titleFor(t *testing.T, workspace, payload string) (string, bool) {
+	t.Helper()
+	var out strings.Builder
+	runAgentTitleHook(workspace, strings.NewReader(payload), &out)
+	if strings.TrimSpace(out.String()) == "" {
+		return "", false
+	}
+	var decoded titleHookOutput
+	if err := json.Unmarshal([]byte(out.String()), &decoded); err != nil {
+		t.Fatalf("the hook must print valid JSON, got %q: %v", out.String(), err)
+	}
+	if decoded.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
+		t.Errorf("hookEventName = %q, want UserPromptSubmit", decoded.HookSpecificOutput.HookEventName)
+	}
+	return decoded.HookSpecificOutput.SessionTitle, true
+}
+
+func TestTitleHookNamesASessionAfterTheFirstAsk(t *testing.T) {
+	got, ok := titleFor(t, "corgi", `{"prompt":"fix the login redirect loop","session_title":"corgi · main · 18:55"}`)
+	if !ok {
+		t.Fatal("a first ask on a corgi-named session must produce a title")
+	}
+	if got != "corgi · fix the login redirect loop" {
+		t.Errorf("title = %q", got)
+	}
+}
+
+func TestTitleHookLeavesAChosenNameAlone(t *testing.T) {
+	// Somebody named this session, or the first prompt already did. Either way
+	// a name that changes under you is worse than a dull one.
+	for _, title := range []string{
+		"corgi · fix the login redirect loop", // already titled by this hook
+		"ship the release",                    // named from the phone
+		"corgi · 18:55 and then some",         // a clock, but not at the end
+		"unrelated",
+	} {
+		if got, ok := titleFor(t, "corgi", `{"prompt":"now add a test for it","session_title":`+quoteJSON(title)+`}`); ok {
+			t.Errorf("title %q must be left alone, got %q", title, got)
+		}
+	}
+}
+
+func TestTitleHookAcceptsTheNamesNobodyChose(t *testing.T) {
+	for _, title := range []string{
+		"corgi",                     // the workspace id
+		"corgi-3e",                  // Claude Code's derived name
+		"corgi (work) · 09:02",      // corgi's composed name, under a profile
+		"corgi · fix/login · 18:55", // and with a branch
+		"",                          // nothing recorded yet
+	} {
+		if _, ok := titleFor(t, "corgi", `{"prompt":"rewrite the payment webhook","session_title":`+quoteJSON(title)+`}`); !ok {
+			t.Errorf("an unchosen name (%q) is corgi's to replace", title)
+		}
+	}
+}
+
+func TestTitleHookIgnoresPromptsThatSayNothing(t *testing.T) {
+	for _, prompt := range []string{
+		"yes", "continue", "ok", "do it", "fix it.", "", "   ",
+		"/corgi-remote",             // a slash command is a command, not a description
+		"go",                        // too short to name anything
+		"/review\n/another-command", // nothing but commands
+	} {
+		if got, ok := titleFor(t, "corgi", `{"prompt":`+quoteJSON(prompt)+`,"session_title":"corgi"}`); ok {
+			t.Errorf("prompt %q must not rename the session, got %q", prompt, got)
+		}
+	}
+}
+
+func TestTitleHookTakesTheFirstRealLine(t *testing.T) {
+	prompt := "/context\n\n  make the launcher show the branch  \nand then the tests"
+	got, ok := titleFor(t, "corgi", `{"prompt":`+quoteJSON(prompt)+`,"session_title":"corgi"}`)
+	if !ok {
+		t.Fatal("a prompt with a leading command still describes work")
+	}
+	if got != "corgi · make the launcher show the branch" {
+		t.Errorf("title = %q, want the first line that is not a command, whitespace collapsed", got)
+	}
+}
+
+func TestTitleHookFitsTheListAndStaysSane(t *testing.T) {
+	long := strings.Repeat("refactor the supervisor ", 12)
+	got, ok := titleFor(t, "corgi", `{"prompt":`+quoteJSON(long)+`,"session_title":"corgi"}`)
+	if !ok {
+		t.Fatal("a long ask still names the session")
+	}
+	if n := len([]rune(got)); n > maxTitleLen {
+		t.Errorf("title is %d runes (%q), want at most %d", n, got, maxTitleLen)
+	}
+	if !strings.HasPrefix(got, "corgi · ") {
+		t.Errorf("title = %q, want the workspace kept in front", got)
+	}
+
+	// Whatever a prompt contains, a control character must not travel into a
+	// name that other software will render.
+	withControls := "drop the\ttab and the bell from this ask"
+	got, _ = titleFor(t, "corgi", `{"prompt":`+quoteJSON(withControls)+`,"session_title":"corgi"}`)
+	if strings.ContainsFunc(got, func(r rune) bool { return r < 0x20 || r == 0x7f }) {
+		t.Errorf("title = %q, want control characters stripped", got)
+	}
+}
+
+func TestTitleHookSurvivesJunk(t *testing.T) {
+	// A hook that cannot read its input must cost the turn nothing.
+	for _, payload := range []string{"", "not json", "{}", `{"prompt":123}`, "null"} {
+		if _, ok := titleFor(t, "corgi", payload); ok {
+			t.Errorf("payload %q must produce no output", payload)
+		}
+	}
+}
+
+func quoteJSON(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -21,8 +21,13 @@ import (
 const (
 	hookEventNotification = "Notification"
 	hookEventStop         = "Stop"
+	hookEventPrompt       = "UserPromptSubmit"
 	hookMarker            = "corgi agent hook"
 )
+
+// corgiHookEvents is every event corgi writes, so enable and disable can never
+// disagree about what to clean up.
+var corgiHookEvents = []string{hookEventNotification, hookEventStop, hookEventPrompt}
 
 var agentHooksCmd = &cobra.Command{
 	Use:   "hooks",
@@ -33,10 +38,17 @@ var agentHooksEnableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Notify when a Claude session here asks for permission or finishes",
 	Long: `Writes Claude Code hooks into .claude/settings.local.json (local to this
-machine, never committed): one for permission prompts and questions, and with
---turns one for a finished turn. They call ` + "`corgi agent hook`" + `, which
-tells the corgi daemon, which sends the same notification as a restart —
-including the phone push when notifyUrl is set.
+machine, never committed): one for permission prompts and questions, one that
+names a session after the first thing you ask it, and with --turns one for a
+finished turn. They call ` + "`corgi agent hook`" + `, which tells the corgi
+daemon, which sends the same notification as a restart — including the phone
+push when notifyUrl is set.
+
+The naming one answers nothing to the daemon: it replies to Claude Code with a
+title, so "corgi · main · 18:55" becomes "corgi · fix the login redirect" as
+soon as you say what you want. It only ever replaces a name corgi composed or
+Claude Code derived — one you typed, or one it already set, is left alone —
+and --no-title skips it entirely.
 
 By default only the first: a permission prompt blocks the session until you
 answer it, while a finished turn is just noise once several workspaces are busy.
@@ -95,8 +107,9 @@ func claudeLocalSettingsPath(dir string) string {
 func runAgentHooksEnable(cmd *cobra.Command, _ []string) {
 	turns := wantsTurnHook(cmd)
 	idle := wantsIdleHook(cmd)
+	title := wantsTitleHook(cmd)
 	for _, target := range hookTargets(cmd) {
-		if err := enableHooksIn(target.dir, target.id, turns, idle); err != nil {
+		if err := enableHooksIn(target.dir, target.id, turns, idle, title); err != nil {
 			exitWithError("agent_hooks", err, 1)
 		}
 		utils.Infof("✓ %s will notify you when a session there needs you (%s)\n",
@@ -107,6 +120,9 @@ func runAgentHooksEnable(cmd *cobra.Command, _ []string) {
 	}
 	if idle {
 		utils.Info("also notifying when a session has just been idle a while (--idle)")
+	}
+	if title {
+		utils.Info("sessions here will also be named after the first thing you ask them (--no-title to skip)")
 	}
 	if !notifyURLConfigured() {
 		printNotifyUrlHelp()
@@ -122,6 +138,17 @@ func printNotifyUrlHelp() {
 	utils.Info("  corgi agent notify set <slack-or-discord-webhook-url>")
 	utils.Info("")
 	utils.Info("  then: corgi agent restart")
+}
+
+// The title hook is on by default: a list of sessions all called after their
+// repo is the thing people ask corgi to fix, and the hook only ever renames a
+// session corgi named itself.
+func wantsTitleHook(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return true
+	}
+	skip, _ := cmd.Flags().GetBool("no-title")
+	return !skip
 }
 
 func wantsIdleHook(cmd *cobra.Command) bool {
@@ -213,7 +240,7 @@ func allSuffix(cmd *cobra.Command) string {
 	return ""
 }
 
-func enableHooksIn(dir, id string, turns, idle bool) error {
+func enableHooksIn(dir, id string, turns, idle, title bool) error {
 	path := claudeLocalSettingsPath(dir)
 	settings := readJSONObject(path)
 	hooks, _ := settings["hooks"].(map[string]any)
@@ -221,10 +248,10 @@ func enableHooksIn(dir, id string, turns, idle bool) error {
 		hooks = map[string]any{}
 	}
 
-	wanted := map[string]bool{hookEventNotification: true, hookEventStop: turns}
-	for event, want := range wanted {
-		if want {
-			hooks[event] = withCorgiHook(hooks[event], id, idle)
+	wanted := map[string]bool{hookEventNotification: true, hookEventStop: turns, hookEventPrompt: title}
+	for _, event := range corgiHookEvents {
+		if wanted[event] {
+			hooks[event] = withCorgiHook(hooks[event], id, event, idle)
 			continue
 		}
 		remaining := stripCorgiHooks(hooks[event])
@@ -243,12 +270,15 @@ func enableHooksIn(dir, id string, turns, idle bool) error {
 	return writeJSONObject(path, settings)
 }
 
-func withCorgiHook(existing any, workspaceID string, idle bool) []any {
+func withCorgiHook(existing any, workspaceID, event string, idle bool) []any {
 	out := stripCorgiHooks(existing)
 	// The choice rides in the command corgi writes, so it is per workspace and
 	// visible in the settings file rather than hidden in another config.
 	command := fmt.Sprintf("corgi agent hook --workspace %s", workspaceID)
-	if idle {
+	if event == hookEventPrompt {
+		command += " title"
+	}
+	if idle && event != hookEventPrompt {
 		command += " --idle"
 	}
 	return append(out, map[string]any{
@@ -291,7 +321,7 @@ func disableHooksIn(dir string) (bool, error) {
 	if hooks == nil {
 		return false, nil
 	}
-	for _, event := range []string{hookEventNotification, hookEventStop} {
+	for _, event := range corgiHookEvents {
 		remaining := stripCorgiHooks(hooks[event])
 		if len(remaining) == 0 {
 			delete(hooks, event)
@@ -316,6 +346,12 @@ func runAgentHook(cmd *cobra.Command, args []string) {
 	event := ""
 	if len(args) > 0 {
 		event = args[0]
+	}
+	if event == "title" {
+		// The one hook that answers rather than reports: it prints a session
+		// title on stdout and tells the daemon nothing.
+		runAgentTitleHook(id, titleHookStdin, os.Stdout)
+		return
 	}
 	detail := hookDetail(event, os.Stdin)
 
@@ -424,6 +460,7 @@ func init() {
 	agentHooksEnableCmd.Flags().Bool("all", false, "Apply to every registered workspace, not just this directory")
 	agentHooksEnableCmd.Flags().Bool("turns", false, "Also notify when a session finishes a turn (noisy across several workspaces)")
 	agentHooksEnableCmd.Flags().Bool("idle", false, "Also notify on Claude's \"waiting for your input\" nudge, which fires when nothing is actually blocked")
+	agentHooksEnableCmd.Flags().Bool("no-title", false, "Do not name sessions after the first thing you ask them")
 	agentHooksDisableCmd.Flags().Bool("all", false, "Apply to every registered workspace, not just this directory")
 	agentHooksCmd.AddCommand(agentHooksEnableCmd, agentHooksDisableCmd)
 	agentCmd.AddCommand(agentHooksCmd, agentHookCmd)

--- a/cmd/agent_hooks_idle_test.go
+++ b/cmd/agent_hooks_idle_test.go
@@ -27,11 +27,11 @@ func TestIsIdleNudge(t *testing.T) {
 // The default hook drops the idle nudge; --idle keeps it, and the choice is
 // visible in the command written into the settings file.
 func TestWithCorgiHookRecordsTheIdleChoice(t *testing.T) {
-	plain := marshalCompact(withCorgiHook(nil, "acme", false))
+	plain := marshalCompact(withCorgiHook(nil, "acme", hookEventNotification, false))
 	if strings.Contains(plain, "--idle") {
 		t.Errorf("the default hook asked for idle notifications: %s", plain)
 	}
-	withIdle := marshalCompact(withCorgiHook(nil, "acme", true))
+	withIdle := marshalCompact(withCorgiHook(nil, "acme", hookEventNotification, true))
 	if !strings.Contains(withIdle, "--idle") {
 		t.Errorf("--idle was not written into the hook: %s", withIdle)
 	}
@@ -43,7 +43,7 @@ func TestWithCorgiHookRecordsTheIdleChoice(t *testing.T) {
 
 func TestEnableHooksInWritesTheIdleFlag(t *testing.T) {
 	dir := t.TempDir()
-	if err := enableHooksIn(dir, "acme", false, true); err != nil {
+	if err := enableHooksIn(dir, "acme", false, true, false); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.local.json"))
@@ -119,5 +119,43 @@ func TestHookDetailFallbacks(t *testing.T) {
 	}
 	if got := hookDetail("", nil); got != "a session is waiting for you" {
 		t.Errorf("default detail = %q", got)
+	}
+}
+
+func TestEnableWritesTheTitleHookAndDisableTakesItBack(t *testing.T) {
+	dir := t.TempDir()
+	if err := enableHooksIn(dir, "acme", false, false, true); err != nil {
+		t.Fatal(err)
+	}
+	settings := readJSONObject(claudeLocalSettingsPath(dir))
+	hooks, _ := settings["hooks"].(map[string]any)
+	written := marshalCompact(hooks[hookEventPrompt])
+	if !strings.Contains(written, "corgi agent hook --workspace acme title") {
+		t.Errorf("UserPromptSubmit hook = %s, want the title hook for this workspace", written)
+	}
+	// --idle belongs to the notification hook; the title hook has no use for it.
+	if strings.Contains(written, "--idle") {
+		t.Errorf("the title hook must not carry notification flags: %s", written)
+	}
+
+	// Off by request, without touching the notification hook.
+	if err := enableHooksIn(dir, "acme", false, false, false); err != nil {
+		t.Fatal(err)
+	}
+	settings = readJSONObject(claudeLocalSettingsPath(dir))
+	hooks, _ = settings["hooks"].(map[string]any)
+	if _, still := hooks[hookEventPrompt]; still {
+		t.Error("--no-title must remove the hook corgi wrote")
+	}
+	if _, gone := hooks[hookEventNotification]; !gone {
+		t.Error("the notification hook must be left in place")
+	}
+
+	if _, err := disableHooksIn(dir); err != nil {
+		t.Fatal(err)
+	}
+	settings = readJSONObject(claudeLocalSettingsPath(dir))
+	if _, left := settings["hooks"]; left {
+		t.Errorf("disable must remove every hook corgi wrote: %v", settings)
 	}
 }

--- a/cmd/agent_polish_test.go
+++ b/cmd/agent_polish_test.go
@@ -264,11 +264,11 @@ func TestHookDetail(t *testing.T) {
 
 func TestWithCorgiHookReplacesOnlyOurs(t *testing.T) {
 	other := map[string]any{"hooks": []any{map[string]any{"type": "command", "command": "echo mine"}}}
-	first := withCorgiHook([]any{other}, "acme", false)
+	first := withCorgiHook([]any{other}, "acme", hookEventNotification, false)
 	if len(first) != 2 {
 		t.Fatalf("entries = %d, want the existing one plus ours", len(first))
 	}
-	again := withCorgiHook(first, "acme", false)
+	again := withCorgiHook(first, "acme", hookEventNotification, false)
 	if len(again) != 2 {
 		t.Errorf("re-running must replace ours, not add another: %d entries", len(again))
 	}

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -819,32 +820,93 @@ func sessionProcessIsLive(cs claudeSession) bool {
 	if !pidExists(cs.PID) {
 		return false
 	}
-	started, ok := processStartTicks(cs.PID)
+	started, ok := processStartToken(cs.PID)
 	if !ok || strings.TrimSpace(cs.ProcStart) == "" {
 		return true
 	}
-	return strings.TrimSpace(cs.ProcStart) == started
+	return sameStartToken(cs.ProcStart, started)
 }
 
-// processStartTicks reads the start time Linux keeps for a pid (field 22 of
-// /proc/<pid>/stat, in clock ticks since boot) — the same value Claude Code
-// stores. ok is false anywhere else, including macOS, where the equivalent
-// costs a subprocess per session and this list is polled every second.
-func processStartTicks(pid int) (string, bool) {
-	if runtime.GOOS != "linux" || pid <= 0 {
+// processStartToken reads the start time the OS keeps for a pid, in the exact
+// form Claude Code records it, so the two can be compared as strings:
+//
+//	linux   field 22 of /proc/<pid>/stat — clock ticks since boot
+//	darwin  the output of `ps -o lstart= -p <pid>` under LC_ALL=C and TZ=UTC
+//
+// ok is false where neither is available (Windows, or the read failed), and
+// the caller then falls back to "a live pid is live", as it did everywhere
+// before this existed. Comparing a token we could not read is never worth a
+// session vanishing from the list.
+func processStartToken(pid int) (string, bool) {
+	if pid <= 0 {
 		return "", false
 	}
+	if token, ok := cachedStartToken(pid); ok {
+		return token, true
+	}
+	var token string
+	var ok bool
+	switch runtime.GOOS {
+	case "linux":
+		token, ok = linuxStartTicks(pid)
+	case "darwin":
+		token, ok = darwinStartDate(pid)
+	}
+	if ok {
+		rememberStartToken(pid, token)
+	}
+	return token, ok
+}
+
+// startTokenTTL bounds how long a read is reused. A process's start time never
+// changes, so this only exists so a recycled pid cannot keep a dead session's
+// answer — and so the darwin path costs at most one `ps` per pid per minute
+// while the phone polls this list every second.
+const startTokenTTL = time.Minute
+
+var startTokens = struct {
+	mu   sync.Mutex
+	seen map[int]startToken
+}{seen: map[int]startToken{}}
+
+type startToken struct {
+	value string
+	read  time.Time
+}
+
+func cachedStartToken(pid int) (string, bool) {
+	startTokens.mu.Lock()
+	defer startTokens.mu.Unlock()
+	entry, ok := startTokens.seen[pid]
+	if !ok || time.Since(entry.read) > startTokenTTL {
+		return "", false
+	}
+	return entry.value, true
+}
+
+func rememberStartToken(pid int, value string) {
+	startTokens.mu.Lock()
+	defer startTokens.mu.Unlock()
+	if len(startTokens.seen) > 512 {
+		// A daemon alive for weeks must not accumulate an entry per pid ever
+		// seen; every entry is re-readable, so dropping them costs one read.
+		startTokens.seen = map[int]startToken{}
+	}
+	startTokens.seen[pid] = startToken{value: value, read: time.Now()}
+}
+
+func linuxStartTicks(pid int) (string, bool) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
 		return "", false
 	}
 	// The second field is the executable name in parentheses and may itself
 	// contain spaces and parentheses, so fields are counted from the last ')'.
-	close := strings.LastIndex(string(data), ")")
-	if close < 0 {
+	closing := strings.LastIndex(string(data), ")")
+	if closing < 0 {
 		return "", false
 	}
-	fields := strings.Fields(string(data)[close+1:])
+	fields := strings.Fields(string(data)[closing+1:])
 	// state is the field after comm, so starttime (22nd overall) is index 19
 	// of what is left.
 	const startTimeOffset = 19
@@ -852,6 +914,33 @@ func processStartTicks(pid int) (string, bool) {
 		return "", false
 	}
 	return fields[startTimeOffset], true
+}
+
+// darwinStartDate runs the same command Claude Code does, with the same
+// locale and timezone pinned, so the strings line up. Bounded: this sits on a
+// request path the phone polls.
+func darwinStartDate(pid int) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid)) // NOSONAR — fixed argv, numeric pid
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "TZ=UTC")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return "", false
+	}
+	return line, true
+}
+
+// sameStartToken compares two start times for the same pid. Internal spacing
+// is normalised first: `ps` pads a single-digit day ("Sep  3"), and a session
+// disappearing from the phone over a space would be a far worse bug than the
+// stale record this is here to catch.
+func sameStartToken(a, b string) bool {
+	return strings.Join(strings.Fields(a), " ") == strings.Join(strings.Fields(b), " ")
 }
 
 func pidExists(pid int) bool {

--- a/cmd/mcp_launcher_test.go
+++ b/cmd/mcp_launcher_test.go
@@ -192,11 +192,11 @@ func TestLaunchStateReportsADisabledWorkspace(t *testing.T) {
 }
 
 func TestSessionProcessIsLiveRejectsARecycledPID(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("start times are only read from /proc")
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("no start time to read on this platform")
 	}
 	mine := os.Getpid()
-	started, ok := processStartTicks(mine)
+	started, ok := processStartToken(mine)
 	if !ok || started == "" {
 		t.Fatalf("this process's start time must be readable, got %q ok=%v", started, ok)
 	}
@@ -214,6 +214,36 @@ func TestSessionProcessIsLiveRejectsARecycledPID(t *testing.T) {
 	}
 	if sessionProcessIsLive(claudeSession{PID: 0}) {
 		t.Error("pid 0 is not a session")
+	}
+}
+
+func TestSameStartTokenIgnoresPsPadding(t *testing.T) {
+	// ps pads a single-digit day, and the same reading must not look like a
+	// different process over a space: that would drop a live session.
+	if !sameStartToken("Wed Sep  3 16:04:12 2025", "Wed Sep 3 16:04:12 2025") {
+		t.Error("internal padding must not matter")
+	}
+	if sameStartToken("Wed Sep  3 16:04:12 2025", "Wed Sep  3 16:04:13 2025") {
+		t.Error("a different second is a different process")
+	}
+	if !sameStartToken(" 690 ", "690") {
+		t.Error("surrounding space must not matter")
+	}
+}
+
+func TestStartTokenCacheAnswersTwice(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("no start time to read on this platform")
+	}
+	// The second read must come from the cache: on darwin the uncached path
+	// runs ps, and this list is polled every second.
+	first, ok := processStartToken(os.Getpid())
+	if !ok {
+		t.Skip("could not read this process's start time")
+	}
+	cached, hit := cachedStartToken(os.Getpid())
+	if !hit || cached != first {
+		t.Errorf("cached = %q hit=%v, want the first reading %q", cached, hit, first)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "1.21.28"
+var APP_VERSION = "1.21.29"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -236,7 +236,7 @@ corgi agent serve --foreground   # run it in this terminal and watch
 | `corgi agent logs <workspace>` | the session timeline: starts, exits and why, links |
 | `corgi agent restart` | `down` + `up --fresh` in one — run it after `corgi upgrade` |
 | `corgi agent tunnel setup <host>` | one-time permanent-URL setup, remembered for later runs |
-| `corgi agent hooks enable` / `disable` | notify when a session in this workspace needs you |
+| `corgi agent hooks enable` / `disable` | notify when a session needs you, and name sessions after what you ask them |
 | `corgi agent stop` | stop the daemon |
 
 ## Restarts, and being told about them
@@ -314,13 +314,43 @@ That is the name it **starts** with. After that the name belongs to Claude
 Code, which keeps its own record of it (`<configDir>/sessions/<pid>.json`,
 with a `nameSource` saying who last set it — `user` for one someone typed,
 `derived` or `auto` for one Claude picked, `hook` for one a hook set). A
-session renamed in flight — by `/rename`, by a hook, or by Claude as the work
-takes shape — is renamed in corgi's list too: the launcher reads that record
-on every refresh and shows the current name, with *renamed 4m ago* beside it.
+session renamed in flight is renamed in corgi's list too: the launcher reads
+that record on every refresh and shows the current name, with *renamed 4m ago*
+beside it.
 
 What corgi cannot do is rename a session on claude.ai after the fact: the name
-in that list is the one remote control registered at start, which is why the
-starting name is worth composing well.
+in that list is the one remote control registered at start.
+
+### Naming a session after what you asked it
+
+A start-time name answers *which machine, which checkout, when*. It cannot
+answer the question you actually scan the list for — what is this session
+doing — because nothing knows that until you say it.
+
+`corgi agent hooks enable` writes a `UserPromptSubmit` hook for that: the
+first thing you ask becomes the name.
+
+```
+corgi · main · 18:55        →   corgi · fix the login redirect
+```
+
+The workspace stays in front, because claude.ai lists every session you have
+running on every machine and the ask alone does not say where. corgi's own
+list trims it back off — the card it sits on has already said which repo this
+is.
+
+It renames once, and only a name nobody chose: the one corgi composed (they
+all end in a clock) or the one Claude Code derived from the directory
+(`corgi-3e`). A name you typed from the phone, and the one this hook already
+set, are left alone — a session that renames itself on every prompt flickers
+through "ok", "continue", "now the tests", and a name that changes under you
+is worse than a dull one. Prompts that describe nothing — a slash command,
+"yes", "continue", anything under twelve characters — are ignored.
+
+Skip it with `corgi agent hooks enable --no-title`, and note that the
+`sessionTitle` field it replies with is in Claude Code's own hook schema but
+not in the published hooks reference: if a release stops reading it, the
+session keeps its starting name and nothing else changes.
 
 Name a session yourself and that wins — it says what the session is *for*,
 which no local probe can know:
@@ -436,9 +466,10 @@ per workspace and corgi tells you:
 
 ```bash
 cd ~/dev/your-stack
-corgi agent hooks enable        # writes the needs-you hook into .claude/settings.local.json
+corgi agent hooks enable        # writes the needs-you and naming hooks into .claude/settings.local.json
 corgi agent hooks enable --all  # or every registered workspace at once, from anywhere
 corgi agent hooks enable --all --turns   # also ping on every finished turn (noisy)
+corgi agent hooks enable --no-title      # skip the one that names a session after your first ask
 ```
 
 Only the permission prompt notifies by default: it blocks the session until you

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude how to use the corgi CLI: author corgi-compose.yml, start a stack (or a slice) detached and wait until healthy, debug a misbehaving stack local-first then escalate to its logs/analytics provider, interpret doctor/status output, generate (or fix) the CI pipeline that boots the whole stack and runs cross-repo e2e on every PR (GitHub Actions or GitLab CI, with caching, health gates, and log artifacts), plan from the tracker (Linear/Jira) with standup/triage/epic-decompose tied to real PR+CI state across services, pick up build-ready tickets (explicit links or the `agent`-labelled queue) and dispatch them to stories, suggest ranked evidence-backed product + engineering improvements, ship batches of tracker issues or a feature description across the workspace as tested, reviewed draft PRs/MRs, review existing GitHub/GitLab PRs/MRs against repo standards with inline suggestions, and run a supervised autopilot loop that drains the agent ticket queue into draft PRs with one spec gate per batch, a heartbeat, and a kill switch, plus a committed workspace-memory store the skills read before acting and append to (confirmed) after a notable fix, and run suggest proactively on a schedule to auto-propose (or, opt-in, auto-file as a draft) one rate-limited tracker ticket for the top win, and measuring and reducing the cyclomatic complexity of changed code (a gate the stories and review skills apply to every diff).",
-  "version": "1.21.28",
+  "version": "1.21.29",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"


### PR DESCRIPTION
The two follow-ups left over from #62.

## 1. A session gets named after the first thing you ask it

A start-time name — `corgi · main · 18:55` — answers *which machine, which checkout, when*. It cannot answer the question you actually scan the list for, which is what the session is **doing**, because nothing knows that until you say it.

`corgi agent hooks enable` now writes a `UserPromptSubmit` hook alongside the needs-you one:

```
corgi · main · 18:55        →   corgi · fix the login redirect
```

- The workspace stays in front: claude.ai lists every session on every machine, and the ask alone does not say where. corgi's own list trims it back off, since the card has already said which repo this is.
- **It renames once**, and only a name nobody chose: one corgi composed (they all end in a clock — that is what tells them apart from a title made from an ask) or one Claude Code derived from the directory (`corgi-3e`). A name typed from the phone, and the one this hook already wrote, are left alone — a session that renames itself every prompt flickers through "ok", "continue", "now the tests", and a name that changes under you is worse than a dull one.
- Prompts that describe nothing are ignored: a slash command, a continuation word ("yes", "continue", "do it"), anything under twelve characters. Control characters never reach the title, and it is capped at the 60 characters claude.ai shows.
- `--no-title` skips it.

**On the risk:** the `sessionTitle` field is in Claude Code's own hook schema but *not* in the published hooks reference. The hook is built so a release that stops reading it costs nothing — it prints a title, exits 0, and never blocks a prompt or fails a turn; the session just keeps its starting name.

Driven through the real binary as Claude Code would invoke it:

```
$ echo '{"prompt":"add a wake lock for the preview tunnels","session_title":"corgi · main · 18:55"}' \
    | corgi agent hook --workspace corgi title
{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","sessionTitle":"corgi · add a wake lock for the preview tunnels"}}

$ echo '{"prompt":"now write the tests for it","session_title":"corgi · add a wake lock for the preview tunnels"}' \
    | corgi agent hook --workspace corgi title
(nothing — already named)
```

## 2. The recycled-pid check now works on macOS

#62 stopped a stale session record from counting as live when its pid came round again after a reboot — but only on Linux, so the machines most of this runs on still showed the phantom.

Claude Code records the start time as `ps -o lstart= -p <pid>` under `LC_ALL=C`/`TZ=UTC` on darwin and `/proc/<pid>/stat` field 22 on linux. corgi now reads whichever applies and compares the same string.

- Readings are cached for a minute: a process's start time never changes, and this list is polled every second while a session starts, so the darwin path costs at most one `ps` per pid per minute.
- Comparison normalises internal spacing first — `ps` pads a single-digit day (`Sep  3`) — because a live session vanishing from the phone over a space would be a worse bug than the stale record this catches.
- Where the start time cannot be read at all (Windows, a failed read), a live pid is still the answer, exactly as before.

## Tests

- `cmd/agent_hook_title_test.go` — the naming rules: first ask wins, a chosen name is left alone, the names nobody chose are replaceable, trivial prompts and slash commands are ignored, the title fits the list, control characters are stripped, and junk input produces no output at all.
- `cmd/agent_hooks_idle_test.go` — enable writes the hook for the right workspace without notification flags, `--no-title` takes it back without touching the needs-you hook, and disable removes everything corgi wrote.
- `cmd/mcp_launcher_test.go` — the start-token cache answers twice, and `ps` padding does not make one process look like another.

`go build ./...`, `go vet ./cmd/... ./utils/...` and `go test ./cmd` pass. The 6 failures in `./utils` are pre-existing on `main` in this container (`gh` not installed; one test that needs a non-root user).

Version: `1.21.28` → `1.21.29`.