### PR TITLE
Wave 1: ignore sticks everywhere, one Documents prompt, corgi-bar at login, limits are quota or overload, daemon auto-continue

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -138,9 +138,13 @@ func runAgentServe(cmd *cobra.Command, _ []string) {
 	// by corgi profile, and size the board as the user config says.
 	d.Sessions.Resolve = workspaceResolver(dir)
 	d.Sessions.ProfileFor = profileResolver(dir)
-	if user, uerr := config.LoadUser(agentUserConfigPath(dir)); uerr == nil && user != nil && strings.TrimSpace(user.DigestAt) != "" {
-		d.DigestAt = strings.TrimSpace(user.DigestAt)
-		d.Digest = func(now time.Time) string { return digestText(dir, now) }
+	if user, uerr := config.LoadUser(agentUserConfigPath(dir)); uerr == nil && user != nil {
+		if strings.TrimSpace(user.DigestAt) != "" {
+			d.DigestAt = strings.TrimSpace(user.DigestAt)
+			d.Digest = func(now time.Time) string { return digestText(dir, now) }
+		}
+		d.AutoContinue = user.AutoContinue
+		d.Sessions.AutoContinue = user.AutoContinue
 	}
 	d.AccountDirs = func() []string {
 		profiles, err := loadProfiles(dir)

--- a/cmd/agent_at_login.go
+++ b/cmd/agent_at_login.go
@@ -81,6 +81,7 @@ func enableAtLogin(dir string, settings *upSettings) {
 	}
 	setAtLogin(dir, settings, true)
 	utils.Info("✓ starts at login — after a reboot the daemon, the MCP endpoint and this tunnel come back on their own")
+	startMenuBarIfInstalled(func(s string) { utils.Info(s) })
 	// Coming back at login is only half of being reachable: a sleeping laptop
 	// answers nothing, and between sessions nothing holds it awake.
 	if !stayAwakeEnabled(dir) {

--- a/cmd/agent_continue.go
+++ b/cmd/agent_continue.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/config"
+	"github.com/spf13/cobra"
+)
+
+// A session that hit a limit waits on a clock. The editor extension can type
+// "continue" when the window resets, but only while the editor is open; the
+// daemon can do it from anywhere. Off by default because it types into a
+// terminal that is yours.
+var agentContinueCmd = &cobra.Command{
+	Use:   "continue [on|off]",
+	Short: "Let the daemon continue a limited session when its limit is over",
+	Long: `A session that hit a usage limit is waiting on a clock, not on you. With this
+on, the daemon plans a resume from the account's reset time (or a few minutes
+after an overload), types "continue" once the numbers say the window is back,
+and gives up after a few tries if the limit comes straight back.
+
+  corgi agent continue on
+  corgi agent continue off
+  corgi agent continue        what is set now
+
+The board shows the plan on the key ("continues 14:02"). The VS Code extension
+has the same feature; when the daemon does it, the extension stands down.`,
+	Args: cobra.MaximumNArgs(1),
+	Run:  runAgentContinue,
+}
+
+var autoContinueLine = regexp.MustCompile(`(?m)^autoContinue:.*$`)
+
+func runAgentContinue(_ *cobra.Command, args []string) {
+	dir, err := agentDir()
+	if err != nil {
+		exitWithError("agent_data_dir", err, 1)
+	}
+	path := agentUserConfigPath(dir)
+	if len(args) == 0 {
+		user, err := config.LoadUser(path)
+		if err != nil || user == nil || !user.AutoContinue {
+			utils.Infof("autoContinue is off (%s) — a limited session waits for you\n", path)
+			utils.Info("turn it on with `corgi agent continue on`")
+			return
+		}
+		utils.Infof("autoContinue is on (%s) — the daemon continues limited sessions when their window resets\n", path)
+		return
+	}
+	on, err := parseOnOff(args[0])
+	if err != nil {
+		exitWithError(utils.ErrUsage, err, 2)
+		return
+	}
+	if err := writeUserConfigLine(path, autoContinueLine, fmt.Sprintf("autoContinue: %t", on)); err != nil {
+		exitWithError("agent_continue", err, 1)
+		return
+	}
+	if on {
+		utils.Infof("✓ autoContinue: true in %s\n", path)
+		utils.Info("the daemon will type \"continue\" into a limited session once its window resets")
+	} else {
+		utils.Infof("✓ autoContinue: false in %s\n", path)
+	}
+	utils.Info("run `corgi agent restart` so the running daemon picks it up")
+}
+
+// writeUserConfigLine edits one line of the hand-edited config, like
+// writeStayAwake: a marshal round-trip would flatten the comments.
+func writeUserConfigLine(path string, line *regexp.Regexp, value string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot read %s: %v", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	body := string(data)
+	switch {
+	case line.MatchString(body):
+		body = line.ReplaceAllString(body, value)
+	case strings.TrimSpace(body) == "":
+		body = value + "\n"
+	default:
+		body = strings.TrimRight(body, "\n") + "\n" + value + "\n"
+	}
+	return os.WriteFile(path, []byte(body), 0o600)
+}
+
+func init() {
+	agentCmd.AddCommand(agentContinueCmd)
+}

--- a/cmd/agent_install.go
+++ b/cmd/agent_install.go
@@ -141,10 +141,16 @@ func installLoginService() error {
 	if err != nil {
 		return err
 	}
-	// Deliberately NOT EvalSymlinks. Homebrew installs corgi as a symlink into
-	// a versioned Cellar directory; resolving it would bake that version into
-	// the service file, and the next `brew upgrade corgi` would delete the path
-	// and agent mode would silently stop starting at login.
+	// Deliberately NOT EvalSymlinks on Linux. Homebrew installs corgi as a
+	// symlink into a versioned directory; resolving it would bake that version
+	// into the service file, and the next upgrade would delete the path and
+	// agent mode would silently stop starting at login. macOS goes further and
+	// runs its own copy, see agent_install_stable.go.
+	if daemonRunsFromStableCopy() {
+		if binary, err = refreshStableDaemonBinary(binary); err != nil {
+			return fmt.Errorf("copy corgi for the daemon: %w", err)
+		}
+	}
 
 	logDir, err := agentDir()
 	if err != nil {

--- a/cmd/agent_install_stable.go
+++ b/cmd/agent_install_stable.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+// On macOS the daemon runs from its own copy of the binary, at a path that
+// never changes. launchd resolves /opt/homebrew/bin/corgi to the versioned
+// Caskroom directory, and macOS keys "corgi wants access to Documents" on
+// that real path — so every `corgi upd` looked like a new tool and asked
+// again at the next login. A stable path with a stable signing identity is
+// asked once. Linux has no such prompt and keeps the symlink.
+
+func stableDaemonBinary() (string, error) {
+	base, err := utils.NativeDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "bin", "corgi"), nil
+}
+
+func daemonRunsFromStableCopy() bool {
+	return runtime.GOOS == "darwin"
+}
+
+// refreshStableDaemonBinary copies the binary at from into the stable path
+// unless the copy already matches byte for byte. Returns the stable path.
+func refreshStableDaemonBinary(from string) (string, error) {
+	dest, err := stableDaemonBinary()
+	if err != nil {
+		return "", err
+	}
+	if real, err := filepath.EvalSymlinks(from); err == nil {
+		from = real
+	}
+	if same, _ := sameFileContent(from, dest); same {
+		return dest, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return "", err
+	}
+	src, err := os.Open(from)
+	if err != nil {
+		return "", err
+	}
+	defer src.Close()
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".corgi-*")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	if _, err := io.Copy(tmp, src); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	// A running daemon keeps its old inode open; the rename swaps the path
+	// under it without touching the process.
+	if err := os.Rename(tmpPath, dest); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	return dest, nil
+}
+
+func sameFileContent(a, b string) (bool, error) {
+	ha, err := fileDigest(a)
+	if err != nil {
+		return false, err
+	}
+	hb, err := fileDigest(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(ha, hb), nil
+}
+
+func fileDigest(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+// installedDaemonBinary is the program the login service file names, or ""
+// when there is no service file or it cannot be read.
+func installedDaemonBinary() string {
+	path := loginServicePath()
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return programFromServiceFile(string(data))
+}
+
+// programFromServiceFile pulls the executable out of a launchd plist or a
+// systemd unit without a full parser: the first <string> after
+// ProgramArguments, or the first word of ExecStart.
+func programFromServiceFile(text string) string {
+	if i := strings.Index(text, "<key>ProgramArguments</key>"); i >= 0 {
+		rest := text[i:]
+		if j := strings.Index(rest, "<string>"); j >= 0 {
+			rest = rest[j+len("<string>"):]
+			if k := strings.Index(rest, "</string>"); k >= 0 {
+				return strings.TrimSpace(rest[:k])
+			}
+		}
+		return ""
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "ExecStart=") {
+			fields := strings.Fields(strings.TrimPrefix(strings.TrimSpace(line), "ExecStart="))
+			if len(fields) > 0 {
+				return fields[0]
+			}
+		}
+	}
+	return ""
+}
+
+const checkDaemonBinary = "daemon binary"
+
+// checkDaemonBinaryPath is the doctor's answer to "why does macOS keep
+// asking about Documents": the service runs corgi from a path that changes
+// with every update, or from a copy older than the corgi you have.
+func checkDaemonBinaryPath() agentCheck {
+	if !daemonRunsFromStableCopy() || !loginServiceInstalled() {
+		return agentCheck{Name: checkDaemonBinary, OK: true, Detail: "not applicable"}
+	}
+	program := installedDaemonBinary()
+	stable, err := stableDaemonBinary()
+	if err != nil {
+		return agentCheck{Name: checkDaemonBinary, Detail: err.Error()}
+	}
+	if program != stable {
+		return agentCheck{
+			Name:   checkDaemonBinary,
+			Detail: fmt.Sprintf("the login service runs %s — a path that changes with every update, so macOS asks for Documents access again after each one", program),
+			Fix:    "`corgi agent install` moves the daemon to a stable copy; one prompt, then never again",
+		}
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return agentCheck{Name: checkDaemonBinary, OK: true, Detail: stable}
+	}
+	if real, err := filepath.EvalSymlinks(self); err == nil {
+		self = real
+	}
+	if self == stable {
+		return agentCheck{Name: checkDaemonBinary, OK: true, Detail: stable}
+	}
+	if same, err := sameFileContent(self, stable); err == nil && !same {
+		return agentCheck{
+			Name:   checkDaemonBinary,
+			Detail: "the daemon's copy is not the corgi you are running — it was installed before the last update",
+			Fix:    "`corgi agent install` refreshes the copy and restarts the daemon",
+		}
+	}
+	return agentCheck{Name: checkDaemonBinary, OK: true, Detail: stable + " (current)"}
+}

--- a/cmd/agent_install_stable_test.go
+++ b/cmd/agent_install_stable_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The daemon's binary path must not change between updates, or macOS asks
+// for Documents access again at the next login. So it is a copy, refreshed
+// only when the bytes differ, swapped in by rename under a running daemon.
+func TestDaemonRunsFromAStableCopy(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("CORGI_DATA_DIR", data)
+	src := filepath.Join(t.TempDir(), "corgi")
+	if err := os.WriteFile(src, []byte("v1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "corgi")
+	if err := os.Symlink(src, link); err != nil {
+		t.Fatal(err)
+	}
+
+	dest, err := refreshStableDaemonBinary(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dest != filepath.Join(data, "bin", "corgi") {
+		t.Fatalf("the copy lives under the data dir, got %s", dest)
+	}
+	if got, _ := os.ReadFile(dest); string(got) != "v1" {
+		t.Fatalf("copy has %q", got)
+	}
+	if info, _ := os.Stat(dest); info.Mode()&0o111 == 0 {
+		t.Fatal("the copy has to be executable")
+	}
+	if info, _ := os.Lstat(dest); info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("a symlink would resolve to the versioned path again")
+	}
+
+	first, _ := os.Stat(dest)
+	if _, err := refreshStableDaemonBinary(link); err != nil {
+		t.Fatal(err)
+	}
+	if again, _ := os.Stat(dest); !again.ModTime().Equal(first.ModTime()) {
+		t.Fatal("an unchanged binary is not rewritten")
+	}
+
+	if err := os.WriteFile(src, []byte("v2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := refreshStableDaemonBinary(link); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(dest); string(got) != "v2" {
+		t.Fatal("an update refreshes the copy")
+	}
+}
+
+func TestProgramFromServiceFile(t *testing.T) {
+	plist := renderedLaunchdPlist("/Users/me/Library/Application Support/corgi/bin/corgi", "/o", "/e", nil)
+	if got := programFromServiceFile(plist); got != "/Users/me/Library/Application Support/corgi/bin/corgi" {
+		t.Fatalf("plist program: %q", got)
+	}
+	unit := renderedSystemdUnit("/usr/local/bin/corgi", nil)
+	if got := programFromServiceFile(unit); got != "/usr/local/bin/corgi" {
+		t.Fatalf("unit program: %q", got)
+	}
+	if !strings.Contains(plist, "bin/corgi") {
+		t.Fatal("sanity")
+	}
+}

--- a/cmd/agent_menubar.go
+++ b/cmd/agent_menubar.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// The menu bar app is its own program with its own login item; corgi only
+// knows whether it is installed and running, and can open it. Opening it once
+// is enough for login: corgi-bar turns its login item on the first time it
+// runs from /Applications.
+const menuBarAppPath = "/Applications/corgi-bar.app"
+
+var lookForMenuBar = func() (installed, running bool) {
+	if runtime.GOOS != "darwin" {
+		return false, false
+	}
+	if _, err := os.Stat(menuBarAppPath); err != nil {
+		return false, false
+	}
+	out, err := exec.Command("pgrep", "-x", "corgi-bar").Output()
+	return true, err == nil && strings.TrimSpace(string(out)) != ""
+}
+
+var openMenuBar = func() error {
+	return exec.Command("open", "-g", "-a", menuBarAppPath).Run()
+}
+
+// startMenuBarIfInstalled opens corgi-bar when it is installed and not up,
+// so `agent up --at-login` leaves the whole setup coming back after a reboot,
+// not just the daemon. Says nothing when the app is not installed: the menu
+// bar is optional, and setup already offers it.
+func startMenuBarIfInstalled(say func(string)) {
+	installed, running := lookForMenuBar()
+	if !installed || running {
+		return
+	}
+	if err := openMenuBar(); err != nil {
+		say("⚠ could not open corgi-bar: " + err.Error())
+		return
+	}
+	say("✓ opened corgi-bar — it starts at login from now on (Settings › App to change)")
+}
+
+const checkMenuBar = "menu bar"
+
+func checkMenuBarApp() agentCheck {
+	if runtime.GOOS != "darwin" {
+		return agentCheck{Name: checkMenuBar, OK: true, Detail: "not applicable"}
+	}
+	installed, running := lookForMenuBar()
+	switch {
+	case !installed:
+		return agentCheck{Name: checkMenuBar, OK: true, Detail: "corgi-bar not installed (optional)", Fix: "`brew install --cask andriiklymiuk/tools/corgi-bar`"}
+	case !running:
+		return agentCheck{Name: checkMenuBar, OK: true, Detail: "corgi-bar installed, not running", Fix: "`open -a corgi-bar` — its first run turns login start on"}
+	}
+	return agentCheck{Name: checkMenuBar, OK: true, Detail: "corgi-bar running"}
+}

--- a/cmd/agent_menubar_test.go
+++ b/cmd/agent_menubar_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// `agent up --at-login` opens the menu bar once when it is installed and not
+// running — its first run registers the login item — and stays quiet about
+// an app that is not installed.
+func TestAtLoginOpensTheMenuBarOnceWhenInstalled(t *testing.T) {
+	origLook, origOpen := lookForMenuBar, openMenuBar
+	defer func() { lookForMenuBar, openMenuBar = origLook, origOpen }()
+	opened := 0
+	openMenuBar = func() error { opened++; return nil }
+
+	var said []string
+	say := func(s string) { said = append(said, s) }
+
+	lookForMenuBar = func() (bool, bool) { return false, false }
+	startMenuBarIfInstalled(say)
+	lookForMenuBar = func() (bool, bool) { return true, true }
+	startMenuBarIfInstalled(say)
+	if opened != 0 || len(said) != 0 {
+		t.Fatalf("not installed or already running: nothing to do, got opened=%d said=%v", opened, said)
+	}
+
+	lookForMenuBar = func() (bool, bool) { return true, false }
+	startMenuBarIfInstalled(say)
+	if opened != 1 || len(said) != 1 || !strings.Contains(said[0], "login") {
+		t.Fatalf("installed and down: open it and say so, got opened=%d said=%v", opened, said)
+	}
+}

--- a/cmd/agent_sessions.go
+++ b/cmd/agent_sessions.go
@@ -294,9 +294,15 @@ func formatSlot(sl sessions.Slot) string {
 	if sl.Stuck {
 		word = "SLOW"
 	}
+	if sl.Status == sessions.StatusLimited && sl.Limit == sessions.LimitOverload {
+		word = "OVERLOAD"
+	}
 	line := fmt.Sprintf("%s %s %s %-18s %-10s", key, pin, statusGlyph(sl.Status), clipTitle(sl.Label, 18), word)
 	if detail := firstNonEmpty(sl.Note, sl.Detail); detail != "" {
 		line += " " + clipTitle(detail, 24)
+	}
+	if !sl.ResumeAt.IsZero() {
+		line += " · continues " + sl.ResumeAt.Local().Format("15:04")
 	}
 	line += "  " + sl.Profile + " · " + string(sl.Host)
 	if sl.Context > 0 {

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -438,7 +438,7 @@ func anyCheckFailed(checks []agentCheck) bool {
 func collectAgentChecks() []agentCheck {
 	var checks []agentCheck
 
-	checks = append(checks, checkClaudeBinary(), checkAmbientAPIKey(), checkWakeLockSupport(), checkInstallSupport())
+	checks = append(checks, checkClaudeBinary(), checkAmbientAPIKey(), checkWakeLockSupport(), checkInstallSupport(), checkDaemonBinaryPath())
 
 	dir, err := agentDir()
 	if err != nil {

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -438,7 +438,7 @@ func anyCheckFailed(checks []agentCheck) bool {
 func collectAgentChecks() []agentCheck {
 	var checks []agentCheck
 
-	checks = append(checks, checkClaudeBinary(), checkAmbientAPIKey(), checkWakeLockSupport(), checkInstallSupport(), checkDaemonBinaryPath())
+	checks = append(checks, checkClaudeBinary(), checkAmbientAPIKey(), checkWakeLockSupport(), checkInstallSupport(), checkDaemonBinaryPath(), checkMenuBarApp())
 
 	dir, err := agentDir()
 	if err != nil {

--- a/cmd/agent_watch_ignore.go
+++ b/cmd/agent_watch_ignore.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/watch"
+	"github.com/spf13/cobra"
+)
+
+var agentWatchIgnoreCmd = &cobra.Command{
+	Use:   "ignore <REF|key>",
+	Short: "Take a ticket out of the inbox for good",
+	Long: `Drops every inbox row for a ticket, and stops the unattended mode picking it
+up. Writes nothing to the tracker: this is your decision, kept on this machine
+and shared by the phone, the menu bar and the editor.
+
+  corgi agent watch ignore ABC-123
+  corgi agent watch ignore acme/api#42 --workspace api
+  corgi agent watch unignore ABC-123
+
+A REF is what the inbox shows; a key (linear:ABC-123:comment:…) is what --json
+prints, for a surface that already has one.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runIgnore(cmd, args[0], true)
+	},
+}
+
+var agentWatchUnignoreCmd = &cobra.Command{
+	Use:   "unignore <REF|key>",
+	Short: "Put an ignored ticket back in the inbox",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runIgnore(cmd, args[0], false)
+	},
+}
+
+func runIgnore(cmd *cobra.Command, arg string, ignore bool) {
+	dir := mustAgentDir()
+	workspace, _ := cmd.Flags().GetString("workspace")
+	keys := inboxKeysFor(dir, arg, workspace)
+	if len(keys) == 0 {
+		exitWithError("agent_watch_ignore", fmt.Errorf("nothing in the inbox matches %q", arg), 2)
+	}
+	state := watch.LoadState(dir)
+	for _, k := range keys {
+		var err error
+		if ignore {
+			err = state.Ignore(k)
+		} else {
+			err = state.Unignore(k)
+		}
+		if err != nil {
+			exitWithError("agent_watch_ignore", err, 1)
+		}
+	}
+	verb := "ignored"
+	if !ignore {
+		verb = "back in the inbox"
+	}
+	said := fmt.Sprintf("%s %s (%s)", arg, verb, plural(len(keys), "row", "rows"))
+	if utils.JSONOutput {
+		utils.PrintJSON(map[string]any{"ref": arg, "keys": keys, "ignored": ignore})
+		return
+	}
+	fmt.Println(said)
+}
+
+// inboxKeysFor is every logged event key for a ticket, newest first. An
+// exact key wins; otherwise every recent event whose ref matches, so
+// "ignore ABC-123" covers the issue and all of its comments.
+func inboxKeysFor(dir, arg, workspace string) []string {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return nil
+	}
+	if e, ok := watch.FindEvent(dir, arg); ok {
+		return []string{e.Key}
+	}
+	var keys []string
+	for _, e := range watch.RecentEvents(dir, 500) {
+		if !strings.EqualFold(e.Ref, arg) {
+			continue
+		}
+		if workspace != "" && e.Workspace != workspace {
+			continue
+		}
+		keys = append(keys, e.Key)
+	}
+	return keys
+}
+
+func init() {
+	for _, c := range []*cobra.Command{agentWatchIgnoreCmd, agentWatchUnignoreCmd} {
+		c.Flags().String("workspace", "", "only this workspace's rows, when a ref exists in two")
+	}
+	agentWatchCmd.AddCommand(agentWatchIgnoreCmd, agentWatchUnignoreCmd)
+}

--- a/cmd/agent_watch_ignore_test.go
+++ b/cmd/agent_watch_ignore_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"andriiklymiuk/corgi/utils/agent/watch"
+)
+
+// "Ignore ABC-1" means the ticket, not one of its rows: the issue and every
+// comment on it go together. A key from --json still targets one row.
+func TestIgnoringARefCoversEveryRowOnIt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "watch"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lines := `{"key":"linear:ABC-1","ref":"ABC-1","kind":"issue.new","workspace":"api"}
+{"key":"linear:ABC-1:c1","ref":"ABC-1","kind":"issue.comment","workspace":"api"}
+{"key":"linear:ABC-2","ref":"ABC-2","kind":"issue.new","workspace":"api"}
+{"key":"github:acme/web#5","ref":"acme/web#5","kind":"pr.comment","workspace":"web"}
+`
+	if err := os.WriteFile(filepath.Join(dir, "watch", "events.jsonl"), []byte(lines), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := inboxKeysFor(dir, "abc-1", "")
+	if len(got) != 2 {
+		t.Fatalf("a ref covers all of its rows, got %v", got)
+	}
+	if got := inboxKeysFor(dir, "linear:ABC-1:c1", ""); len(got) != 1 || got[0] != "linear:ABC-1:c1" {
+		t.Fatalf("a key is one row, got %v", got)
+	}
+	if got := inboxKeysFor(dir, "ABC-1", "web"); len(got) != 0 {
+		t.Fatalf("--workspace narrows, got %v", got)
+	}
+	if got := inboxKeysFor(dir, "ABC-9", ""); got != nil {
+		t.Fatalf("unknown ref is nothing, got %v", got)
+	}
+
+	state := watch.LoadState(dir)
+	for _, k := range inboxKeysFor(dir, "ABC-1", "") {
+		if err := state.Ignore(k); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !watch.LoadState(dir).IsIgnored("linear:ABC-1:c1") || watch.LoadState(dir).IsIgnored("linear:ABC-2") {
+		t.Fatal("only ABC-1's rows are ignored")
+	}
+}

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -1893,6 +1893,8 @@ const launcherPageHTML = `<!doctype html>
         label.className = 'slabel'; label.textContent = s.display || s.label || '?';
         row.appendChild(dot); row.appendChild(label);
         let detail = s.detail || STATUS_WORD[s.status] || '';
+        if (s.status === 'limited' && s.limit === 'overload') detail = 'API overloaded';
+        if (s.resumeAt) detail += (detail ? ' · ' : '') + 'continues ' + clock(s.resumeAt);
         if (s.context && s.context.percent >= 50) detail += (detail ? ' · ' : '') + 'ctx ' + s.context.percent + '%';
         if (detail) {
           const d = document.createElement('span');

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -59,6 +59,7 @@ func upgradeRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Failed to upgrade via Homebrew: %s\n", err)
 		} else {
 			fmt.Println("Upgrade successful!")
+			refreshDaemonAfterUpgrade(exePath)
 		}
 	case installMethodScript:
 		fmt.Printf("Detected script install at %s. Re-running install script...\n", exeDir)
@@ -66,6 +67,7 @@ func upgradeRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Failed to upgrade via install script: %s\n", err)
 		} else {
 			fmt.Println("Upgrade successful!")
+			refreshDaemonAfterUpgrade(exePath)
 		}
 	case installMethodWindows:
 		// We can't safely overwrite the running corgi.exe from inside corgi.exe.
@@ -281,4 +283,32 @@ func tagFromReleaseLocation(location string) string {
 		tag = tag[:j]
 	}
 	return strings.TrimSpace(tag)
+}
+
+// refreshDaemonAfterUpgrade hands the login service the corgi that was just
+// installed. The daemon runs from its own copy (see agent_install_stable.go),
+// and that copy is only refreshed by `agent install` — which has to be the
+// new binary, not this process, so the copy is the new version.
+func refreshDaemonAfterUpgrade(exePath string) {
+	if !daemonRunsFromStableCopy() || !loginServiceInstalled() {
+		return
+	}
+	if installedDaemonBinary() != mustStableDaemonBinary() {
+		// Older installs point launchd straight at Homebrew's path, which is
+		// what brings the macOS file prompt back after every update.
+		fmt.Println("The daemon still starts from Homebrew's path — run `corgi agent install` once to stop macOS asking about Documents after every update.")
+		return
+	}
+	out, err := exec.Command(exePath, "agent", "install").CombinedOutput()
+	if err != nil {
+		fmt.Printf("Could not refresh the daemon's copy of corgi: %s\n%s", err, out)
+		fmt.Println("Run `corgi agent install` yourself.")
+		return
+	}
+	fmt.Println("Daemon restarted from the new corgi.")
+}
+
+func mustStableDaemonBinary() string {
+	p, _ := stableDaemonBinary()
+	return p
 }

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -592,6 +592,8 @@ corgi agent answer <session> allow|always|deny       # its permission prompt; ri
 corgi agent note <session> "waiting on PR"           # a line of yours under the session
 corgi agent usage [--json|--watch]                   # every account: 5h and week windows, forecast, when a reached limit lifts
 corgi agent carry <session> --profile work           # continue a limited session under another listed account
+corgi agent continue on                              # daemon types "continue" into a limited session once its window resets (off by default)
+corgi agent watch ignore <REF|key>                   # a ticket out of the inbox everywhere, for good; unignore puts it back
 corgi agent claude --profile auto                    # start under the listed account with the most budget
 corgi agent watch enable --auto-for reviews,comments # work those unattended; a fresh ticket only notifies
 corgi agent watch enable --ci                        # red builds too: the one kind with its own test for done
@@ -617,7 +619,11 @@ window in front, a hold picks another open window), and the **Telegram bot**
 (`corgi agent notify telegram --token …`: reply to a "needs you" message to
 type into it; `/sessions`, `/usage`, `/send`, `/allow`, `/always`, `/deny`,
 `/focus`). "limit lifted — back to work" arrives once a limited session
-finishes a turn again. The **phone launcher** has the same under each
+finishes a turn again. A limited key says which kind: **quota** (the
+account's window is spent; `resets 2pm`, carry or wait) or **overload**
+(the API said try later; minutes). With `corgi agent continue on` the daemon
+plans the resume itself — the key shows `continues 14:02` — and gives up after
+three tries when the limit comes straight back. The **phone launcher** has the same under each
 session row: Allow, Always, Deny when it needs you, Send… for any live one,
 and a PR link when the session mentioned one; its **New chat** box opens a
 session in a chosen editor window with a first prompt, a model and an

--- a/plugins/corgi/skills/setup/SKILL.md
+++ b/plugins/corgi/skills/setup/SKILL.md
@@ -120,8 +120,14 @@ open -a corgi-bar
 
 Then the person: reload each VS Code window once (`Developer: Reload
 Window`), grant corgi-bar **Accessibility** (Talk and typed prompts press
-keys) and **Notifications** when macOS asks, turn on Launch at login in its
-Settings.
+keys) and **Notifications** when macOS asks. corgi-bar turns Launch at login
+on by itself the first time it runs from /Applications (its Settings › App
+toggle turns it off); `corgi agent up --at-login` opens it once for that.
+
+Two macOS traps `corgi agent doctor` checks: the daemon must run from its own
+copy of the binary (`corgi agent install` does this; an older install that
+ran Homebrew's path makes macOS ask "corgi wants access to Documents" after
+every update), and the menu bar must be running for its login item to exist.
 
 Stream Deck: `gh release download -R Andriiklymiuk/corgi-agent-deck -p
 '*.streamDeckPlugin' -D /tmp && open /tmp/*.streamDeckPlugin` installs the

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -53,6 +53,10 @@ type UserConfig struct {
 	// state agent mode exists to avoid. Off by default: a machine that never
 	// sleeps is a flat battery, and that must be the owner's choice.
 	StayAwake bool `yaml:"stayAwake"`
+	// AutoContinue lets the daemon type "continue" into a session that hit
+	// a limit once the window resets (quota) or after a short wait
+	// (overload). Off by default: it types into your terminal.
+	AutoContinue bool `yaml:"autoContinue"`
 	// Profiles are named setting bundles pickable at session-start time —
 	// "work", "personal" — for running one workspace under different Claude
 	// accounts. Trusted like everything else here: a remote caller sends only

--- a/utils/agent/daemon/autocontinue.go
+++ b/utils/agent/daemon/autocontinue.go
@@ -1,0 +1,144 @@
+package daemon
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
+)
+
+// A session that hit a limit is waiting on a clock, not a person. The
+// daemon watches the clock so the editor does not have to be open: when a
+// spent window resets, or a few minutes after an overload, it types
+// "continue" into the session. Bounded — a limit that comes straight back
+// is not fought — and only with autoContinue on, because it types into a
+// terminal that is yours.
+
+const (
+	resumeGrace      = 30 * time.Second
+	resumeJitter     = 60 * time.Second
+	overloadBackoff  = 2 * time.Minute
+	overloadBackoffM = 15 * time.Minute
+	maxQuotaResumes  = 3
+	maxOverloadTries = 5
+	// quotaStillFull is the reading at which a window is not really back.
+	quotaStillFull = 95
+)
+
+var jitter = func(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(max)))
+}
+
+// readLimits is a seam for tests; the daemon reads Claude's cached usage.
+var readLimits = usage.ReadLimits
+
+func (d *Daemon) autoContinue(ctx context.Context, now time.Time) {
+	if !d.AutoContinue || d.Sessions == nil {
+		return
+	}
+	for _, s := range d.Sessions.Sessions() {
+		if s.Status != sessions.StatusLimited {
+			continue
+		}
+		if s.ResumeAt.IsZero() {
+			if at := resumeTime(s, now); !at.IsZero() {
+				d.Sessions.PlanResume(s.ID, at)
+			}
+			continue
+		}
+		if now.Before(s.ResumeAt) {
+			continue
+		}
+		if s.Limit == sessions.LimitQuota && quotaStillSpent(s.ConfigDir, now) {
+			// The clock said yes, the numbers say no: the reset has not
+			// landed in the cache yet, or the week is what is spent. Look
+			// again in a few minutes rather than type into a wall.
+			d.Sessions.PlanResume(s.ID, now.Add(5*time.Minute))
+			continue
+		}
+		if s.Resumes >= maxResumes(s.Limit) {
+			continue
+		}
+		if _, ok := d.Sessions.MarkResumed(s.ID); !ok {
+			continue
+		}
+		utils.Infof("agent: %s: continuing after %s limit (try %d)\n", s.Display, s.Limit, s.Resumes+1)
+		d.sendToSession(ctx, s.ID, "continue", true)
+		label := s.Display
+		if label == "" {
+			label = s.Label
+		}
+		go d.notifyAttention("corgi agent · "+label, "limit should be over — continued for you", s.Folder)
+	}
+}
+
+func maxResumes(kind sessions.LimitKind) int {
+	if kind == sessions.LimitOverload {
+		return maxOverloadTries
+	}
+	return maxQuotaResumes
+}
+
+// resumeTime is when to try: for an overload a growing wait from now; for
+// a quota the earliest reset of a window that is actually spent, from the
+// account's cached numbers. No numbers, no plan — guessing at a reset time
+// means typing into a session at the wrong moment.
+func resumeTime(s sessions.Session, now time.Time) time.Time {
+	switch s.Limit {
+	case sessions.LimitOverload:
+		wait := overloadBackoff << uint(s.Resumes)
+		if wait > overloadBackoffM {
+			wait = overloadBackoffM
+		}
+		return now.Add(wait + jitter(resumeJitter))
+	case sessions.LimitQuota:
+		l, ok := readLimits(s.ConfigDir)
+		if !ok {
+			return time.Time{}
+		}
+		var at time.Time
+		for _, w := range []usage.Window{l.FiveHour, l.SevenDay} {
+			if w.Percent < quotaStillFull || w.ResetsAt.IsZero() {
+				continue
+			}
+			if at.IsZero() || w.ResetsAt.Before(at) {
+				at = w.ResetsAt
+			}
+		}
+		if at.IsZero() {
+			// Nothing reads as spent but the session said limit: the
+			// cache is older than the limit. The five-hour reset is the
+			// honest default when it is known.
+			at = l.FiveHour.ResetsAt
+		}
+		if at.IsZero() {
+			return time.Time{}
+		}
+		if at.Before(now) {
+			at = now
+		}
+		return at.Add(resumeGrace + jitter(resumeJitter))
+	}
+	return time.Time{}
+}
+
+// quotaStillSpent says the account's numbers still read as full: a window
+// at or above the stop line whose reset is not yet behind us.
+func quotaStillSpent(configDir string, now time.Time) bool {
+	l, ok := readLimits(configDir)
+	if !ok {
+		return false
+	}
+	for _, w := range []usage.Window{l.FiveHour, l.SevenDay} {
+		if w.Percent >= quotaStillFull && (w.ResetsAt.IsZero() || w.ResetsAt.After(now)) {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/agent/daemon/autocontinue_test.go
+++ b/utils/agent/daemon/autocontinue_test.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
+)
+
+// A limited session is waiting on a clock. With autoContinue on, the daemon
+// plans a resume from the account's reset time, types "continue" once the
+// numbers say the window is back, and stops after a few tries so a limit
+// that comes straight back is not fought all night.
+func TestTheDaemonContinuesALimitedSessionWhenTheWindowResets(t *testing.T) {
+	d := trackingDaemon(t)
+	d.AutoContinue = true
+	d.Sessions.Load()
+	var mu sync.Mutex
+	var typed []string
+	d.Raise = func(context.Context, sessions.FocusTarget) error { return nil }
+	d.TypeText = func(_ context.Context, target sessions.FocusTarget, text string, enter bool) error {
+		mu.Lock()
+		defer mu.Unlock()
+		typed = append(typed, target.SessionID+":"+text+":"+strconv.FormatBool(enter))
+		return nil
+	}
+	origJitter, origLimits := jitter, readLimits
+	defer func() { jitter, readLimits = origJitter, origLimits }()
+	jitter = func(time.Duration) time.Duration { return 0 }
+
+	now := time.Now()
+	reset := now.Add(20 * time.Minute)
+	limits := usage.Limits{FetchedAt: now, FiveHour: usage.Window{Percent: 100, ResetsAt: reset}, SevenDay: usage.Window{Percent: 40}}
+	readLimits = func(string) (usage.Limits, bool) { return limits, true }
+
+	d.Sessions.Apply(sessions.Event{Name: "UserPromptSubmit", SessionID: "s1", Cwd: "/tmp/a", ClaudePID: 100, TermProgram: "iTerm.app", TTY: 5, At: now})
+	d.Sessions.Apply(sessions.Event{Name: "StopFailure", SessionID: "s1", Error: "rate_limit", Message: "usage limit — resets 3pm", At: now})
+
+	ctx := context.Background()
+	d.autoContinue(ctx, now)
+	s := d.Sessions.Sessions()[0]
+	if s.ResumeAt.IsZero() || s.ResumeAt.Before(reset) {
+		t.Fatalf("the plan is the reset plus grace, got %v for reset %v", s.ResumeAt, reset)
+	}
+
+	// The clock passes but a fresh reading says the account is still spent
+	// (the week, say — a new reset ahead): wait, do not type.
+	later := s.ResumeAt.Add(time.Second)
+	limits.FiveHour = usage.Window{Percent: 100, ResetsAt: later.Add(time.Hour)}
+	d.autoContinue(ctx, later)
+	if got := d.Sessions.Sessions()[0]; !got.ResumeAt.After(later) {
+		t.Fatal("numbers still full: the plan moves out, nothing is typed")
+	}
+	mu.Lock()
+	if len(typed) != 0 {
+		t.Fatalf("typed into a spent account: %v", typed)
+	}
+	mu.Unlock()
+
+	// The reset lands in the cache.
+	limits.FiveHour = usage.Window{Percent: 3, ResetsAt: reset.Add(5 * time.Hour)}
+	at := d.Sessions.Sessions()[0].ResumeAt.Add(time.Second)
+	d.autoContinue(ctx, at)
+	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return len(typed) == 1 })
+	mu.Lock()
+	if typed[0] != "s1:continue:true" {
+		t.Fatalf("typed = %v", typed)
+	}
+	mu.Unlock()
+	if got := d.Sessions.Sessions()[0]; got.Resumes != 1 || !got.ResumeAt.IsZero() {
+		t.Fatalf("one resume counted, plan cleared: %+v", got)
+	}
+
+	// The limit comes straight back, three times: the daemon stops.
+	for i := 0; i < 4; i++ {
+		d.Sessions.Apply(sessions.Event{Name: "UserPromptSubmit", SessionID: "s1", Cwd: "/tmp/a", ClaudePID: 100, TermProgram: "iTerm.app", TTY: 5, At: at})
+		d.Sessions.Apply(sessions.Event{Name: "StopFailure", SessionID: "s1", Error: "rate_limit", Message: "usage limit", At: at})
+		d.autoContinue(ctx, at)
+		at = d.Sessions.Sessions()[0].ResumeAt.Add(time.Second)
+		if at.IsZero() {
+			at = now.Add(time.Duration(i+1) * time.Hour)
+		}
+		d.autoContinue(ctx, at)
+	}
+	d.swaps.Wait()
+	mu.Lock()
+	if len(typed) != maxQuotaResumes {
+		t.Fatalf("bounded at %d continues, got %d", maxQuotaResumes, len(typed))
+	}
+	mu.Unlock()
+}
+
+func TestAutoContinueIsOffUnlessAsked(t *testing.T) {
+	d := trackingDaemon(t)
+	d.Sessions.Load()
+	origLimits := readLimits
+	defer func() { readLimits = origLimits }()
+	readLimits = func(string) (usage.Limits, bool) {
+		return usage.Limits{FiveHour: usage.Window{Percent: 100, ResetsAt: time.Now().Add(-time.Minute)}}, true
+	}
+	now := time.Now()
+	d.Sessions.Apply(sessions.Event{Name: "UserPromptSubmit", SessionID: "s1", Cwd: "/tmp/a", ClaudePID: 100, TermProgram: "iTerm.app", TTY: 5, At: now})
+	d.Sessions.Apply(sessions.Event{Name: "StopFailure", SessionID: "s1", Error: "rate_limit", Message: "usage limit", At: now})
+	d.autoContinue(context.Background(), now)
+	if s := d.Sessions.Sessions()[0]; !s.ResumeAt.IsZero() {
+		t.Fatal("off means not even a plan: it types into a terminal")
+	}
+}
+
+// An overload is minutes, not hours: a growing wait from now, capped.
+func TestAnOverloadWaitsMinutesNotHours(t *testing.T) {
+	origJitter := jitter
+	defer func() { jitter = origJitter }()
+	jitter = func(time.Duration) time.Duration { return 0 }
+	now := time.Now()
+	s := sessions.Session{Limit: sessions.LimitOverload}
+	if got := resumeTime(s, now); got.Sub(now) != overloadBackoff {
+		t.Fatalf("first try after %v, got %v", overloadBackoff, got.Sub(now))
+	}
+	s.Resumes = 6
+	if got := resumeTime(s, now); got.Sub(now) != overloadBackoffM {
+		t.Fatalf("capped at %v, got %v", overloadBackoffM, got.Sub(now))
+	}
+}

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -136,6 +136,9 @@ type Daemon struct {
 	// cmd. TypeText is the emulator typing seam.
 	AccountDirs func() []string
 	TypeText    func(ctx context.Context, t sessions.FocusTarget, text string, enter bool) error
+	// AutoContinue types "continue" into limited sessions when their limit
+	// should be over; see autocontinue.go.
+	AutoContinue bool
 	// DigestAt is the local HH:MM for the daily digest; Digest builds its
 	// text. Both injected by cmd; either empty means no digest.
 	DigestAt string

--- a/utils/agent/daemon/sessions.go
+++ b/utils/agent/daemon/sessions.go
@@ -339,6 +339,7 @@ func (d *Daemon) reapSessions(ctx context.Context) {
 			nextSweep = now.Add(sweepInterval)
 			d.Sessions.Sweep(now)
 			d.sampleAccounts(now)
+			d.autoContinue(ctx, now)
 		}
 		d.flushSessions()
 	}

--- a/utils/agent/sessions/registry.go
+++ b/utils/agent/sessions/registry.go
@@ -50,6 +50,8 @@ type Registry struct {
 	notice   string
 	noticeAt time.Time
 	accounts []Account
+	// AutoContinue is copied onto every snapshot; the daemon sets it.
+	AutoContinue bool
 	// OnTransition, when set, is told about every status change after it
 	// happened. The daemon turns some into notifications and metrics.
 	OnTransition func(s Session, from, to Status, now time.Time)
@@ -79,10 +81,13 @@ type State struct {
 	FrontSession string `json:"frontSession,omitempty"`
 	// Notice is the last board-level failure — a `new` with no window to
 	// open in, say — with its time, for a key to flash once.
-	Notice   string    `json:"notice,omitempty"`
-	NoticeAt time.Time `json:"noticeAt,omitempty"`
-	Sessions []Session `json:"sessions"`
-	Windows  []Window  `json:"windows,omitempty"`
+	// AutoContinue says the daemon types "continue" into limited sessions
+	// itself, so an editor with the same feature can stand down.
+	AutoContinue bool      `json:"autoContinue,omitempty"`
+	Notice       string    `json:"notice,omitempty"`
+	NoticeAt     time.Time `json:"noticeAt,omitempty"`
+	Sessions     []Session `json:"sessions"`
+	Windows      []Window  `json:"windows,omitempty"`
 	// Accounts is every account the sessions run under, with its limits.
 	Accounts []Account `json:"accounts,omitempty"`
 }
@@ -117,6 +122,10 @@ type Slot struct {
 	PR      string `json:"pr,omitempty"`
 	// TurnS is how long the current turn has been running, 0 unless working.
 	TurnS int `json:"turnS,omitempty"`
+	// Limit is quota or overload on a limited key; ResumeAt when the daemon
+	// will continue it on its own, so the key can say "continues 14:02".
+	Limit    LimitKind `json:"limit,omitempty"`
+	ResumeAt time.Time `json:"resumeAt,omitempty"`
 }
 
 // New returns a registry persisted at path, with a board of size keys.
@@ -292,8 +301,8 @@ func (r *Registry) transition(s *Session, ev Event, now time.Time) {
 		r.setStatus(s, StatusDone, now)
 	case "StopFailure":
 		s.Tool, s.Pending = "", nil
-		if limited, reset := LimitReset(ev.Error, ev.Message); limited {
-			r.applyLimit(s, reset, now)
+		if kind, reset, limited := ClassifyLimit(ev.Error, ev.Message); limited {
+			r.applyLimit(s, kind, reset, now)
 			return
 		}
 		s.Detail = firstNonEmpty(ev.Error, "api error")
@@ -356,17 +365,21 @@ func (r *Registry) applyEnd(s *Session, ev Event, now time.Time) {
 
 // applyLimit: the account is out of quota. Not a question, so not
 // needs_input; the key says when to come back instead.
-func (r *Registry) applyLimit(s *Session, reset string, now time.Time) {
+func (r *Registry) applyLimit(s *Session, kind LimitKind, reset string, now time.Time) {
 	s.Detail = "limit reached"
+	if kind == LimitOverload {
+		s.Detail = "API overloaded"
+	}
 	if reset != "" {
 		s.Detail = "resets " + reset
 	}
+	s.Limit, s.ResumeAt = kind, time.Time{}
 	r.setStatus(s, StatusLimited, now)
 }
 
 func (r *Registry) applyNotification(s *Session, ev Event, now time.Time) {
-	if limited, reset := LimitReset("", ev.Message); limited {
-		r.applyLimit(s, reset, now)
+	if kind, reset, limited := ClassifyLimit("", ev.Message); limited {
+		r.applyLimit(s, kind, reset, now)
 		return
 	}
 	switch ev.Notification {
@@ -517,6 +530,14 @@ func (r *Registry) setStatus(s *Session, st Status, now time.Time) {
 	from := s.Status
 	s.Status = st
 	s.StatusSince = now
+	if st != StatusLimited {
+		s.Limit, s.ResumeAt = "", time.Time{}
+	}
+	// A turn that finished or asked something is real progress; the count
+	// of continues is for one limit episode, not the session's life.
+	if st == StatusDone || st == StatusNeedsInput {
+		s.Resumes = 0
+	}
 	if r.OnTransition != nil {
 		r.OnTransition(*s, from, st, now)
 	}
@@ -845,6 +866,33 @@ func (r *Registry) SetNote(ref, note string) error {
 	s.Note = note
 	r.touch()
 	return nil
+}
+
+// PlanResume records when the daemon will continue a limited session; a
+// zero time clears the plan. Nothing else changes, so no transition fires.
+func (r *Registry) PlanResume(id string, at time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.sessions[id]
+	if !ok || s.Status != StatusLimited || s.ResumeAt.Equal(at) {
+		return false
+	}
+	s.ResumeAt = at
+	return true
+}
+
+// MarkResumed counts one continue typed into a limited session and clears
+// the plan; the next hook event decides whether it worked.
+func (r *Registry) MarkResumed(id string) (Session, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.sessions[id]
+	if !ok {
+		return Session{}, false
+	}
+	s.Resumes++
+	s.ResumeAt = time.Time{}
+	return *s, true
 }
 
 // SetAccounts replaces the accounts block. Sessions per account are counted
@@ -1198,7 +1246,7 @@ func (r *Registry) Snapshot(now time.Time) State {
 
 func (r *Registry) snapshotLocked(now time.Time) State {
 	st := State{UpdatedAt: r.updatedAt, Size: r.board.Size, Overflow: r.board.Hidden(),
-		LastFocusWindow: r.lastFocus.WindowID, Notice: r.notice, NoticeAt: r.noticeAt}
+		LastFocusWindow: r.lastFocus.WindowID, Notice: r.notice, NoticeAt: r.noticeAt, AutoContinue: r.AutoContinue}
 	if st.UpdatedAt.IsZero() {
 		st.UpdatedAt = now
 	}
@@ -1219,6 +1267,7 @@ func (r *Registry) snapshotLocked(now time.Time) State {
 		sl.SessionID, sl.Label, sl.Profile, sl.Status = s.ID, r.displayLocked(s), s.Profile, s.Status
 		sl.Detail, sl.Host, sl.FocusError, sl.FocusAt = s.Detail, s.Host.Kind, s.FocusError, s.FocusAt
 		sl.Note, sl.Stuck = s.Note, s.Stuck
+		sl.Limit, sl.ResumeAt = s.Limit, s.ResumeAt
 		sl.Branch, sl.Summary, sl.PR = s.Branch, s.Summary, s.PR
 		if s.Status == StatusWorking && !s.TurnStartedAt.IsZero() && now.After(s.TurnStartedAt) {
 			sl.TurnS = int(now.Sub(s.TurnStartedAt).Seconds())

--- a/utils/agent/sessions/session.go
+++ b/utils/agent/sessions/session.go
@@ -42,21 +42,50 @@ const (
 )
 
 var (
-	limitText  = regexp.MustCompile(`(?i)\b(session|usage|rate|weekly|daily) limit\b|\brate.?limited?\b`)
-	limitReset = regexp.MustCompile(`(?i)\bresets?\s+(?:at\s+)?([^\n"}\\]+?)\s*(?:$|["}\\])`)
+	limitText    = regexp.MustCompile(`(?i)\b(session|usage|rate|weekly|daily) limit\b|\brate.?limited?\b`)
+	limitReset   = regexp.MustCompile(`(?i)\bresets?\s+(?:at\s+)?([^\n"}\\]+?)\s*(?:$|["}\\])`)
+	overloadText = regexp.MustCompile(`(?i)\boverloaded?\b|\b529\b|\bcapacity\b|\btry again (later|in)\b|\btemporarily unavailable\b`)
+	quotaText    = regexp.MustCompile(`(?i)\b(session|usage|weekly|daily) limit\b|\bresets?\s`)
 )
 
-// LimitReset says whether a StopFailure or notification is the account's
-// usage limit rather than something to answer, and when it resets ("12:10pm
-// (Europe/Kiev)") when the text says.
-func LimitReset(errorType, message string) (bool, string) {
-	if errorType != "rate_limit" && !limitText.MatchString(message) {
-		return false, ""
+// LimitKind is why a session cannot go on, because the two reasons want
+// opposite reactions: a used-up window is hours and a clock, an overloaded
+// API is minutes and a retry.
+type LimitKind string
+
+const (
+	// LimitQuota: the account's usage window is spent. Comes back at a
+	// known time; carry to another account or wait for the reset.
+	LimitQuota LimitKind = "quota"
+	// LimitOverload: the API asked to try later. Nothing to do with the
+	// account; wait a few minutes and try again.
+	LimitOverload LimitKind = "overload"
+)
+
+// ClassifyLimit says whether a StopFailure or notification is a limit rather
+// than something to answer, which kind, and when it resets ("12:10pm
+// (Europe/Kiev)") when the text says. An error typed rate_limit with no
+// reset time and overload wording is an overload: Claude Code uses the
+// same type for both.
+func ClassifyLimit(errorType, message string) (LimitKind, string, bool) {
+	if errorType != "rate_limit" && !limitText.MatchString(message) && !overloadText.MatchString(message) {
+		return "", "", false
 	}
+	reset := ""
 	if m := limitReset.FindStringSubmatch(message); m != nil {
-		return true, strings.TrimSpace(m[1])
+		reset = strings.TrimRight(strings.TrimSpace(m[1]), ".")
 	}
-	return true, ""
+	if reset == "" && !quotaText.MatchString(message) && overloadText.MatchString(message) {
+		return LimitOverload, "", true
+	}
+	return LimitQuota, reset, true
+}
+
+// LimitReset is ClassifyLimit without the kind, for callers that only need
+// to know a limit was hit.
+func LimitReset(errorType, message string) (bool, string) {
+	_, reset, ok := ClassifyLimit(errorType, message)
+	return ok, reset
 }
 
 // StaleAfter is how long a working or done session may sit without an event
@@ -224,6 +253,12 @@ type Session struct {
 	Summary       string    `json:"summary,omitempty"`
 	PR            string    `json:"pr,omitempty"`
 	TurnStartedAt time.Time `json:"turnStartedAt,omitempty"`
+	// Limit says which kind of limit a limited session hit; ResumeAt when
+	// the daemon plans to type "continue" into it, Resumes how many times
+	// it has this episode. Cleared when the session moves on.
+	Limit    LimitKind `json:"limit,omitempty"`
+	ResumeAt time.Time `json:"resumeAt,omitempty"`
+	Resumes  int       `json:"resumes,omitempty"`
 }
 
 // Pending is one permission prompt: the tool and the safe word about its

--- a/utils/agent/sessions/session_test.go
+++ b/utils/agent/sessions/session_test.go
@@ -1,0 +1,61 @@
+package sessions
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A spent window and an overloaded API both arrive as rate_limit, and they
+// want opposite reactions: the first is hours and a clock, the second is
+// minutes and a retry. The classifier has to tell them apart from the text.
+func TestALimitIsQuotaOrOverload(t *testing.T) {
+	cases := []struct {
+		errType, msg string
+		kind         LimitKind
+		reset        string
+	}{
+		{"rate_limit", "You've hit your usage limit. It resets at 2pm (Europe/Kiev).", LimitQuota, "2pm (Europe/Kiev)"},
+		{"", "Weekly limit reached — resets Tue 08:59", LimitQuota, "Tue 08:59"},
+		{"rate_limit", "API error 529: Overloaded. Please try again later.", LimitOverload, ""},
+		{"", "The service is temporarily unavailable due to capacity", LimitOverload, ""},
+		{"rate_limit", "rate limit", LimitQuota, ""},
+	}
+	for _, c := range cases {
+		kind, reset, ok := ClassifyLimit(c.errType, c.msg)
+		if !ok || kind != c.kind || reset != c.reset {
+			t.Errorf("%q: got %s %q %v, want %s %q", c.msg, kind, reset, ok, c.kind, c.reset)
+		}
+	}
+	if _, _, ok := ClassifyLimit("", "permission denied for Bash"); ok {
+		t.Fatal("an ordinary failure is not a limit")
+	}
+}
+
+func TestALimitedSessionKeepsItsKindUntilItMovesOn(t *testing.T) {
+	r := New(filepath.Join(t.TempDir(), "sessions.json"), 6)
+	now := time.Now()
+	r.Apply(Event{Name: "UserPromptSubmit", SessionID: "s1", Cwd: "/tmp/a", ClaudePID: 1, At: now})
+	r.Apply(Event{Name: "StopFailure", SessionID: "s1", Error: "rate_limit", Message: "usage limit resets 3pm", At: now})
+	s := r.Sessions()[0]
+	if s.Status != StatusLimited || s.Limit != LimitQuota {
+		t.Fatalf("limited quota, got %s %s", s.Status, s.Limit)
+	}
+	if !r.PlanResume("s1", now.Add(time.Hour)) {
+		t.Fatal("a limited session takes a plan")
+	}
+	if s := r.Sessions()[0]; s.ResumeAt.IsZero() {
+		t.Fatal("the plan is on the session, for the keys to show")
+	}
+	if got, ok := r.MarkResumed("s1"); !ok || got.Resumes != 1 || !got.ResumeAt.IsZero() {
+		t.Fatalf("resumed once, plan cleared: %+v", got)
+	}
+	r.Apply(Event{Name: "UserPromptSubmit", SessionID: "s1", Cwd: "/tmp/a", ClaudePID: 1, At: now})
+	if s := r.Sessions()[0]; s.Limit != "" || s.Resumes != 1 {
+		t.Fatalf("working clears the kind but keeps the count for the episode: %+v", s)
+	}
+	r.Apply(Event{Name: "Stop", SessionID: "s1", At: now})
+	if s := r.Sessions()[0]; s.Resumes != 0 {
+		t.Fatal("a finished turn ends the episode")
+	}
+}

--- a/utils/agent/watch/duplicates_test.go
+++ b/utils/agent/watch/duplicates_test.go
@@ -1,6 +1,8 @@
 package watch
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -236,5 +238,53 @@ func TestACommentOnAMergedPullRequestIsNotWork(t *testing.T) {
 	// A review on my own merged PR is also over.
 	if rules.Match(Event{Kind: KindPRReview, Ref: "acme/api#7", Mine: true, State: "merged"}) {
 		t.Fatal("feedback arrives after a merge; acting on it unattended does not")
+	}
+}
+
+// The daemon keeps its State in memory from start; the phone loads a fresh
+// one to ignore a row. Both write the same file whole, so the daemon's next
+// save used to bring the row back — and the daemon never learned it was
+// ignored, so the unattended mode could still pick it up.
+func TestAnIgnoreFromAnotherProcessSurvivesTheDaemonsNextSave(t *testing.T) {
+	dir := t.TempDir()
+	daemon := LoadState(dir)
+	phone := LoadState(dir)
+
+	if err := phone.Ignore("jira:ABC-1"); err != nil {
+		t.Fatal(err)
+	}
+	daemon.MarkSeen("jira:XYZ-9") // any save from the stale copy
+
+	if !LoadState(dir).IsIgnored("jira:ABC-1") {
+		t.Fatal("the daemon's save clobbered the phone's ignore")
+	}
+	if !daemon.IsIgnored("jira:ABC-1") {
+		t.Fatal("the daemon has to see an ignore it did not make, or it fixes the ticket anyway")
+	}
+}
+
+// An ignored list written by an older corgi lives inside state.json; it has
+// to move to its own file, once, and not come back.
+func TestOldIgnoredListMovesOutOfStateJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "watch"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := `{"cursors":{},"seen":["jira:ABC-1"],"ignored":["jira:ABC-1"]}`
+	if err := os.WriteFile(filepath.Join(dir, "watch", "state.json"), []byte(old), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := LoadState(dir)
+	if !s.IsIgnored("jira:ABC-1") {
+		t.Fatal("an ignore from before the move still counts")
+	}
+	s.MarkSeen("jira:XYZ-9")
+	data, _ := os.ReadFile(filepath.Join(dir, "watch", "state.json"))
+	if strings.Contains(string(data), "ignored") {
+		t.Fatalf("state.json still carries the list, so a stale copy can clobber it: %s", data)
+	}
+	if !LoadState(dir).IsIgnored("jira:ABC-1") {
+		t.Fatal("the move lost the ignore")
 	}
 }

--- a/utils/agent/watch/ignored.go
+++ b/utils/agent/watch/ignored.go
@@ -1,0 +1,97 @@
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"andriiklymiuk/corgi/utils/atomicfile"
+)
+
+// The ignored list is a person's decision, and two processes act on it: the
+// phone writes it, the daemon reads it. It lives in its own file so nobody's
+// in-memory copy of state.json can write over it, and it is read fresh every
+// time so the daemon sees an ignore it did not make.
+type ignoredFile struct {
+	Ignored []string `json:"ignored"`
+}
+
+func ignoredPath(agentDir string) string {
+	return filepath.Join(agentDir, "watch", "ignored.json")
+}
+
+func readIgnored(agentDir string) []string {
+	var f ignoredFile
+	if data, err := os.ReadFile(ignoredPath(agentDir)); err == nil {
+		_ = json.Unmarshal(data, &f)
+	}
+	return f.Ignored
+}
+
+func writeIgnored(agentDir string, keys []string) error {
+	if len(keys) > seenKeep {
+		keys = keys[len(keys)-seenKeep:]
+	}
+	data, err := json.MarshalIndent(ignoredFile{Ignored: keys}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(ignoredPath(agentDir)), 0o700); err != nil {
+		return err
+	}
+	return atomicfile.Write(ignoredPath(agentDir), data, 0o600)
+}
+
+// Ignore drops an event from the inbox for good and stops the unattended
+// mode picking it up. A person's decision, never corgi's.
+func (s *State) Ignore(key string) error {
+	if key == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := readIgnored(s.agentDir)
+	if containsString(keys, key) {
+		return nil
+	}
+	return writeIgnored(s.agentDir, append(keys, key))
+}
+
+// Unignore puts it back, which is what undoing a run has to do.
+func (s *State) Unignore(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := readIgnored(s.agentDir)
+	kept := keys[:0]
+	for _, k := range keys {
+		if k != key {
+			kept = append(kept, k)
+		}
+	}
+	if len(kept) == len(keys) {
+		return nil
+	}
+	return writeIgnored(s.agentDir, kept)
+}
+
+func (s *State) IsIgnored(key string) bool {
+	return containsString(readIgnored(s.agentDir), key)
+}
+
+// moveIgnoredOut carries a list an older corgi kept inside state.json into
+// its own file, once. The field stays readable so the move can happen, and
+// is cleared so the next save does not write it back.
+func (s *State) moveIgnoredOut() {
+	if len(s.Ignored) == 0 {
+		return
+	}
+	keys := readIgnored(s.agentDir)
+	for _, k := range s.Ignored {
+		if !containsString(keys, k) {
+			keys = append(keys, k)
+		}
+	}
+	if writeIgnored(s.agentDir, keys) == nil {
+		s.Ignored = nil
+	}
+}

--- a/utils/agent/watch/watch.go
+++ b/utils/agent/watch/watch.go
@@ -321,17 +321,17 @@ type Sink func(ctx context.Context, e Event)
 // State is what survives restarts: cursors per workspace and source, and
 // the keys already handled. One file under the agent dir.
 type State struct {
-	mu      sync.Mutex
-	path    string
-	Cursors map[string]Cursor `json:"cursors"` // "<workspace>/<source>"
-	Seen    []string          `json:"seen"`    // newest last
-	Errors  map[string]string `json:"errors,omitempty"`
-	Polled  map[string]string `json:"polled,omitempty"` // "<workspace>/<source>" → RFC3339
+	mu       sync.Mutex
+	path     string
+	agentDir string
+	Cursors  map[string]Cursor `json:"cursors"` // "<workspace>/<source>"
+	Seen     []string          `json:"seen"`    // newest last
+	Errors   map[string]string `json:"errors,omitempty"`
+	Polled   map[string]string `json:"polled,omitempty"` // "<workspace>/<source>" → RFC3339
 	// Held is what quiet hours swallowed, waiting for the window to open.
 	Held []HeldNote `json:"held,omitempty"`
-	// Ignored is what a person dismissed from the inbox. Distinct from Seen,
-	// which every delivered event gets: seen means corgi told you, ignored
-	// means you said no thanks.
+	// Ignored is only read, from a state.json an older corgi wrote; the list
+	// now lives in ignored.json (see ignored.go) and this is cleared on load.
 	Ignored []string `json:"ignored,omitempty"`
 	// seen indexes Seen so a lookup does not walk the list.
 	seen map[string]struct{}
@@ -357,10 +357,11 @@ const heldKeep = 100
 
 // LoadState reads <agentDir>/watch/state.json; a missing file is empty state.
 func LoadState(agentDir string) *State {
-	s := &State{path: filepath.Join(agentDir, "watch", "state.json"), Cursors: map[string]Cursor{}}
+	s := &State{path: filepath.Join(agentDir, "watch", "state.json"), agentDir: agentDir, Cursors: map[string]Cursor{}}
 	if data, err := os.ReadFile(s.path); err == nil {
 		_ = json.Unmarshal(data, s)
 	}
+	s.moveIgnoredOut()
 	if s.Cursors == nil {
 		s.Cursors = map[string]Cursor{}
 	}
@@ -1157,42 +1158,6 @@ func (l *FixLog) RecentBlocker(workspace string, within time.Duration, now time.
 		runs++
 	}
 	return kind, runs
-}
-
-// Ignore drops an event from the inbox for good and stops the unattended
-// mode picking it up. A person's decision, never corgi's.
-func (s *State) Ignore(key string) error {
-	s.mu.Lock()
-	if key == "" || containsString(s.Ignored, key) {
-		s.mu.Unlock()
-		return nil
-	}
-	s.Ignored = append(s.Ignored, key)
-	if len(s.Ignored) > seenKeep {
-		s.Ignored = s.Ignored[len(s.Ignored)-seenKeep:]
-	}
-	s.mu.Unlock()
-	return s.save()
-}
-
-// Unignore puts it back, which is what undoing a run has to do.
-func (s *State) Unignore(key string) error {
-	s.mu.Lock()
-	kept := s.Ignored[:0]
-	for _, k := range s.Ignored {
-		if k != key {
-			kept = append(kept, k)
-		}
-	}
-	s.Ignored = kept
-	s.mu.Unlock()
-	return s.save()
-}
-
-func (s *State) IsIgnored(key string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return containsString(s.Ignored, key)
 }
 
 func containsString(list []string, s string) bool {


### PR DESCRIPTION
Four bugs from this morning and the two small things that make limits honest. Everything opt-in or a fix; no behavior changes for a machine that has none of it set.

**Fixes**
- Ignoring a row on the phone was undone a minute later: the daemon rewrote `watch/state.json` from its in-memory copy. Person decisions now live in `watch/ignored.json`, read fresh on every check — so the daemon also stops picking ignored rows up in unattended mode. Old lists move over once.
- `corgi agent watch ignore|unignore <REF|key>` — the verb the menu bar needed (corgi-bar 0.9.1 adds the row action).
- "corgi wants access to Documents" after every update: launchd resolved `/opt/homebrew/bin/corgi` to the versioned Caskroom path, so each version looked like a new tool to macOS. The daemon now runs from a stable copy under `~/Library/Application Support/corgi/bin/`; `corgi upd` refreshes it; `doctor` flags an old-style install.
- `corgi agent up --at-login` opens corgi-bar once so its login item is registered; `doctor` reports the menu bar.

**Limits**
- A limited session now says which kind: `quota` (window spent, resets at a time) or `overload` (API said try later). Board field `limit`, slot field too.
- `corgi agent continue on` — the daemon plans a resume from the account's cached reset time (or a growing wait for an overload), types `continue` once the numbers say the window is back, and stops after three tries. Off by default. Board carries `autoContinue` and per-session `resumeAt` so the VS Code extension can stand down.

Tests: new unit tests for each; `-race` on watch, sessions, daemon.