### PR TITLE
2.0.1 — the move keeps the old ignore rule instead of replacing it

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var APP_VERSION = "2.0.0"
+var APP_VERSION = "2.0.1"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/plugins/corgi/.claude-plugin/plugin.json
+++ b/plugins/corgi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "corgi",
   "description": "Teach Claude the corgi CLI: author compose files, run a stack until healthy, debug local first, generate ci for the stack, plan with the tracker, build stories into draft PRs, review PRs, ship mobile apps, run a supervised autopilot, watch issues and reviews, draw showcase images, and setup the machine end to end. Daily skills: resume, standup, prep pr, budget.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "Andrii Klymiuk",
     "url": "https://github.com/Andriiklymiuk"

--- a/utils/corgipaths.go
+++ b/utils/corgipaths.go
@@ -213,6 +213,11 @@ func runningContainers(containers []string) []string {
 	return up
 }
 
+// retargetGitignore adds a rule for the new path beside each rule for the old
+// one, and keeps the old rule. Replacing it would un-ignore the folder for
+// everyone on the team still running a corgi that puts it there, who would
+// pull the commit and find the whole thing untracked. A repository already
+// ignoring .corgi/ needs nothing.
 func retargetGitignore(composeDir string) {
 	path := filepath.Join(composeDir, ".gitignore")
 	data, err := os.ReadFile(path)
@@ -221,22 +226,66 @@ func retargetGitignore(composeDir string) {
 	}
 	nested := CorgiDirName + "/" + CorgiServicesName
 	lines := strings.Split(string(data), "\n")
-	changed := false
-	for i, line := range lines {
-		bare := strings.TrimSpace(line)
-		negate := strings.HasPrefix(bare, "!")
-		bare = strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(bare, "!"), "/"), "./")
-		if bare != CorgiServicesName && !strings.HasPrefix(bare, CorgiServicesName+"/") {
-			continue
-		}
-		lines[i] = nested + strings.TrimPrefix(bare, CorgiServicesName)
-		if negate {
-			lines[i] = "!" + lines[i]
-		}
-		changed = true
-	}
-	if !changed {
+	if ignoresCorgiDir(lines) || hasRule(lines, nested) {
 		return
 	}
-	_ = os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
+	out := make([]string, 0, len(lines)+2)
+	added := false
+	for _, line := range lines {
+		bare, negate, ok := legacyRule(line)
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		rule := nested + strings.TrimPrefix(bare, CorgiServicesName)
+		if negate {
+			rule = "!" + rule
+		}
+		if !hasRule(out, rule) {
+			out = append(out, rule)
+			added = true
+		}
+		out = append(out, line)
+	}
+	if !added {
+		return
+	}
+	_ = os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o644)
+}
+
+// legacyRule reads a line naming the old top-level folder: the bare path, and
+// whether the rule un-ignores rather than ignores.
+func legacyRule(line string) (bare string, negate bool, ok bool) {
+	bare = strings.TrimSpace(line)
+	negate = strings.HasPrefix(bare, "!")
+	bare = strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(bare, "!"), "/"), "./")
+	if bare != CorgiServicesName && !strings.HasPrefix(bare, CorgiServicesName+"/") {
+		return "", false, false
+	}
+	return bare, negate, true
+}
+
+// ignoresCorgiDir says the whole .corgi/ is already ignored, which covers the
+// folder wherever inside it corgi puts things.
+func ignoresCorgiDir(lines []string) bool {
+	for _, line := range lines {
+		bare := strings.TrimSpace(line)
+		if strings.HasPrefix(bare, "!") {
+			continue
+		}
+		bare = strings.TrimSuffix(strings.TrimPrefix(strings.TrimPrefix(bare, "/"), "./"), "/")
+		if bare == CorgiDirName {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRule(lines []string, rule string) bool {
+	for _, line := range lines {
+		if strings.TrimSpace(line) == rule {
+			return true
+		}
+	}
+	return false
 }

--- a/utils/corgipaths_test.go
+++ b/utils/corgipaths_test.go
@@ -60,7 +60,13 @@ func TestMigrateMovesTheFolderAndRetargetsGitignore(t *testing.T) {
 		t.Errorf("content did not come along: %v", err)
 	}
 	ignore, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	for _, want := range []string{"node_modules", ".corgi/corgi_services/*", "!.corgi/corgi_services/.gitignore"} {
+	// The old rules stay: dropping them un-ignores the folder for anyone on
+	// the team whose corgi still puts it there.
+	for _, want := range []string{
+		"node_modules",
+		".corgi/corgi_services/*", "corgi_services/*",
+		"!.corgi/corgi_services/.gitignore", "!corgi_services/.gitignore",
+	} {
 		if !strings.Contains(string(ignore), want) {
 			t.Errorf("missing %q in\n%s", want, ignore)
 		}
@@ -225,5 +231,40 @@ func TestMigrateRepairsMovedWorktrees(t *testing.T) {
 	want := filepath.Join(root, ".corgi", "corgi_services", ".worktrees", "api-feature-x")
 	if !strings.Contains(string(out), want) {
 		t.Errorf("the repo should point at the new path %q:\n%s", want, out)
+	}
+}
+
+func TestGitignoreGainsTheNewPathWithoutLosingTheOld(t *testing.T) {
+	migrateWith := func(t *testing.T, ignore string) string {
+		t.Helper()
+		dir := t.TempDir()
+		os.MkdirAll(filepath.Join(dir, "corgi_services"), 0o755)
+		os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(ignore), 0o644)
+		if _, err := MigrateCorgiServices(dir); err != nil {
+			t.Fatal(err)
+		}
+		out, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
+		return string(out)
+	}
+
+	got := migrateWith(t, "node_modules\ncorgi_services/*\n")
+	if want := "node_modules\n.corgi/corgi_services/*\ncorgi_services/*\n"; got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+
+	// A repository already ignoring .corgi/ has the new path covered.
+	whole := "node_modules\ncorgi_services/*\n.corgi/\n"
+	if got := migrateWith(t, whole); got != whole {
+		t.Errorf("an ignored .corgi/ needs no rule, got:\n%q", got)
+	}
+
+	// Running twice must not stack duplicates.
+	twice := migrateWith(t, ".corgi/corgi_services/*\ncorgi_services/*\n")
+	if strings.Count(twice, ".corgi/corgi_services/*") != 1 {
+		t.Errorf("the rule was added again:\n%q", twice)
+	}
+
+	if got := migrateWith(t, "node_modules\n"); got != "node_modules\n" {
+		t.Errorf("a file naming neither path is left alone, got %q", got)
 	}
 }


### PR DESCRIPTION
Migration rewrote `corgi_services/*` into `.corgi/corgi_services/*`. Whoever
committed that un-ignored the old path for every teammate whose corgi still
puts the folder there:

```
you            corgi 2.0  → folder at .corgi/corgi_services/, commit the rewrite
teammate       corgi 1.21 → folder still at corgi_services/
               git status → hundreds of untracked files, through no fault of theirs
```

## After

The new rule is added *beside* the old one, negations included:

```diff
 node_modules
+.corgi/corgi_services/*
 corgi_services/*
+!.corgi/corgi_services/.gitignore
 !corgi_services/.gitignore
 .env*
```

Both layouts stay ignored, so it does not matter which corgi anyone is on.

Two cases it now handles that it did not:

- **`.corgi/` already ignored** — the new path is covered without a rule of
  its own, so the file is left untouched. This is what a repo here already
  had, and the old code added a redundant line to it.
- **Run twice** — the second run adds nothing.

## Checks

- 2857 tests pass, `go vet` and `gofmt` clean.
- New: both rules kept, negations paired, the `.corgi/` shortcut, idempotence,
  and a file naming neither path left alone.
- Ran the built binary on a scratch repo; the diff above is its real output.