### PR TITLE
agent: publish the window in front and the session the user sees in it

### DIFF
--- a/cmd/agent_sessions.go
+++ b/cmd/agent_sessions.go
@@ -100,7 +100,7 @@ var agentRescanCmd = &cobra.Command{
 
 var agentNewCmd = &cobra.Command{
 	Use:   "new",
-	Short: "Open a new Claude Code session in the last-focused editor window",
+	Short: "Open a new Claude Code session in the editor window in front",
 	Long: `Asks the corgi VS Code extension to open a fresh integrated terminal in
 an editor window and run claude in it: the window named with --window, else
 the one the last focus landed in, else the most recently connected. The new
@@ -362,7 +362,7 @@ func runAgentWindows(_ *cobra.Command, _ []string) {
 func init() {
 	agentSessionsCmd.Flags().Bool("watch", false, "Redraw the board whenever it changes")
 	agentPinCmd.Flags().Bool("off", false, "Release the key instead")
-	agentNewCmd.Flags().String("window", "", "Editor window id, as `corgi agent windows` lists them (default: the last focused)")
+	agentNewCmd.Flags().String("window", "", "Editor window id, as `corgi agent windows` lists them (default: the one in front)")
 	agentCmd.AddCommand(agentSessionsCmd, agentFocusCmd, agentPinCmd, agentPageCmd, agentRescanCmd, agentWindowsCmd, agentNewCmd)
 }
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -287,7 +287,7 @@ corgi agent serve --foreground   # run it in this terminal and watch
 | `corgi agent focus <session>` | bring that session's window to the front and reveal its terminal tab |
 | `corgi agent pin <key> [--off]` / `page` / `rescan` / `windows` | reserve a key, turn the overflow page, adopt untracked sessions, list connected editor windows |
 | `corgi agent board [--slots N]` | the board's size, or set it — applied to a running daemon at once |
-| `corgi agent new [--window ID]` | open a new Claude session in the last-focused editor window (the "+" key) |
+| `corgi agent new [--window ID]` | open a new Claude session in the editor window in front (the "+" key) |
 | `corgi agent stop` | stop the daemon |
 
 ## Restarts, and being told about them
@@ -653,8 +653,9 @@ things, all of them files or commands, nothing to pair or authenticate:
 | the totals | `needsInput`, `working`, `overflow` at the top level |
 | a press | `corgi agent focus <sessionId>` · long press `corgi agent pin <key>` / `--off` · pager `corgi agent page next|prev` |
 | its key count | `corgi agent board --slots N` once; the next `sessions.json` has `size: N` |
-| an empty key pressed | `corgi agent new`: a fresh terminal running `claude` in the last-focused window (`lastFocusWindow`); a failure lands in `notice` / `noticeAt` |
+| an empty key pressed | `corgi agent new`: a fresh terminal running `claude` in the window in front (`frontWindow`, else `lastFocusWindow`); a failure lands in `notice` / `noticeAt` |
 | a failed press | `focusError` and `focusAt` on the slot, cleared by the session's next event |
+| a talk key pressed | `frontSession`: the session in the window in front (its active terminal tab, else its panel), so dictation lands without a key press first |
 
 Slot indexes never move unless paged or unpinned, so the plugin can map keys by
 `(row, column)` order and hold nothing else. From a phone, the same board is the
@@ -670,8 +671,9 @@ things, all of them files or commands, nothing to pair or authenticate:
 | the totals | `needsInput`, `working`, `overflow` at the top level |
 | a press | `corgi agent focus <sessionId>` · long press `corgi agent pin <key>` / `--off` · pager `corgi agent page next|prev` |
 | its key count | `corgi agent board --slots N` once; the next `sessions.json` has `size: N` |
-| an empty key pressed | `corgi agent new`: a fresh terminal running `claude` in the last-focused window (`lastFocusWindow`); a failure lands in `notice` / `noticeAt` |
+| an empty key pressed | `corgi agent new`: a fresh terminal running `claude` in the window in front (`frontWindow`, else `lastFocusWindow`); a failure lands in `notice` / `noticeAt` |
 | a failed press | `focusError` and `focusAt` on the slot, cleared by the session's next event |
+| a talk key pressed | `frontSession`: the session in the window in front (its active terminal tab, else its panel), so dictation lands without a key press first |
 
 Slot indexes never move unless paged or unpinned, so the plugin can map keys by
 `(row, column)` order and hold nothing else. From a phone, the same board is the

--- a/utils/agent/sessions/registry.go
+++ b/utils/agent/sessions/registry.go
@@ -40,8 +40,9 @@ type Registry struct {
 	// lastFocus is the window the last successful focus landed in: where
 	// a new session opens when nobody says otherwise.
 	lastFocus struct {
-		WindowID string
-		At       time.Time
+		WindowID  string
+		SessionID string
+		At        time.Time
 	}
 	notice   string
 	noticeAt time.Time
@@ -63,6 +64,12 @@ type State struct {
 	// LastFocusWindow is where the last successful focus went, and where
 	// `corgi agent new` opens a session by default.
 	LastFocusWindow string `json:"lastFocusWindow,omitempty"`
+	// FrontWindow is the connected window most recently in front, and
+	// FrontSession the session the user is looking at in it: the one in its
+	// active terminal tab, else its panel session, else the one that moved
+	// last. What a talk key dictates into without a key being pressed first.
+	FrontWindow  string `json:"frontWindow,omitempty"`
+	FrontSession string `json:"frontSession,omitempty"`
 	// Notice is the last board-level failure — a `new` with no window to
 	// open in, say — with its time, for a key to flash once.
 	Notice   string    `json:"notice,omitempty"`
@@ -533,6 +540,9 @@ func sameWindows(a, b map[string]Window) bool {
 		if !ok || !o.UpdatedAt.Equal(w.UpdatedAt) || o.ExtHostPID != w.ExtHostPID || len(o.Terminals) != len(w.Terminals) {
 			return false
 		}
+		if !o.FocusedAt.Equal(w.FocusedAt) || o.ActiveShellPID != w.ActiveShellPID {
+			return false
+		}
 	}
 	return true
 }
@@ -784,7 +794,7 @@ func (r *Registry) RecordFocus(id string, err error) {
 	}
 	s.FocusAt = time.Now()
 	if err == nil && s.Host.WindowID != "" {
-		r.lastFocus.WindowID, r.lastFocus.At = s.Host.WindowID, s.FocusAt
+		r.lastFocus.WindowID, r.lastFocus.SessionID, r.lastFocus.At = s.Host.WindowID, s.ID, s.FocusAt
 	}
 	if s.FocusError == msg && msg == "" {
 		return
@@ -809,21 +819,19 @@ func (r *Registry) SetNotice(err error) {
 var ErrNoWindow = errors.New("no editor window connected — open a folder in VS Code with the corgi extension installed")
 
 // NewSessionTarget picks the window a fresh session opens in: the one
-// named, else the one the last focus landed in, else the most recently
-// updated. The window must be connected: only its extension can open a
-// terminal in it.
+// named, else the one in front, else the most recently updated. The window
+// must be connected: only its extension can open a terminal in it.
 func (r *Registry) NewSessionTarget(windowID string) (FocusTarget, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var w Window
 	var ok bool
-	switch {
-	case windowID != "":
+	if windowID != "" {
 		if w, ok = r.windows[windowID]; !ok {
 			return FocusTarget{}, fmt.Errorf("window %s is not connected", windowID)
 		}
-	case r.lastFocus.WindowID != "":
-		w, ok = r.windows[r.lastFocus.WindowID]
+	} else {
+		w, ok = r.frontWindowLocked()
 	}
 	if !ok {
 		for _, cand := range r.sortedWindowsLocked() {
@@ -950,7 +958,67 @@ func (r *Registry) snapshotLocked(now time.Time) State {
 		}
 	}
 	st.Windows = r.sortedWindowsLocked()
+	if w, ok := r.frontWindowLocked(); ok {
+		st.FrontWindow = w.ID
+		if s := r.frontSessionLocked(w); s != nil {
+			st.FrontSession = s.ID
+		}
+	}
 	return st
+}
+
+// frontWindowLocked is the connected window most recently in front: the
+// newest focus its extension reported, or where corgi's own last focus
+// landed when that is newer. A lone window with no word either way is the
+// front one too.
+func (r *Registry) frontWindowLocked() (Window, bool) {
+	var best Window
+	found := false
+	for _, w := range r.sortedWindowsLocked() {
+		if !w.FocusedAt.IsZero() && (!found || w.FocusedAt.After(best.FocusedAt)) {
+			best, found = w, true
+		}
+	}
+	if w, ok := r.windows[r.lastFocus.WindowID]; ok && (!found || r.lastFocus.At.After(best.FocusedAt)) {
+		return w, true
+	}
+	if !found && len(r.windows) == 1 {
+		for _, w := range r.windows {
+			return w, true
+		}
+	}
+	return best, found
+}
+
+// frontSessionLocked is the session the user sees in a window: the one
+// corgi just focused there, until the window reports something newer; else
+// the one in its active terminal tab, else its panel session, else the one
+// that moved last. Nil when no live session is bound to the window.
+func (r *Registry) frontSessionLocked(w Window) *Session {
+	if r.lastFocus.WindowID == w.ID && r.lastFocus.At.After(w.FocusedAt) {
+		if s := r.sessions[r.lastFocus.SessionID]; s != nil && s.Status != StatusGone {
+			return s
+		}
+	}
+	var panel, latest *Session
+	for _, s := range r.sortedLocked() {
+		if s.Host.WindowID != w.ID || s.Status == StatusGone {
+			continue
+		}
+		if w.ActiveShellPID != 0 && s.Host.ShellPID == w.ActiveShellPID {
+			return s
+		}
+		if s.Host.Kind == HostVSCodePanel && (panel == nil || s.LastActivity.After(panel.LastActivity)) {
+			panel = s
+		}
+		if latest == nil || s.LastActivity.After(latest.LastActivity) {
+			latest = s
+		}
+	}
+	if panel != nil {
+		return panel
+	}
+	return latest
 }
 
 // displayLocked makes a label unique among live sessions: two sessions in

--- a/utils/agent/sessions/registry_test.go
+++ b/utils/agent/sessions/registry_test.go
@@ -695,3 +695,63 @@ func TestNewSessionTargetPrefersTheLastFocusedWindow(t *testing.T) {
 		t.Fatal("notice cleared")
 	}
 }
+
+func TestFrontSessionFollowsTheWindowInFront(t *testing.T) {
+	r := newTestRegistry(t)
+	if st := r.Snapshot(t0); st.FrontWindow != "" || st.FrontSession != "" {
+		t.Fatalf("nothing in front without windows: %+v", st)
+	}
+	tab := ev("Stop", "tab", 0)
+	tab.Window, tab.ClaudePID, tab.Ancestors = "w1", 101, []int{101, 90, 80}
+	r.Apply(tab)
+	panel := ev("Stop", "panel", time.Second)
+	panel.ClaudePID, panel.Ancestors = 102, []int{102, 7}
+	r.Apply(panel)
+	other := ev("Stop", "other", 2*time.Second)
+	other.Window, other.ClaudePID, other.Ancestors = "w2", 103, []int{103, 95, 80}
+	r.Apply(other)
+	w1 := Window{ID: "w1", App: "Visual Studio Code", ExtHostPID: 7, Folders: []string{"/f"}, Terminals: []Terminal{{Name: "zsh", ShellPID: 90}}, UpdatedAt: t0}
+	w2 := Window{ID: "w2", App: "Visual Studio Code", ExtHostPID: 8, Folders: []string{"/g"}, Terminals: []Terminal{{Name: "zsh", ShellPID: 95}}, UpdatedAt: t0.Add(time.Minute)}
+
+	r.SetWindows([]Window{w1, w2})
+	if st := r.Snapshot(t0); st.FrontWindow != "" || st.FrontSession != "" {
+		t.Fatalf("two windows and no focus word: nobody is in front: %+v", st)
+	}
+	if target, err := r.NewSessionTarget(""); err != nil || target.WindowID != "w2" {
+		t.Fatalf("new falls back to the most recently updated window: %+v %v", target, err)
+	}
+
+	w1.FocusedAt, w1.ActiveShellPID = t0.Add(time.Hour), 90
+	if !r.SetWindows([]Window{w1, w2}) {
+		t.Fatal("a focus change is a window change")
+	}
+	st := r.Snapshot(t0)
+	if st.FrontWindow != "w1" || st.FrontSession != "tab" {
+		t.Fatalf("the active tab's session is in front: %+v", st)
+	}
+	if target, _ := r.NewSessionTarget(""); target.WindowID != "w1" {
+		t.Fatalf("new opens in the window in front: %+v", target)
+	}
+
+	w1.ActiveShellPID = 91
+	r.SetWindows([]Window{w1, w2})
+	if st := r.Snapshot(t0); st.FrontSession != "panel" {
+		t.Fatalf("a tab with no session: the panel session is in front: %+v", st)
+	}
+
+	w2.FocusedAt = t0.Add(2 * time.Hour)
+	r.SetWindows([]Window{w1, w2})
+	if st := r.Snapshot(t0); st.FrontWindow != "w2" || st.FrontSession != "other" {
+		t.Fatalf("the newest focus wins: %+v", st)
+	}
+
+	r.RecordFocus("tab", nil)
+	if st := r.Snapshot(t0); st.FrontWindow != "w1" || st.FrontSession != "tab" {
+		t.Fatalf("corgi's own focus, being newer, wins: %+v", st)
+	}
+
+	r.SetWindows([]Window{w2})
+	if st := r.Snapshot(t0); st.FrontWindow != "w2" {
+		t.Fatalf("a lone window is the front one: %+v", st)
+	}
+}

--- a/utils/agent/sessions/session.go
+++ b/utils/agent/sessions/session.go
@@ -176,7 +176,12 @@ type Window struct {
 	ExtHostPID int        `json:"extHostPid"`
 	Folders    []string   `json:"folders,omitempty"`
 	Terminals  []Terminal `json:"terminals,omitempty"`
-	UpdatedAt  time.Time  `json:"updatedAt"`
+	// FocusedAt is when the window last came to the front, as its extension
+	// saw it; ActiveShellPID is the shell of its active terminal tab. Together
+	// they say which session the user is looking at.
+	FocusedAt      time.Time `json:"focusedAt,omitempty"`
+	ActiveShellPID int       `json:"activeShellPid,omitempty"`
+	UpdatedAt      time.Time `json:"updatedAt"`
 }
 
 // EditorFromChain names the editor whose process tree a session runs in,


### PR DESCRIPTION
## What

`corgi agent sessions --json` (and sessions.json) gain two fields:

- `frontWindow` — the connected editor window most recently in front: the newest `focusedAt` its extension reported, or where corgi's last focus landed when that is newer; a lone window counts.
- `frontSession` — the session the user sees in it: the one corgi just focused there (until the window reports something newer), else the session in the active terminal tab, else the panel session, else the one that moved last.

`corgi agent new` now opens in the window in front, falling back to the most recently updated one as before.

`Window` reads two new optional fields from the extension's record: `focusedAt`, `activeShellPid`. A change in either republishes the board.

## Why

The Stream Deck talk key had nothing to dictate into until a session key was pressed in the same plugin lifetime, and `+` could open in a stale window. Now corgi knows what is in front.

Pairs with Andriiklymiuk/corgi_vscode_extension (reports the fields) and Andriiklymiuk/agent-deck (reads `frontSession`).

## Tests

`go test -race ./utils/agent/...` — new `TestFrontSessionFollowsTheWindowInFront` covers tab / panel / newest-focus / own-focus / lone-window rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)