### PR TITLE
Waves 2 + 3: handoff, workpad, kanban, queue, cost, scope hooks, drift, models, changed surface, harden, docs check, routines, stack tools, evals

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,54 @@
+name: Skill evals
+
+# The plugin's skills are prompts; a change to one is a change to what the
+# agent does. Two checks, both needing a Claude login (CLAUDE_CODE_OAUTH_TOKEN
+# or ANTHROPIC_API_KEY in secrets): does the right skill fire on its own, and
+# do the eval cases still score. Skipped when no credential is set.
+
+on:
+  pull_request:
+    paths:
+      - "plugins/corgi/**"
+      - "scripts/skill-activation.sh"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Plugin manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - run: npm install -g @anthropic-ai/claude-code
+      - run: claude plugin validate plugins/corgi
+
+  activation:
+    name: Skill activation
+    runs-on: ubuntu-latest
+    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - run: npm install -g @anthropic-ai/claude-code
+      - run: scripts/skill-activation.sh
+
+  evals:
+    name: Eval cases
+    runs-on: ubuntu-latest
+    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - run: npm install -g @anthropic-ai/claude-code
+      # Early access: when the command is not available on this account the
+      # step says so and passes; the activation job above still gates.
+      - run: |
+          set +e
+          out=$(claude plugin eval plugins/corgi --threshold 0.8 --max-cost-usd 5 --no-publish 2>&1)
+          code=$?
+          echo "$out"
+          if echo "$out" | grep -qi "early access"; then echo "plugin eval not available on this account yet"; exit 0; fi
+          exit $code

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -24,28 +24,37 @@ jobs:
   activation:
     name: Skill activation
     runs-on: ubuntu-latest
-    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - run: npm install -g @anthropic-ai/claude-code
-      - run: scripts/skill-activation.sh
+      # A job-level if cannot read secrets; a step can.
+      - id: login
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] || [ -n "$ANTHROPIC_API_KEY" ]; then echo "has=true" >> "$GITHUB_OUTPUT"; else echo "no Claude login in secrets — skipping"; echo "has=false" >> "$GITHUB_OUTPUT"; fi
+      - if: steps.login.outputs.has == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+      - if: steps.login.outputs.has == 'true'
+        run: scripts/skill-activation.sh
 
   evals:
     name: Eval cases
     runs-on: ubuntu-latest
-    if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' || secrets.ANTHROPIC_API_KEY != '' }}
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - run: npm install -g @anthropic-ai/claude-code
+      - id: login
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] || [ -n "$ANTHROPIC_API_KEY" ]; then echo "has=true" >> "$GITHUB_OUTPUT"; else echo "no Claude login in secrets — skipping"; echo "has=false" >> "$GITHUB_OUTPUT"; fi
+      - if: steps.login.outputs.has == 'true'
+        run: npm install -g @anthropic-ai/claude-code
       # Early access: when the command is not available on this account the
       # step says so and passes; the activation job above still gates.
-      - run: |
+      - if: steps.login.outputs.has == 'true'
+        run: |
           set +e
           out=$(claude plugin eval plugins/corgi --threshold 0.8 --max-cost-usd 5 --no-publish 2>&1)
           code=$?

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ coverage-by-pkg: test
 test\:cov:
 	go test ./... -timeout 30s -coverprofile=/tmp/coverage.out -covermode=atomic 2>&1 | tail -10 && go tool cover -func=/tmp/coverage.out | tail -1
 
+skill-evals: ## does the right corgi skill fire on its own (needs a Claude login)
+	scripts/skill-activation.sh
+
 fmt-check:
 	@unformatted=$$(gofmt -l .); \
 	if [ -n "$$unformatted" ]; then \

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -174,6 +174,7 @@ func runAgentServe(cmd *cobra.Command, _ []string) {
 	d.ClaimTicket = func(workspaceID string, e watch.Event) (bool, string, error) {
 		return claimTicket(d.Dir, workspaceID, e)
 	}
+	d.Isolate = isolateFixWorktrees
 	d.Workpad = func(workspaceID, ref, section, text string) {
 		writeWorkpad(d.Dir, workspaceID, ref, section, text)
 	}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -174,6 +174,9 @@ func runAgentServe(cmd *cobra.Command, _ []string) {
 	d.ClaimTicket = func(workspaceID string, e watch.Event) (bool, string, error) {
 		return claimTicket(d.Dir, workspaceID, e)
 	}
+	d.Workpad = func(workspaceID, ref, section, text string) {
+		writeWorkpad(d.Dir, workspaceID, ref, section, text)
+	}
 	d.Delivered = func(workspaceID string, e watch.Event, prs []string) {
 		markDelivered(d.Dir, workspaceID, e, prs)
 	}

--- a/cmd/agent_carry.go
+++ b/cmd/agent_carry.go
@@ -41,9 +41,7 @@ the new one is up; its process is left alone.`,
 func runAgentCarry(cmd *cobra.Command, args []string) {
 	profile, _ := cmd.Flags().GetString("profile")
 	profile = strings.TrimSpace(profile)
-	if profile == "" {
-		exitWithError("agent_carry", fmt.Errorf("--profile is required: which account to carry to"), 2)
-	}
+	fresh, _ := cmd.Flags().GetBool("fresh")
 	dir := mustAgentDir()
 	board, err := readBoard(dir)
 	if err != nil {
@@ -53,12 +51,18 @@ func runAgentCarry(cmd *cobra.Command, args []string) {
 	if err != nil {
 		exitWithError("agent_carry", err, 1)
 	}
-	fresh, _ := cmd.Flags().GetBool("fresh")
+	// A fresh start needs no other account: the same one, a clean context.
+	if profile == "" && fresh {
+		profile = firstNonEmpty(s.Profile, "default")
+	}
+	if profile == "" {
+		exitWithError("agent_carry", fmt.Errorf("--profile is required: which account to carry to (or --fresh to restart under the same one)"), 2)
+	}
 	if !fresh && s.Context != nil && s.Context.Percent >= carryFreshAt {
 		fresh = true
 		utils.Infof("context is %d%% full — starting the new session clean, from the handoff\n", s.Context.Percent)
 	}
-	plan, err := planCarry(dir, s, profile)
+	plan, err := planCarry(dir, s, profile, fresh)
 	if err != nil {
 		exitWithError("agent_carry", err, 1)
 	}
@@ -163,7 +167,7 @@ func carryPrompt(p handoff.Packet, path string) string {
 // planCarry checks the move is allowed and works out the paths. It reads
 // the workspace's accounts list from the trusted user config: a committed
 // file can never widen where a conversation may go.
-func planCarry(agentD string, s sessions.Session, profile string) (carryPlan, error) {
+func planCarry(agentD string, s sessions.Session, profile string, fresh bool) (carryPlan, error) {
 	if s.Cwd == "" {
 		return carryPlan{}, fmt.Errorf("%s has no working directory on record", s.Display)
 	}
@@ -191,24 +195,27 @@ func planCarry(agentD string, s sessions.Session, profile string) (carryPlan, er
 	}
 	repo, _ := config.LoadRepo(ws.AbsPath)
 	resolved := config.Resolve(launch.Workspace, repo, user)
-	if !accountAllowed(resolved.Accounts, profile) {
+	sameAccount := strings.EqualFold(profile, firstNonEmpty(s.Profile, "default"))
+	if !sameAccount && !accountAllowed(resolved.Accounts, profile) {
 		if len(resolved.Accounts) == 0 {
 			return carryPlan{}, fmt.Errorf("workspace %s lists no accounts: add `accounts: [default, %s]` under it in %s", launch.Workspace, profile, agentUserConfigPath(agentD))
 		}
 		return carryPlan{}, fmt.Errorf("workspace %s may run under %s, not %s", launch.Workspace, strings.Join(resolved.Accounts, ", "), profile)
 	}
-	target, err := config.ApplyProfile(resolved, user, profile)
-	if err != nil {
-		return carryPlan{}, err
+	target := resolved
+	if !sameAccount || profile != "default" {
+		if target, err = config.ApplyProfile(resolved, user, profile); err != nil {
+			return carryPlan{}, err
+		}
 	}
 	fromDir := claudeConfigDir(s.ConfigDir)
 	toDir := claudeConfigDir(expandTilde(target.ConfigDir))
-	if samePath(fromDir, toDir) {
-		return carryPlan{}, fmt.Errorf("%s already runs under %s", s.Display, profile)
+	if samePath(fromDir, toDir) && !fresh {
+		return carryPlan{}, fmt.Errorf("%s already runs under %s — --fresh restarts it there from a handoff", s.Display, profile)
 	}
 	rel := filepath.Join("projects", mungeClaudeProjectDir(s.Cwd), s.ID+".jsonl")
 	plan := carryPlan{From: filepath.Join(fromDir, rel), To: filepath.Join(toDir, rel)}
-	if _, err := os.Stat(plan.From); err != nil {
+	if _, err := os.Stat(plan.From); err != nil && !fresh {
 		return carryPlan{}, fmt.Errorf("no transcript for %s at %s", s.Display, plan.From)
 	}
 	exe, err := os.Executable()
@@ -271,6 +278,6 @@ func findBoardSession(st sessions.State, ref string) (sessions.Session, error) {
 
 func init() {
 	agentCarryCmd.Flags().String("profile", "", "The account (corgi profile) to continue under")
-	agentCarryCmd.Flags().Bool("fresh", false, "Start clean from the handoff instead of resuming the transcript (automatic past 85% context)")
+	agentCarryCmd.Flags().Bool("fresh", false, "Start clean from the handoff instead of resuming the transcript (automatic past 85% context); without --profile, the same account")
 	agentCmd.AddCommand(agentCarryCmd)
 }

--- a/cmd/agent_carry.go
+++ b/cmd/agent_carry.go
@@ -11,17 +11,25 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/command"
 	"andriiklymiuk/corgi/utils/agent/config"
+	"andriiklymiuk/corgi/utils/agent/handoff"
 	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
 )
 
 var agentCarryCmd = &cobra.Command{
 	Use:   "carry <session> --profile <name>",
 	Short: "Continue a session under another account, conversation and all",
-	Long: `Moves a session to another of the workspace's accounts: its transcript is
-copied into that account's config directory and a new terminal in the same
-window runs ` + "`corgi agent claude --profile <name> -- --resume <id>`" + `, so
-the conversation carries on where it was. For the session that hit its limit
-while the other account still has budget.
+	Long: `Moves a session to another of the workspace's accounts. For the session that
+hit its limit while the other account still has budget.
+
+First it leaves a handoff for the ticket (corgi agent handoff): a draft from
+git and the last thing the session said, unless the session wrote its own.
+Then, by default, the transcript is copied into the other account's config
+directory and a new terminal in the same window runs
+` + "`corgi agent claude --profile <name> -- --resume <id>`" + `, so the conversation
+carries on where it was. With --fresh — or on its own when the context window
+is over 85% full — the new session starts clean instead, with the handoff as
+its first prompt: same worktree, none of the old context.
 
 Only a profile the workspace's accounts: list names is allowed — a workspace
 that lists none cannot be carried anywhere. The old session is dismissed once
@@ -45,18 +53,42 @@ func runAgentCarry(cmd *cobra.Command, args []string) {
 	if err != nil {
 		exitWithError("agent_carry", err, 1)
 	}
+	fresh, _ := cmd.Flags().GetBool("fresh")
+	if !fresh && s.Context != nil && s.Context.Percent >= carryFreshAt {
+		fresh = true
+		utils.Infof("context is %d%% full — starting the new session clean, from the handoff\n", s.Context.Percent)
+	}
 	plan, err := planCarry(dir, s, profile)
 	if err != nil {
 		exitWithError("agent_carry", err, 1)
 	}
-	if err := os.MkdirAll(filepath.Dir(plan.To), 0o700); err != nil {
-		exitWithError("agent_carry", err, 1)
+	packet, packetPath := leaveCarryHandoff(plan.Workspace, s, profile)
+	if fresh {
+		if packetPath == "" {
+			exitWithError("agent_carry", fmt.Errorf("a fresh start needs a handoff, and the branch %q names no ticket — say --ref on `corgi agent handoff` first", sessions.Branch(s.Cwd)), 2)
+		}
+		id, err := savePrompt(dir, carryPrompt(packet, packetPath))
+		if err != nil {
+			exitWithError("agent_carry", err, 1)
+		}
+		plan.Command = fmt.Sprintf("%s agent claude --profile %s --prompt-id %s", shellQuote(plan.Exe), shellQuote(profile), id)
+	} else {
+		if err := os.MkdirAll(filepath.Dir(plan.To), 0o700); err != nil {
+			exitWithError("agent_carry", err, 1)
+		}
+		if err := copyFile(plan.From, plan.To); err != nil {
+			exitWithError("agent_carry", fmt.Errorf("copy transcript: %w", err), 1)
+		}
 	}
-	if err := copyFile(plan.From, plan.To); err != nil {
-		exitWithError("agent_carry", fmt.Errorf("copy transcript: %w", err), 1)
+	how := "a new terminal resumes it there"
+	if fresh {
+		how = "a new terminal starts clean there, from the handoff"
 	}
 	sendBoardCommand(command.Command{Action: command.ActionNew, WindowID: s.Host.WindowID, Command: plan.Command, Source: "cli"},
-		fmt.Sprintf("carrying %s to %s: a new terminal resumes it there", s.Display, profile))
+		fmt.Sprintf("carrying %s to %s: %s", s.Display, profile, how))
+	if packetPath != "" && !utils.JSONOutput {
+		utils.Infof("handoff: %s\n", packetPath)
+	}
 	if s.Status == sessions.StatusLimited || s.Status == sessions.StatusDone || s.Status == sessions.StatusStale {
 		_, _ = command.Write(dir, command.Command{Action: command.ActionDismiss, SessionID: s.ID, Source: "cli"})
 	}
@@ -66,8 +98,66 @@ func runAgentCarry(cmd *cobra.Command, args []string) {
 }
 
 type carryPlan struct {
-	From, To string
-	Command  string
+	From, To  string
+	Command   string
+	Exe       string
+	Workspace string
+}
+
+// carryFreshAt is the context fill past which resuming the transcript
+// carries mostly baggage; the handoff is the better start.
+const carryFreshAt = 85
+
+// leaveCarryHandoff makes sure the ticket has a handoff before the move: the
+// session's own if it wrote one after its last turn began, else a draft from
+// git and the last thing it said. Returns the packet and its Markdown path,
+// or "" when the branch names no ticket.
+func leaveCarryHandoff(workspaceDir string, s sessions.Session, profile string) (handoff.Packet, string) {
+	if workspaceDir == "" {
+		return handoff.Packet{}, ""
+	}
+	where := handoff.GitWhere(s.Cwd)
+	ref := handoff.RefFromBranch(where.Branch)
+	if ref == "" {
+		return handoff.Packet{}, ""
+	}
+	if p, err := handoff.Read(workspaceDir, ref); err == nil && !p.Draft && !p.WrittenAt.Before(s.TurnStartedAt) {
+		return p, handoff.MarkdownPath(workspaceDir, ref)
+	}
+	if rel, err := filepath.Rel(workspaceDir, s.Cwd); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		where.Worktree = rel
+	}
+	p := handoff.Packet{Ref: ref, State: handoff.StateInputRequired, Where: where, Draft: true,
+		Next: firstLineOf(s.Summary),
+		From: handoff.From{Harness: "claude", Session: s.ID, Account: s.Profile, Host: hostname()}}
+	if s.Context != nil {
+		p.From.Model = s.Context.Model
+		p.Budget.Context = s.Context.Percent
+	}
+	if l, ok := usage.ReadLimits(s.ConfigDir); ok {
+		p.Budget.FiveHour, p.Budget.SevenDay = l.FiveHour.Percent, l.SevenDay.Percent
+	}
+	if s.Status == sessions.StatusLimited {
+		p.Decisions = []string{fmt.Sprintf("carried from %s to %s: the first account hit its limit", firstNonEmpty(s.Profile, "default"), profile)}
+	}
+	if err := handoff.Write(workspaceDir, p); err != nil {
+		utils.Infof("could not write a handoff: %v\n", err)
+		return handoff.Packet{}, ""
+	}
+	return p, handoff.MarkdownPath(workspaceDir, ref)
+}
+
+// carryPrompt is the first message of a fresh session: read the packet,
+// then do the next thing.
+func carryPrompt(p handoff.Packet, path string) string {
+	msg := fmt.Sprintf("Continue the work on %s. Read the handoff first: %s — it is typed state from the previous session, not a transcript; check its done list against the diff before building on it.", p.Ref, path)
+	if p.Draft {
+		msg += " It is a draft corgi assembled from git and the last thing the session said, so start by looking at the branch."
+	}
+	if p.Next != "" {
+		msg += " Then: " + p.Next
+	}
+	return msg
 }
 
 // planCarry checks the move is allowed and works out the paths. It reads
@@ -125,6 +215,7 @@ func planCarry(agentD string, s sessions.Session, profile string) (carryPlan, er
 	if err != nil || exe == "" {
 		exe = "corgi"
 	}
+	plan.Exe, plan.Workspace = exe, ws.AbsPath
 	plan.Command = fmt.Sprintf("%s agent claude --profile %s -- --resume %s", shellQuote(exe), shellQuote(profile), s.ID)
 	return plan, nil
 }
@@ -180,5 +271,6 @@ func findBoardSession(st sessions.State, ref string) (sessions.Session, error) {
 
 func init() {
 	agentCarryCmd.Flags().String("profile", "", "The account (corgi profile) to continue under")
+	agentCarryCmd.Flags().Bool("fresh", false, "Start clean from the handoff instead of resuming the transcript (automatic past 85% context)")
 	agentCmd.AddCommand(agentCarryCmd)
 }

--- a/cmd/agent_carry_handoff_test.go
+++ b/cmd/agent_carry_handoff_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/handoff"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
+)
+
+// A carry leaves a handoff before it moves: a draft from git and the last
+// thing said when the session wrote none, the session's own when it did.
+func TestCarryLeavesAHandoffFirst(t *testing.T) {
+	ws := t.TempDir()
+	gitRepoOnBranch(t, ws, "feature/ABC-3/limits")
+	s := sessions.Session{ID: "s1", Cwd: ws, Profile: "work", Status: sessions.StatusLimited,
+		Summary: "the api side is done; the web banner is next", Context: &usage.Context{Percent: 40, Model: "opus"}}
+
+	p, path := leaveCarryHandoff(ws, s, "personal")
+	if path == "" || !p.Draft || p.Ref != "ABC-3" || p.Next != "the api side is done; the web banner is next" {
+		t.Fatalf("draft packet: %+v %q", p, path)
+	}
+	if p.Where.Branch != "feature/ABC-3/limits" || p.From.Session != "s1" || p.From.Account != "work" || p.From.Model != "opus" {
+		t.Fatalf("where/from: %+v", p)
+	}
+	if !strings.Contains(strings.Join(p.Decisions, " "), "carried from work to personal") {
+		t.Fatalf("says why it moved: %v", p.Decisions)
+	}
+
+	own := handoff.Packet{Ref: "ABC-3", State: handoff.StateInputRequired, Done: []string{"api"}, Next: "web", WrittenAt: time.Now()}
+	if err := handoff.Write(ws, own); err != nil {
+		t.Fatal(err)
+	}
+	s.TurnStartedAt = time.Now().Add(-time.Hour)
+	p, _ = leaveCarryHandoff(ws, s, "personal")
+	if p.Draft || p.Next != "web" {
+		t.Fatalf("the session's own packet wins over a draft: %+v", p)
+	}
+
+	prompt := carryPrompt(p, filepath.Join(ws, "x.md"))
+	if !strings.Contains(prompt, "Continue the work on ABC-3") || !strings.Contains(prompt, "Then: web") || strings.Contains(prompt, "draft") {
+		t.Fatalf("prompt: %s", prompt)
+	}
+
+	main := t.TempDir()
+	gitRepoOnBranch(t, main, "main")
+	if _, path := leaveCarryHandoff(main, sessions.Session{ID: "s2", Cwd: main}, "personal"); path != "" {
+		t.Fatal("no ticket in the branch, no packet")
+	}
+}

--- a/cmd/agent_claude.go
+++ b/cmd/agent_claude.go
@@ -169,7 +169,7 @@ func resolveClaudeLaunch(dir, profile string, extra []string) (claudeLaunch, err
 	repo, _ := config.LoadRepo(best)
 	resolved := config.Resolve(id, repo, user)
 	if strings.EqualFold(strings.TrimSpace(profile), "auto") {
-		profile = pickAccountProfile(user, resolved)
+		profile = pickAccountProfileSticky(agentD, user, resolved)
 	}
 	if p := strings.TrimSpace(profile); p != "" {
 		withProfile, err := config.ApplyProfile(resolved, user, p)
@@ -299,6 +299,43 @@ func pickAccountProfile(user *config.UserConfig, resolved config.Resolved) strin
 		return ""
 	}
 	return best
+}
+
+// autoSwitchAt is the reading past which --profile auto leaves the account
+// it has been using. Not sooner: a session pinned to an account with room
+// left should stay there, and bouncing between accounts on every small
+// difference is how two windows end up limited at once.
+const autoSwitchAt = 98
+
+func autoProfilePath(agentDir string) string { return filepath.Join(agentDir, "auto-profile") }
+
+// pickAccountProfileSticky is --profile auto with a memory: the account it
+// picked last time stays picked until its window is nearly spent, then the
+// one with the most room takes over and stays even when the first recovers.
+func pickAccountProfileSticky(agentDir string, user *config.UserConfig, resolved config.Resolved) string {
+	if user == nil || len(resolved.Accounts) == 0 {
+		return ""
+	}
+	if last, err := os.ReadFile(autoProfilePath(agentDir)); err == nil {
+		name := strings.TrimSpace(string(last))
+		if name != "" && accountAllowed(resolved.Accounts, name) {
+			if p, ok := user.Profiles[name]; ok || name == "default" {
+				if l, ok := usage.ReadLimits(expandTilde(p.ConfigDir)); !ok || l.FiveHour.Percent < autoSwitchAt {
+					if name == "default" {
+						return ""
+					}
+					return name
+				}
+			}
+		}
+	}
+	pick := pickAccountProfile(user, resolved)
+	remember := pick
+	if remember == "" {
+		remember = "default"
+	}
+	_ = os.WriteFile(autoProfilePath(agentDir), []byte(remember+"\n"), 0o600)
+	return pick
 }
 
 // A prompt typed on the phone reaches the new terminal by id, never inside

--- a/cmd/agent_claude.go
+++ b/cmd/agent_claude.go
@@ -19,6 +19,7 @@ import (
 	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/supervisor"
 	"andriiklymiuk/corgi/utils/agent/usage"
+	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
 // claudeLaunch is the command line `corgi agent claude` runs: the binary,
@@ -43,6 +44,7 @@ the corgi VS Code extension's "+" key runs it in a new terminal.
   corgi agent claude --workspace api # that workspace, whatever folder you are in
   corgi agent claude --profile work  # under a corgi profile
   corgi agent claude --profile auto  # the listed account with most budget left
+  corgi agent claude --model auto    # the workspace's models: policy, else opusplan
   corgi agent claude --show          # print the command instead of running it
   corgi agent claude -- --resume     # arguments after -- go to claude`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -67,6 +69,9 @@ the corgi VS Code extension's "+" key runs it in a new terminal.
 				exitWithError("agent_claude", err, 1)
 			}
 			cwd = root
+		}
+		if strings.EqualFold(strings.TrimSpace(model), "auto") {
+			model = autoModelFor(cwd)
 		}
 		if model != "" {
 			if !validModel(model) {
@@ -299,6 +304,25 @@ func pickAccountProfile(user *config.UserConfig, resolved config.Resolved) strin
 		return ""
 	}
 	return best
+}
+
+// autoModelFor is --model auto: the workspace's policy, else opusplan —
+// Opus to plan, Sonnet to execute, in one session.
+func autoModelFor(cwd string) string {
+	dir := agentDirOrEmpty()
+	if dir == "" {
+		return config.ModelAutoDefault
+	}
+	registry, err := workspace.Load(agentRegistryPath(dir))
+	if err != nil {
+		return config.ModelAutoDefault
+	}
+	id, _ := workspaceLabel(registry, cwd)
+	resolved, err := resolveWorkspaceConfig(dir, id)
+	if err != nil {
+		return config.ModelAutoDefault
+	}
+	return resolved.Models.ForAuto()
 }
 
 // autoSwitchAt is the reading past which --profile auto leaves the account

--- a/cmd/agent_handoff.go
+++ b/cmd/agent_handoff.go
@@ -1,0 +1,295 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/handoff"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
+	"andriiklymiuk/corgi/utils/agent/workspace"
+	"github.com/spf13/cobra"
+)
+
+// A handoff is what one run leaves for the next: typed, short, never a
+// transcript. Written by the session that is stopping — on a limit, at the
+// end of the day, before a carry — and read by whatever picks the ticket up,
+// on this machine or another, under any account.
+var agentHandoffCmd = &cobra.Command{
+	Use:   "handoff [--ref ABC-123] --done … --remaining … --next …",
+	Short: "Leave a typed handoff for the next run on this ticket",
+	Long: `Writes .corgi/corgi_services/handoffs/<ref>.json and a Markdown twin in the
+workspace. corgi fills in where the code is (branch, head, base, uncommitted
+files), who is writing (session, account) and how much budget was left; you
+say what is done, what is not, what was decided and what to ask.
+
+  corgi agent handoff --ref ABC-123 \
+    --done "POST /limits returns 429" --done "regression test" \
+    --remaining "web banner on 429" \
+    --decision "5h sliding window, not fixed" \
+    --uncertain "should the phone retry by itself?" \
+    --next "web banner, then open the web PR" \
+    --verify "corgi test --changed"
+
+  corgi agent handoff show ABC-123      # the Markdown twin
+  corgi agent handoff list              # every packet here, newest first
+  corgi agent handoff verify ABC-123    # re-run its check at the current head
+  corgi agent handoff rm ABC-123
+
+--ref defaults to the ticket key in the branch name. --verify runs the command
+now and records its exit code and the head it ran on; the next run re-runs it
+before trusting the packet. A packet that names a secret or a TODO is refused.`,
+	Args: cobra.NoArgs,
+	Run:  runAgentHandoff,
+}
+
+var agentHandoffShowCmd = &cobra.Command{
+	Use:   "show <ref>",
+	Short: "Print a handoff",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := handoffWorkspaceDir(cmd)
+		p, err := handoff.Read(dir, args[0])
+		if err != nil {
+			exitWithError("agent_handoff_show", fmt.Errorf("no handoff for %s in %s", args[0], dir), 2)
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(p)
+			return
+		}
+		fmt.Print(p.Markdown())
+		if n, err := handoff.CommitsSince(worktreeFor(dir, p), p.Where.Head); err == nil && n > 0 {
+			fmt.Printf("\n%d commit(s) since it was written — the code moved on; read the diff too.\n", n)
+		}
+	},
+}
+
+var agentHandoffListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Every handoff in this workspace, newest first",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		dir := handoffWorkspaceDir(cmd)
+		list := handoff.List(dir)
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"workspace": dir, "handoffs": list})
+			return
+		}
+		if len(list) == 0 {
+			fmt.Printf("No handoffs in %s\n", handoff.Dir(dir))
+			return
+		}
+		for _, p := range list {
+			fmt.Printf("%-12s %-16s %s  (%s)\n", p.Ref, p.State, p.Summary(), roughAge(time.Since(p.WrittenAt)))
+		}
+	},
+}
+
+var agentHandoffVerifyCmd = &cobra.Command{
+	Use:   "verify <ref>",
+	Short: "Re-run a handoff's check at the current head",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := handoffWorkspaceDir(cmd)
+		p, err := handoff.Read(dir, args[0])
+		if err != nil {
+			exitWithError("agent_handoff_verify", fmt.Errorf("no handoff for %s in %s", args[0], dir), 2)
+		}
+		if p.Verification == nil {
+			exitWithError("agent_handoff_verify", fmt.Errorf("%s has no verification command", p.Ref), 2)
+		}
+		v, ok := handoff.Verify(worktreeFor(dir, p), p, runShell)
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"ref": p.Ref, "verified": ok, "result": v, "recorded": p.Verification})
+		} else if ok {
+			fmt.Printf("✓ %s: `%s` passes at %s — the packet can be trusted as written\n", p.Ref, v.Cmd, shortSHA(v.At))
+		} else {
+			fmt.Printf("✗ %s: `%s` exit %d at %s (packet said exit %d at %s) — start from the ticket and the diff, not the packet\n",
+				p.Ref, v.Cmd, v.Exit, shortSHA(v.At), p.Verification.Exit, shortSHA(p.Verification.At))
+		}
+		if !ok {
+			os.Exit(1)
+		}
+	},
+}
+
+var agentHandoffRmCmd = &cobra.Command{
+	Use:   "rm <ref>",
+	Short: "Delete a handoff",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := handoffWorkspaceDir(cmd)
+		if err := handoff.Remove(dir, args[0]); err != nil {
+			exitWithError("agent_handoff_rm", err, 1)
+		}
+		fmt.Printf("removed %s\n", args[0])
+	},
+}
+
+func runAgentHandoff(cmd *cobra.Command, _ []string) {
+	f := cmd.Flags()
+	dir := handoffWorkspaceDir(cmd)
+	cwd, _ := os.Getwd()
+	where := handoff.GitWhere(cwd)
+	ref, _ := f.GetString("ref")
+	if ref == "" {
+		ref = handoff.RefFromBranch(where.Branch)
+	}
+	if ref == "" {
+		exitWithError("agent_handoff", fmt.Errorf("say --ref: the branch %q names no ticket", where.Branch), 2)
+	}
+	if rel, err := filepath.Rel(dir, cwd); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		where.Worktree = rel
+	}
+	state, _ := f.GetString("state")
+	blocked, _ := f.GetString("blocked")
+	if blocked != "" {
+		state = handoff.StateBlocked
+	}
+	done, _ := f.GetStringArray("done")
+	remaining, _ := f.GetStringArray("remaining")
+	decisions, _ := f.GetStringArray("decision")
+	uncertain, _ := f.GetStringArray("uncertain")
+	next, _ := f.GetString("next")
+	tracker, _ := f.GetString("tracker")
+	model, _ := f.GetString("model")
+	sessionRef, _ := f.GetString("session")
+
+	p := handoff.Packet{Ref: strings.ToUpper(strings.TrimSpace(ref)), Tracker: tracker, State: state, Blocked: blocked,
+		Where: where, Done: done, Remaining: remaining, Decisions: decisions, Uncertain: uncertain, Next: next,
+		From: handoff.From{Harness: "claude", Model: model, Host: hostname()}}
+	fillFromBoard(&p, sessionRef, cwd)
+
+	if verify, _ := f.GetString("verify"); verify != "" {
+		code, _ := runShell(cwd, verify)
+		p.Verification = &handoff.Verification{Cmd: verify, Exit: code, At: where.Head, RanAt: time.Now()}
+	}
+	if err := handoff.Write(dir, p); err != nil {
+		exitWithError("agent_handoff", err, 2)
+	}
+	if utils.JSONOutput {
+		utils.PrintJSON(map[string]any{"path": handoff.Path(dir, p.Ref), "markdown": handoff.MarkdownPath(dir, p.Ref), "handoff": p})
+		return
+	}
+	fmt.Printf("✓ handoff for %s: %s\n  %s\n", p.Ref, p.Summary(), handoff.MarkdownPath(dir, p.Ref))
+	if p.Verification != nil && p.Verification.Exit != 0 {
+		fmt.Printf("  note: `%s` exited %d — the next run will see that\n", p.Verification.Cmd, p.Verification.Exit)
+	}
+}
+
+// fillFromBoard adds who is writing and how much room was left, from the
+// session board: the session named, else the one whose cwd this is.
+func fillFromBoard(p *handoff.Packet, sessionRef, cwd string) {
+	dir := agentDirOrEmpty()
+	if dir == "" {
+		return
+	}
+	rep, err := readBoard(dir)
+	if err != nil {
+		return
+	}
+	var match *sessions.Session
+	for i := range rep.State.Sessions {
+		s := &rep.State.Sessions[i]
+		if sessionRef != "" && (s.ID == sessionRef || s.Label == sessionRef || s.Display == sessionRef) {
+			match = s
+			break
+		}
+		if sessionRef == "" && s.Cwd == cwd && s.Status != sessions.StatusGone {
+			match = s
+		}
+	}
+	if match == nil {
+		return
+	}
+	p.From.Session = match.ID
+	p.From.Account = match.Profile
+	if p.From.Model == "" && match.Context != nil {
+		p.From.Model = match.Context.Model
+	}
+	if match.Context != nil {
+		p.Budget.Context = match.Context.Percent
+	}
+	if l, ok := usage.ReadLimits(match.ConfigDir); ok {
+		p.Budget.FiveHour, p.Budget.SevenDay = l.FiveHour.Percent, l.SevenDay.Percent
+	}
+}
+
+// handoffWorkspaceDir is where the packets live: the registered workspace
+// that contains cwd, else the git root, else cwd. --dir overrides.
+func handoffWorkspaceDir(cmd *cobra.Command) string {
+	if d, _ := cmd.Flags().GetString("dir"); d != "" {
+		return d
+	}
+	cwd, _ := os.Getwd()
+	if dir := agentDirOrEmpty(); dir != "" {
+		if registry, err := workspace.Load(agentRegistryPath(dir)); err == nil {
+			if _, root := workspaceLabel(registry, cwd); root != "" {
+				return root
+			}
+		}
+	}
+	if root := sessions.RepoRoot(cwd); root != "" {
+		return root
+	}
+	return cwd
+}
+
+func worktreeFor(dir string, p handoff.Packet) string {
+	if p.Where.Worktree != "" {
+		return filepath.Join(dir, p.Where.Worktree)
+	}
+	return dir
+}
+
+func runShell(dir, command string) (int, error) {
+	c := exec.Command("sh", "-c", command)
+	c.Dir = dir
+	c.Stdout, c.Stderr = os.Stderr, os.Stderr
+	err := c.Run()
+	if err == nil {
+		return 0, nil
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode(), err
+	}
+	return 1, err
+}
+
+func hostname() string {
+	h, _ := os.Hostname()
+	return h
+}
+
+func shortSHA(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
+}
+
+func init() {
+	f := agentHandoffCmd.Flags()
+	f.String("ref", "", "the ticket (default: the key in the branch name)")
+	f.String("tracker", "", "the ticket's URL")
+	f.String("state", handoff.StateInputRequired, "working, input-required, auth-required, completed, failed")
+	f.String("blocked", "", "the missing tool, credential or secret (sets state blocked)")
+	f.StringArray("done", nil, "one thing that is finished (repeatable)")
+	f.StringArray("remaining", nil, "one thing that is not (repeatable)")
+	f.StringArray("decision", nil, "one call made, so the next run does not re-derive it (repeatable)")
+	f.StringArray("uncertain", nil, "one thing to ask a person before assuming (repeatable)")
+	f.String("next", "", "the first thing the next run should do")
+	f.String("verify", "", "a command to run now and record, e.g. \"corgi test --changed\"")
+	f.String("model", "", "the model that did the work")
+	f.String("session", "", "the board session writing this (default: the one in this directory)")
+	for _, c := range []*cobra.Command{agentHandoffCmd, agentHandoffShowCmd, agentHandoffListCmd, agentHandoffVerifyCmd, agentHandoffRmCmd} {
+		c.Flags().String("dir", "", "the workspace (default: the one containing the current directory)")
+	}
+	agentHandoffCmd.AddCommand(agentHandoffShowCmd, agentHandoffListCmd, agentHandoffVerifyCmd, agentHandoffRmCmd)
+	agentCmd.AddCommand(agentHandoffCmd)
+}

--- a/cmd/agent_harden.go
+++ b/cmd/agent_harden.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/config"
+	"andriiklymiuk/corgi/utils/agent/workspace"
+	"github.com/spf13/cobra"
+)
+
+// harden writes the safe defaults into a workspace's local Claude settings
+// — the ones every unattended run should have and nobody remembers to set:
+// no reading of secrets, no destructive git or shell, and a hook that
+// refuses to write a key into a file. Additive: it never removes a rule
+// someone wrote, and it is silent about rules already there.
+
+var hardenDeny = []string{
+	"Read(./.env)",
+	"Read(./.env.*)",
+	"Read(./**/.env)",
+	"Read(./**/.env.*)",
+	"Read(./**/secrets/**)",
+	"Read(./**/*.pem)",
+	"Read(./**/*.key)",
+	"Read(~/.ssh/**)",
+	"Read(~/.aws/**)",
+	"Bash(rm -rf *)",
+	"Bash(sudo *)",
+	"Bash(git push --force*)",
+	"Bash(git push -f*)",
+	"Bash(git reset --hard*)",
+	"Bash(git clean -fd*)",
+	"Bash(* --no-verify*)",
+	"Bash(curl * | sh)",
+	"Bash(curl * | bash)",
+	"Bash(wget * | sh)",
+}
+
+const (
+	hookSecrets       = "corgi agent hook secrets"
+	trackMarkerSecret = "agent hook secrets"
+)
+
+var agentHardenCmd = &cobra.Command{
+	Use:   "harden",
+	Short: "Write the safe defaults into this workspace's Claude settings",
+	Long: `Adds to .claude/settings.local.json in the workspace: deny rules for reading
+secrets (.env, keys, ~/.ssh, ~/.aws) and for destructive shell and git
+(rm -rf, sudo, force push, reset --hard, --no-verify, curl | sh), and a hook
+that refuses to write a credential into a file. Nothing is removed; a rule
+already there is left alone.
+
+  corgi agent harden               # the workspace you are in
+  corgi agent harden --dry-run     # show what would change
+  corgi agent doctor --security    # what is still loose`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		cwd, _ := os.Getwd()
+		root := scopeWorkspaceRoot(cwd)
+		if root == "" {
+			root = cwd
+		}
+		dry, _ := cmd.Flags().GetBool("dry-run")
+		added, err := hardenSettings(claudeLocalSettingsPath(root), corgiCommandPath(), dry)
+		if err != nil {
+			exitWithError("agent_harden", err, 1)
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"path": claudeLocalSettingsPath(root), "added": added, "dryRun": dry})
+			return
+		}
+		if len(added) == 0 {
+			fmt.Printf("✓ %s already has every rule harden writes\n", claudeLocalSettingsPath(root))
+			return
+		}
+		verb := "added"
+		if dry {
+			verb = "would add"
+		}
+		fmt.Printf("%s %d to %s:\n", verb, len(added), claudeLocalSettingsPath(root))
+		for _, a := range added {
+			fmt.Printf("  %s\n", a)
+		}
+		if !dry {
+			fmt.Println("new sessions here pick it up; a running one after /reload or restart")
+		}
+	},
+}
+
+// hardenSettings merges the rules and the hook into a settings file and
+// returns what it added.
+func hardenSettings(path, bin string, dry bool) ([]string, error) {
+	settings, err := readUserSettings(path)
+	if err != nil {
+		return nil, err
+	}
+	var added []string
+	perms, _ := settings["permissions"].(map[string]any)
+	if perms == nil {
+		perms = map[string]any{}
+	}
+	deny, _ := perms["deny"].([]any)
+	have := map[string]bool{}
+	for _, d := range deny {
+		if s, ok := d.(string); ok {
+			have[s] = true
+		}
+	}
+	for _, rule := range hardenDeny {
+		if !have[rule] {
+			deny = append(deny, rule)
+			added = append(added, "deny "+rule)
+		}
+	}
+	perms["deny"] = deny
+	settings["permissions"] = perms
+
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	if !strings.Contains(marshalCompact(hooks["PreToolUse"]), trackMarkerSecret) {
+		entries, _ := hooks["PreToolUse"].([]any)
+		entries = append(entries, map[string]any{"matcher": writingTools, "hooks": []any{
+			map[string]any{"type": "command", "command": hookCommand(bin, hookSecrets), "timeout": 5},
+		}})
+		hooks["PreToolUse"] = entries
+		added = append(added, "hook PreToolUse "+writingTools+" → "+hookSecrets)
+	}
+	settings["hooks"] = hooks
+	if dry || len(added) == 0 {
+		return added, nil
+	}
+	return added, writeJSONObject(path, settings)
+}
+
+var (
+	secretValue      = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd|private[_-]?key)\s*[:=]\s*['"]?[^\s'"$<{]{12,}`)
+	knownSecret      = regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{8,}|sk-[A-Za-z0-9]{32,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|glpat-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY|lin_api_[A-Za-z0-9]{20,}`)
+	placeholderValue = regexp.MustCompile(`(?i)(example|placeholder|changeme|your[_-]?|xxx+|\$\{|\bprocess\.env\b|os\.Getenv|<[^>]+>)`)
+)
+
+// runSecretsHook refuses a write whose new content carries a credential.
+// The place for a key is the environment or a secret store, never a file a
+// commit can pick up — and never a transcript.
+func runSecretsHook(stdin io.Reader, stdout io.Writer) {
+	data, err := io.ReadAll(io.LimitReader(stdin, 4<<20))
+	if err != nil {
+		return
+	}
+	var in struct {
+		ToolInput struct {
+			FilePath  string `json:"file_path"`
+			Content   string `json:"content"`
+			NewString string `json:"new_string"`
+			Edits     []struct {
+				NewString string `json:"new_string"`
+			} `json:"edits"`
+		} `json:"tool_input"`
+	}
+	if json.Unmarshal(data, &in) != nil {
+		return
+	}
+	var texts []string
+	texts = append(texts, in.ToolInput.Content, in.ToolInput.NewString)
+	for _, e := range in.ToolInput.Edits {
+		texts = append(texts, e.NewString)
+	}
+	for _, t := range texts {
+		if t == "" {
+			continue
+		}
+		for _, line := range strings.Split(t, "\n") {
+			if placeholderValue.MatchString(line) {
+				continue
+			}
+			if knownSecret.MatchString(line) || secretValue.MatchString(line) {
+				_ = json.NewEncoder(stdout).Encode(map[string]any{
+					"hookSpecificOutput": map[string]any{
+						"hookEventName":            "PreToolUse",
+						"permissionDecision":       "deny",
+						"permissionDecisionReason": fmt.Sprintf("that write to %s carries what looks like a credential; keep it in the environment or a secret store and read it from there, never in a file", in.ToolInput.FilePath),
+					},
+				})
+				return
+			}
+		}
+	}
+}
+
+// Security checks for doctor: what a hardened machine has, and what this one
+// is missing.
+
+func checkSecurity() []agentCheck {
+	var checks []agentCheck
+	dir, err := agentDir()
+	if err != nil {
+		return checks
+	}
+	registry, err := workspace.Load(agentRegistryPath(dir))
+	if err != nil {
+		return checks
+	}
+	user, _ := config.LoadUser(agentUserConfigPath(dir))
+	for _, ws := range registry.Workspaces {
+		repo, _ := config.LoadRepo(ws.AbsPath)
+		resolved := config.Resolve(ws.ID, repo, user)
+		name := "security · " + ws.ID
+		var loose []string
+		settings, _ := readUserSettings(claudeLocalSettingsPath(ws.AbsPath))
+		perms, _ := settings["permissions"].(map[string]any)
+		text := marshalCompact(perms)
+		if !strings.Contains(text, "Read(./.env)") {
+			loose = append(loose, "no deny rules for secrets")
+		}
+		if !strings.Contains(marshalCompact(settings["hooks"]), trackMarkerSecret) {
+			loose = append(loose, "no secrets hook")
+		}
+		if resolved.DangerouslySkipPermissions {
+			loose = append(loose, "runs unattended with permissions off")
+		}
+		if resolved.Watch != nil && resolved.Watch.Action == "fix" && !resolved.Watch.Isolate {
+			loose = append(loose, "unattended fixes run in the checkout, not a worktree (--isolate)")
+		}
+		if len(loose) == 0 {
+			checks = append(checks, agentCheck{Name: name, OK: true, Detail: "hardened"})
+			continue
+		}
+		checks = append(checks, agentCheck{Name: name, OK: !resolved.DangerouslySkipPermissions || len(loose) == 1, Detail: strings.Join(loose, "; "),
+			Fix: "`corgi agent harden` in " + ws.AbsPath})
+	}
+	if os.Getenv("CORGI_MCP_ALLOW_DANGEROUS_TUNNEL") != "" {
+		checks = append(checks, agentCheck{Name: "security · tunnel", Detail: "CORGI_MCP_ALLOW_DANGEROUS_TUNNEL is set: exec and database tools answer over a public tunnel", Fix: "unset it unless the tunnel is private (Tailscale, LAN)"})
+	} else {
+		checks = append(checks, agentCheck{Name: "security · tunnel", OK: true, Detail: "dangerous tools stay off a public tunnel"})
+	}
+	return checks
+}
+
+func init() {
+	agentHardenCmd.Flags().Bool("dry-run", false, "show what would change without writing")
+	agentCmd.AddCommand(agentHardenCmd)
+}

--- a/cmd/agent_harden_test.go
+++ b/cmd/agent_harden_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// harden adds what is missing and leaves what is there: deny rules for
+// secrets and destruction, and the hook that refuses to write a key.
+func TestHardenIsAdditiveAndIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"permissions":{"deny":["Bash(sudo *)"],"allow":["Bash(go test *)"]},"hooks":{"Stop":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	added, err := hardenSettings(path, "/usr/local/bin/corgi", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != len(hardenDeny) { // one deny was there already, the hook is new
+		t.Fatalf("added %d: %v", len(added), added)
+	}
+	settings, _ := readUserSettings(path)
+	perms := settings["permissions"].(map[string]any)
+	if allow, _ := perms["allow"].([]any); len(allow) != 1 {
+		t.Fatal("the allow list is untouched")
+	}
+	if deny, _ := perms["deny"].([]any); len(deny) != len(hardenDeny) {
+		t.Fatalf("deny has %d rules", len(deny))
+	}
+	if !strings.Contains(marshalCompact(settings["hooks"]), "agent hook secrets") || !strings.Contains(marshalCompact(settings["hooks"]), "echo hi") {
+		t.Fatal("the hook is added and the existing one kept")
+	}
+	again, err := hardenSettings(path, "/usr/local/bin/corgi", false)
+	if err != nil || len(again) != 0 {
+		t.Fatalf("second run adds nothing: %v %v", again, err)
+	}
+}
+
+// The secrets hook refuses a real key and lets placeholders and env reads
+// through.
+func TestTheSecretsHookRefusesARealKey(t *testing.T) {
+	run := func(content string) string {
+		in, _ := json.Marshal(map[string]any{"tool_input": map[string]any{"file_path": "config.ts", "content": content}})
+		var out bytes.Buffer
+		runSecretsHook(bytes.NewReader(in), &out)
+		return out.String()
+	}
+	if got := run("const key = process.env.API_KEY\nAPI_KEY=your-key-here\ntoken: ${TOKEN}\n"); got != "" {
+		t.Fatalf("placeholders pass: %s", got)
+	}
+	if got := run("export const key = 'sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789'\n"); !strings.Contains(got, "deny") {
+		t.Fatalf("a real key is refused: %s", got)
+	}
+	if got := run("password = \"Tr0ub4dor&3-really-long-password\"\n"); !strings.Contains(got, "deny") {
+		t.Fatalf("a password literal is refused: %s", got)
+	}
+}

--- a/cmd/agent_hook_context.go
+++ b/cmd/agent_hook_context.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"andriiklymiuk/corgi/utils/agent/brief"
+	"andriiklymiuk/corgi/utils/agent/handoff"
 	"andriiklymiuk/corgi/utils/agent/sessions"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
@@ -92,10 +93,38 @@ func sessionContext(dir string, in contextHookInput, configDir string, now time.
 	if path, facts := memoryIndex(in.Cwd, root); facts > 0 {
 		lines = append(lines, fmt.Sprintf("workspace memory: %d facts in %s — read it before changing code", facts, path))
 	}
+	if line := handoffLine(root, sessions.Branch(in.Cwd), now); line != "" {
+		lines = append(lines, line)
+	}
 	if len(lines) == 0 {
 		return ""
 	}
 	return head + "\n" + strings.Join(lines, "\n")
+}
+
+// handoffLine points a new session at the packet an earlier run left for
+// this branch's ticket, with how far the code moved since. The packet is
+// the first thing to read; the hook only says it is there.
+func handoffLine(root, branch string, now time.Time) string {
+	if root == "" {
+		return ""
+	}
+	p, ok := handoff.ForBranch(root, branch)
+	if !ok || now.Sub(p.WrittenAt) > handoff.MaxAge {
+		return ""
+	}
+	line := fmt.Sprintf("handoff for %s (%s, %s ago): read %s first", p.Ref, p.State, roughAge(now.Sub(p.WrittenAt)), handoff.MarkdownPath(root, p.Ref))
+	dir := root
+	if p.Where.Worktree != "" {
+		dir = filepath.Join(root, p.Where.Worktree)
+	}
+	if n, err := handoff.CommitsSince(dir, p.Where.Head); err == nil && n > 0 {
+		line += fmt.Sprintf(" — %d commit(s) since, so check its done list against the diff", n)
+	}
+	if p.Verification != nil {
+		line += fmt.Sprintf("; `corgi agent handoff verify %s` re-runs its check", p.Ref)
+	}
+	return line
 }
 
 // otherSessionsHere names the live sessions in the same workspace, so two

--- a/cmd/agent_hook_context.go
+++ b/cmd/agent_hook_context.go
@@ -12,6 +12,7 @@ import (
 
 	"andriiklymiuk/corgi/utils/agent/brief"
 	"andriiklymiuk/corgi/utils/agent/handoff"
+	"andriiklymiuk/corgi/utils/agent/scope"
 	"andriiklymiuk/corgi/utils/agent/sessions"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 )
@@ -94,6 +95,9 @@ func sessionContext(dir string, in contextHookInput, configDir string, now time.
 		lines = append(lines, fmt.Sprintf("workspace memory: %d facts in %s — read it before changing code", facts, path))
 	}
 	if line := handoffLine(root, sessions.Branch(in.Cwd), now); line != "" {
+		lines = append(lines, line)
+	}
+	if line := scopeLineFor(root, sessions.Branch(in.Cwd)); line != "" {
 		lines = append(lines, line)
 	}
 	if len(lines) == 0 {
@@ -241,4 +245,17 @@ func memoryIndex(cwd, root string) (string, int) {
 		dir = parent
 	}
 	return "", 0
+}
+
+// scopeLineFor tells a session what its branch's ticket agreed to: the
+// paths it may touch and the budget, so the hooks are no surprise.
+func scopeLineFor(root, branch string) string {
+	if root == "" {
+		return ""
+	}
+	s, ok := scope.ForBranch(root, branch)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("scope for %s: %s — a write outside is refused; widen with `corgi agent scope add %s --path …` and say why", s.Ref, scopeLine(s), s.Ref)
 }

--- a/cmd/agent_hook_context.go
+++ b/cmd/agent_hook_context.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"andriiklymiuk/corgi/utils/agent/scope"
 	"andriiklymiuk/corgi/utils/agent/sessions"
 	"andriiklymiuk/corgi/utils/agent/workspace"
+	"gopkg.in/yaml.v3"
 )
 
 // The SessionStart context hook: the one synchronous hook, and the one that
@@ -98,6 +100,9 @@ func sessionContext(dir string, in contextHookInput, configDir string, now time.
 		lines = append(lines, line)
 	}
 	if line := scopeLineFor(root, sessions.Branch(in.Cwd)); line != "" {
+		lines = append(lines, line)
+	}
+	if line := stackLine(root); line != "" {
 		lines = append(lines, line)
 	}
 	if len(lines) == 0 {
@@ -258,4 +263,66 @@ func scopeLineFor(root, branch string) string {
 		return ""
 	}
 	return fmt.Sprintf("scope for %s: %s — a write outside is refused; widen with `corgi agent scope add %s --path …` and say why", s.Ref, scopeLine(s), s.Ref)
+}
+
+// stackLine names the services of the stack a session sits in and how to
+// reach them, so the tools that make this machine different from any other
+// are the first thing the session knows about.
+func stackLine(root string) string {
+	if root == "" {
+		return ""
+	}
+	path := ""
+	for _, name := range []string{"corgi-compose.yml", "corgi-compose.yaml"} {
+		if _, err := os.Stat(filepath.Join(root, name)); err == nil {
+			path = filepath.Join(root, name)
+			break
+		}
+	}
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var y struct {
+		Services map[string]struct {
+			Port int `yaml:"port"`
+		} `yaml:"services"`
+		DBs map[string]struct {
+			Driver string `yaml:"driver"`
+		} `yaml:"db_services"`
+	}
+	if yaml.Unmarshal(data, &y) != nil || (len(y.Services) == 0 && len(y.DBs) == 0) {
+		return ""
+	}
+	var parts []string
+	for _, name := range composeNames(y.Services) {
+		if p := y.Services[name].Port; p > 0 {
+			parts = append(parts, fmt.Sprintf("%s :%d", name, p))
+		} else {
+			parts = append(parts, name)
+		}
+	}
+	for _, name := range composeNames(y.DBs) {
+		if d := y.DBs[name].Driver; d != "" {
+			parts = append(parts, name+" ("+d+")")
+		} else {
+			parts = append(parts, name)
+		}
+	}
+	if len(parts) > 8 {
+		parts = append(parts[:8], fmt.Sprintf("+%d more", len(parts)-8))
+	}
+	return "stack: " + strings.Join(parts, " · ") + " — corgi_http, corgi_logs, corgi_db_query and corgi_explain reach them once corgi run is up"
+}
+
+func composeNames[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/cmd/agent_hook_context_test.go
+++ b/cmd/agent_hook_context_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"andriiklymiuk/corgi/utils/agent/handoff"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -90,5 +91,26 @@ func TestRoughAge(t *testing.T) {
 		if got := roughAge(d); got != want {
 			t.Errorf("%v = %q, want %q", d, got, want)
 		}
+	}
+}
+
+// A session that starts on a branch with a handoff is told to read it
+// first, and how far the code has moved since it was written.
+func TestSessionStartPointsAtTheHandoffForTheBranch(t *testing.T) {
+	root := t.TempDir()
+	if err := handoff.Write(root, handoff.Packet{Ref: "ABC-5", State: handoff.StateInputRequired, Next: "web side",
+		Where: handoff.Where{Branch: "feature/ABC-5/x", Head: "deadbeef"}, Verification: &handoff.Verification{Cmd: "true"}}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	line := handoffLine(root, "feature/ABC-5/x", now)
+	if !strings.Contains(line, "handoff for ABC-5") || !strings.Contains(line, "read ") || !strings.Contains(line, "verify ABC-5") {
+		t.Fatalf("line: %q", line)
+	}
+	if handoffLine(root, "main", now) != "" {
+		t.Fatal("no packet for main")
+	}
+	if handoffLine(root, "feature/ABC-5/x", now.Add(8*24*time.Hour)) != "" {
+		t.Fatal("a week-old packet is not offered")
 	}
 }

--- a/cmd/agent_hook_context_test.go
+++ b/cmd/agent_hook_context_test.go
@@ -114,3 +114,19 @@ func TestSessionStartPointsAtTheHandoffForTheBranch(t *testing.T) {
 		t.Fatal("a week-old packet is not offered")
 	}
 }
+
+func TestSessionStartNamesTheStack(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "corgi-compose.yml"), []byte("services:\n  api:\n    port: 8080\n  web:\n    port: 3000\ndb_services:\n  db:\n    driver: postgres\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	line := stackLine(root)
+	for _, want := range []string{"stack: api :8080", "web :3000", "db (postgres)", "corgi_http"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("line lacks %q: %s", want, line)
+		}
+	}
+	if stackLine(t.TempDir()) != "" {
+		t.Fatal("no compose, no line")
+	}
+}

--- a/cmd/agent_hook_scope.go
+++ b/cmd/agent_hook_scope.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"andriiklymiuk/corgi/utils/agent/scope"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/workspace"
+)
+
+// Two hooks keep a session inside the scope the spec agreed. PreToolUse on
+// a write refuses a path outside it, with the way to widen; Stop reports a
+// diff over budget once, so the size is a decision and not a surprise at
+// review. Both are silent when the branch has no scope, so a workspace that
+// never wrote one is untouched.
+
+type scopeHookInput struct {
+	SessionID string `json:"session_id"`
+	Cwd       string `json:"cwd"`
+	ToolName  string `json:"tool_name"`
+	ToolInput struct {
+		FilePath     string `json:"file_path"`
+		NotebookPath string `json:"notebook_path"`
+	} `json:"tool_input"`
+	StopHookActive bool `json:"stop_hook_active"`
+}
+
+// scopeFor finds the workspace root and the scope for the branch cwd is on.
+func scopeFor(cwd string) (root string, s scope.Scope, ok bool) {
+	root = scopeWorkspaceRoot(cwd)
+	if root == "" {
+		return "", scope.Scope{}, false
+	}
+	s, ok = scope.ForBranch(root, sessions.Branch(cwd))
+	return root, s, ok
+}
+
+// workspaceRootFor is the registered workspace containing cwd, else the git
+// root, else "".
+func scopeWorkspaceRoot(cwd string) string {
+	if dir := agentDirOrEmpty(); dir != "" {
+		if registry, err := workspace.Load(agentRegistryPath(dir)); err == nil {
+			if _, root := workspaceLabel(registry, cwd); root != "" {
+				return root
+			}
+		}
+	}
+	return sessions.RepoRoot(cwd)
+}
+
+func runScopeHook(stdin io.Reader, stdout io.Writer) {
+	data, err := io.ReadAll(io.LimitReader(stdin, 64<<10))
+	if err != nil {
+		return
+	}
+	var in scopeHookInput
+	if json.Unmarshal(data, &in) != nil || in.Cwd == "" {
+		return
+	}
+	file := firstNonEmpty(in.ToolInput.FilePath, in.ToolInput.NotebookPath)
+	if file == "" {
+		return
+	}
+	root, s, ok := scopeFor(in.Cwd)
+	if !ok || len(s.Paths) == 0 {
+		return
+	}
+	abs := file
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(in.Cwd, abs)
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		rel = abs
+	}
+	if s.Allows(rel) {
+		return
+	}
+	reason := fmt.Sprintf("%s is outside the scope agreed for %s (%s). If the change really needs it, widen the scope on the record — `corgi agent scope add %s --path %q` — and say why in the PR; otherwise keep the change inside it.",
+		rel, s.Ref, strings.Join(s.Paths, ", "), s.Ref, rel)
+	_ = json.NewEncoder(stdout).Encode(map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":            "PreToolUse",
+			"permissionDecision":       "deny",
+			"permissionDecisionReason": reason,
+		},
+	})
+}
+
+// diffStat is a seam for tests: added+removed lines and new test files
+// against the branch's base.
+var diffStat = gitDiffStat
+
+func gitDiffStat(dir string) (lines int, newTests int, ok bool) {
+	base := ""
+	for _, b := range []string{"origin/main", "origin/master", "main", "master"} {
+		out, err := exec.Command("git", "-C", dir, "merge-base", "HEAD", b).Output()
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			base = strings.TrimSpace(string(out))
+			break
+		}
+	}
+	if base == "" {
+		return 0, 0, false
+	}
+	out, err := exec.Command("git", "-C", dir, "diff", "--numstat", base).Output()
+	if err != nil {
+		return 0, 0, false
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 3 {
+			continue
+		}
+		a, _ := strconv.Atoi(f[0])
+		d, _ := strconv.Atoi(f[1])
+		lines += a + d
+	}
+	added, err := exec.Command("git", "-C", dir, "diff", "--name-only", "--diff-filter=A", base).Output()
+	if err == nil {
+		for _, f := range strings.Split(strings.TrimSpace(string(added)), "\n") {
+			if f != "" && scope.IsTestFile(f) {
+				newTests++
+			}
+		}
+	}
+	return lines, newTests, true
+}
+
+func runBudgetHook(stdin io.Reader, stdout io.Writer) {
+	data, err := io.ReadAll(io.LimitReader(stdin, 64<<10))
+	if err != nil {
+		return
+	}
+	var in scopeHookInput
+	if json.Unmarshal(data, &in) != nil || in.Cwd == "" || in.StopHookActive {
+		return
+	}
+	root, s, ok := scopeFor(in.Cwd)
+	if !ok || (s.Lines == 0 && s.Tests == 0) {
+		return
+	}
+	lines, tests, ok := diffStat(in.Cwd)
+	if !ok {
+		return
+	}
+	var over []string
+	if s.Lines > 0 && lines > s.Lines {
+		over = append(over, fmt.Sprintf("the diff is %d lines against a budget of %d", lines, s.Lines))
+	}
+	if s.Tests > 0 && tests > s.Tests {
+		over = append(over, fmt.Sprintf("%d new test files against a budget of %d", tests, s.Tests))
+	}
+	if len(over) == 0 {
+		return
+	}
+	// Once per session: the second Stop lets the turn end, so a size the
+	// run has already defended is not a loop.
+	marker := filepath.Join(scope.Dir(root), "."+in.SessionID+"-"+s.Ref+".reported")
+	if _, err := os.Stat(marker); err == nil {
+		return
+	}
+	_ = os.WriteFile(marker, []byte("reported\n"), 0o600)
+	reason := fmt.Sprintf("Before you stop: %s for %s. Trim the change to what the spec asked for, or — if this size is right — say why in one line in the PR body and raise the budget on the record: `corgi agent scope set %s --lines %d --tests %d`.",
+		strings.Join(over, "; "), s.Ref, s.Ref, lines, tests)
+	_ = json.NewEncoder(stdout).Encode(map[string]any{"decision": "block", "reason": reason})
+}

--- a/cmd/agent_hook_scope_test.go
+++ b/cmd/agent_hook_scope_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"andriiklymiuk/corgi/utils/agent/scope"
+)
+
+// A write outside the scope is refused with the way to widen; a write
+// inside, or on a branch with no scope, passes without a word.
+func TestTheScopeHookRefusesAWriteOutsideThePaths(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	root := t.TempDir()
+	gitRepoOnBranch(t, root, "feature/ABC-9/limits")
+	if err := scope.Write(root, scope.Scope{Ref: "ABC-9", Paths: []string{"api/**"}}); err != nil {
+		t.Fatal(err)
+	}
+	run := func(file string) string {
+		in, _ := json.Marshal(map[string]any{"cwd": root, "tool_name": "Edit", "tool_input": map[string]any{"file_path": file}})
+		var out bytes.Buffer
+		runScopeHook(bytes.NewReader(in), &out)
+		return out.String()
+	}
+	if got := run(filepath.Join(root, "api", "limits.go")); got != "" {
+		t.Fatalf("inside: %s", got)
+	}
+	got := run(filepath.Join(root, "web", "Banner.tsx"))
+	if !strings.Contains(got, `"permissionDecision":"deny"`) || !strings.Contains(got, "corgi agent scope add ABC-9") {
+		t.Fatalf("outside: %s", got)
+	}
+	if _, err := scope.Widen(root, "ABC-9", "web/**", "session"); err != nil {
+		t.Fatal(err)
+	}
+	if got := run(filepath.Join(root, "web", "Banner.tsx")); got != "" {
+		t.Fatalf("widened: %s", got)
+	}
+	other := t.TempDir()
+	gitRepoOnBranch(t, other, "main")
+	in, _ := json.Marshal(map[string]any{"cwd": other, "tool_name": "Edit", "tool_input": map[string]any{"file_path": filepath.Join(other, "x.go")}})
+	var out bytes.Buffer
+	runScopeHook(bytes.NewReader(in), &out)
+	if out.String() != "" {
+		t.Fatal("no scope, no opinion")
+	}
+}
+
+// A diff over budget stops the turn once with the numbers and the way to
+// raise the budget; the second stop in the same session lets it end.
+func TestTheBudgetHookReportsOnce(t *testing.T) {
+	t.Setenv("CORGI_DATA_DIR", t.TempDir())
+	root := t.TempDir()
+	gitRepoOnBranch(t, root, "feature/ABC-9/limits")
+	if err := scope.Write(root, scope.Scope{Ref: "ABC-9", Lines: 100, Tests: 1}); err != nil {
+		t.Fatal(err)
+	}
+	orig := diffStat
+	defer func() { diffStat = orig }()
+	diffStat = func(string) (int, int, bool) { return 340, 3, true }
+	run := func(active bool) string {
+		in, _ := json.Marshal(map[string]any{"cwd": root, "session_id": "s1", "stop_hook_active": active})
+		var out bytes.Buffer
+		runBudgetHook(bytes.NewReader(in), &out)
+		return out.String()
+	}
+	got := run(false)
+	if !strings.Contains(got, `"decision":"block"`) || !strings.Contains(got, "340 lines against a budget of 100") || !strings.Contains(got, "3 new test files against a budget of 1") {
+		t.Fatalf("first stop: %s", got)
+	}
+	if got := run(false); got != "" {
+		t.Fatalf("second stop in the session passes: %s", got)
+	}
+	if got := run(true); got != "" {
+		t.Fatal("a stop the hook itself caused is never blocked again")
+	}
+	diffStat = func(string) (int, int, bool) { return 40, 0, true }
+	in, _ := json.Marshal(map[string]any{"cwd": root, "session_id": "s2"})
+	var out bytes.Buffer
+	runBudgetHook(bytes.NewReader(in), &out)
+	if out.String() != "" {
+		t.Fatal("under budget, silent")
+	}
+}

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -355,6 +355,12 @@ func runAgentHook(cmd *cobra.Command, args []string) {
 	case "context":
 		runContextHook(os.Stdin, os.Stdout, os.Getenv, time.Now())
 		return
+	case "scope":
+		runScopeHook(os.Stdin, os.Stdout)
+		return
+	case "budget":
+		runBudgetHook(os.Stdin, os.Stdout)
+		return
 	case "tab":
 		registry, _ := workspace.Load(agentRegistryPath(agentDirOrEmpty()))
 		runTabTitleHook(os.Stdin, os.Stdout, func(cwd string) string {

--- a/cmd/agent_hooks.go
+++ b/cmd/agent_hooks.go
@@ -361,6 +361,9 @@ func runAgentHook(cmd *cobra.Command, args []string) {
 	case "budget":
 		runBudgetHook(os.Stdin, os.Stdout)
 		return
+	case "secrets":
+		runSecretsHook(os.Stdin, os.Stdout)
+		return
 	case "tab":
 		registry, _ := workspace.Load(agentRegistryPath(agentDirOrEmpty()))
 		runTabTitleHook(os.Stdin, os.Stdout, func(cwd string) string {

--- a/cmd/agent_kanban.go
+++ b/cmd/agent_kanban.go
@@ -112,7 +112,7 @@ func buildKanban(in kanbanInputs) []KanbanCard {
 
 	// Inbox events, newest first: the first one on a ref names the card.
 	for _, e := range in.events {
-		if e.Ref == "" || (in.ignored != nil && in.ignored(e.Key)) {
+		if e.Ref == "" || e.Kind == watch.KindRoutine || (in.ignored != nil && in.ignored(e.Key)) {
 			continue
 		}
 		current := e.State
@@ -141,7 +141,7 @@ func buildKanban(in kanbanInputs) []KanbanCard {
 	// outcome on the card.
 	if in.fixes != nil {
 		for _, r := range in.fixes.RecentFixes("", 100) {
-			if r.Ref == "" {
+			if r.Ref == "" || strings.HasPrefix(r.Ref, "routine/") {
 				continue
 			}
 			c := card(r.Workspace, r.Ref)

--- a/cmd/agent_kanban.go
+++ b/cmd/agent_kanban.go
@@ -1,0 +1,327 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/handoff"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/watch"
+	"andriiklymiuk/corgi/utils/agent/workspace"
+	"github.com/spf13/cobra"
+)
+
+// The kanban is one card per ticket, in a column corgi works out from what
+// it already knows: the inbox, the runs, the sessions, the handoffs, the
+// ticket's own state. Nobody drags a card into Running; a run puts it
+// there. Moving a card moves the ticket on the tracker, nothing else.
+
+const (
+	ColInbox   = "Inbox"
+	ColReady   = "Ready"
+	ColRunning = "Running"
+	ColBlocked = "Blocked"
+	ColReview  = "Review"
+	ColDone    = "Done"
+)
+
+var kanbanColumns = []string{ColInbox, ColReady, ColRunning, ColBlocked, ColReview, ColDone}
+
+// KanbanCard is one ticket as the board sees it.
+type KanbanCard struct {
+	Ref       string    `json:"ref"`
+	Key       string    `json:"key,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	Workspace string    `json:"workspace,omitempty"`
+	Kind      string    `json:"kind,omitempty"`
+	Column    string    `json:"column"`
+	Why       string    `json:"why"`
+	State     string    `json:"state,omitempty"`
+	Branch    string    `json:"branch,omitempty"`
+	Blocked   string    `json:"blocked,omitempty"`
+	BlockedBy string    `json:"blockedBy,omitempty"`
+	Session   *CardSess `json:"session,omitempty"`
+	Fix       *CardFix  `json:"fix,omitempty"`
+	Handoff   *CardHand `json:"handoff,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type CardSess struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Status string `json:"status"`
+}
+
+type CardFix struct {
+	Running   bool      `json:"running"`
+	StartedAt time.Time `json:"startedAt"`
+	Outcome   string    `json:"outcome"`
+	PRs       []string  `json:"prs,omitempty"`
+	Branch    string    `json:"branch,omitempty"`
+}
+
+type CardHand struct {
+	State string `json:"state"`
+	Next  string `json:"next,omitempty"`
+	Path  string `json:"path"`
+	Draft bool   `json:"draft,omitempty"`
+}
+
+// kanbanInputs is everything the board is built from, gathered once so the
+// derivation is a pure function that a test can drive.
+type kanbanInputs struct {
+	events   []watch.Event
+	ignored  func(key string) bool
+	moved    *watch.StateLog
+	fixes    *watch.FixLog
+	sessions []sessions.Session
+	packets  map[string][]handoff.Packet // by workspace id
+	now      time.Time
+}
+
+func buildKanban(in kanbanInputs) []KanbanCard {
+	byRef := map[string]*KanbanCard{}
+	order := []string{}
+	card := func(ws, ref string) *KanbanCard {
+		id := ws + "/" + ref
+		if c, ok := byRef[id]; ok {
+			return c
+		}
+		c := &KanbanCard{Ref: ref, Workspace: ws, Column: ColInbox}
+		byRef[id] = c
+		order = append(order, id)
+		return c
+	}
+
+	// Inbox events, newest first: the first one on a ref names the card.
+	for _, e := range in.events {
+		if e.Ref == "" || (in.ignored != nil && in.ignored(e.Key)) {
+			continue
+		}
+		current := e.State
+		if now, ok := in.moved.Get(e.Key); ok {
+			current = now.Status
+		}
+		c := card(e.Workspace, e.Ref)
+		if c.Key == "" {
+			c.Key, c.Title, c.URL, c.Kind, c.State, c.UpdatedAt = e.Key, firstLineOf(e.Title), e.URL, string(e.Kind), current, e.At
+		}
+		if over := watch.Settled(e, current); over != "" && strings.HasPrefix(over, "picked up") {
+			c.Column, c.Why = ColReady, over
+		} else if over != "" {
+			if in.now.Sub(e.At) > 24*time.Hour {
+				delete(byRef, e.Workspace+"/"+e.Ref)
+				continue
+			}
+			c.Column, c.Why = ColDone, over
+		} else if c.Why == "" {
+			c.Why = "waiting in the inbox"
+		}
+	}
+
+	// Runs: in flight is Running; a pull request is Review; a failure is
+	// something a person reads, so it stays where the ticket is with the
+	// outcome on the card.
+	if in.fixes != nil {
+		for _, r := range in.fixes.RecentFixes("", 100) {
+			if r.Ref == "" {
+				continue
+			}
+			c := card(r.Workspace, r.Ref)
+			if c.Fix != nil && !c.Fix.Running {
+				continue // the newest run on a ref is the one that counts
+			}
+			c.Fix = &CardFix{Running: !r.Done(), StartedAt: r.StartedAt, Outcome: r.Outcome(), PRs: r.PRs, Branch: r.Branch}
+			if c.Title == "" {
+				c.Title = firstLineOf(r.Title)
+			}
+			if c.URL == "" {
+				c.URL = r.URL
+			}
+			if r.StartedAt.After(c.UpdatedAt) {
+				c.UpdatedAt = r.StartedAt
+			}
+			switch {
+			case !r.Done():
+				c.Column, c.Why = ColRunning, "a run started "+roughAge(in.now.Sub(r.StartedAt))+" ago"
+			case len(r.PRs) > 0 && c.Column != ColDone:
+				c.Column, c.Why = ColReview, r.Outcome()
+			}
+		}
+		for _, e := range in.fixes.DeferredEvents() {
+			if e.Ref == "" {
+				continue
+			}
+			c := card(e.Workspace, e.Ref)
+			if c.Column == ColInbox {
+				c.Column, c.Why = ColReady, "deferred: waits for budget or a manual run"
+			}
+		}
+	}
+
+	// A live session on the ticket's branch is a person or an agent at work.
+	for _, s := range in.sessions {
+		ref := handoff.RefFromBranch(s.Branch)
+		if ref == "" || s.Status == sessions.StatusGone || s.Status == sessions.StatusStale {
+			continue
+		}
+		for id, c := range byRef {
+			if !strings.EqualFold(c.Ref, ref) {
+				continue
+			}
+			_ = id
+			c.Session = &CardSess{ID: s.ID, Label: firstNonEmpty(s.Display, s.Label), Status: string(s.Status)}
+			c.Branch = s.Branch
+			if c.Column == ColInbox || c.Column == ColReady {
+				c.Column, c.Why = ColRunning, "session "+c.Session.Label+" is on "+s.Branch
+			}
+		}
+	}
+
+	// A handoff means someone stopped part-way: the card is Ready unless a
+	// run or a session has it, and it says what comes next.
+	for ws, list := range in.packets {
+		for _, p := range list {
+			if in.now.Sub(p.WrittenAt) > handoff.MaxAge {
+				continue
+			}
+			c := card(ws, p.Ref)
+			c.Handoff = &CardHand{State: p.State, Next: p.Next, Path: handoff.MarkdownPath("", p.Ref), Draft: p.Draft}
+			if c.Branch == "" {
+				c.Branch = p.Where.Branch
+			}
+			if p.WrittenAt.After(c.UpdatedAt) {
+				c.UpdatedAt = p.WrittenAt
+			}
+			if c.Column == ColInbox {
+				c.Column, c.Why = ColReady, "handoff: "+p.Summary()
+			}
+			if p.State == handoff.StateCompleted && c.Column != ColReview {
+				c.Column, c.Why = ColDone, "handoff says completed"
+			}
+		}
+	}
+
+	// Blocked wins over everything but Done: a wall is a wall.
+	if in.fixes != nil {
+		for _, c := range byRef {
+			if b, ok := in.fixes.Blocked(c.Workspace, c.Ref); ok && c.Column != ColDone {
+				c.Column, c.Why, c.Blocked, c.BlockedBy = ColBlocked, b.Reason, b.Reason, b.By
+			}
+		}
+	}
+
+	out := make([]KanbanCard, 0, len(byRef))
+	for _, id := range order {
+		if c, ok := byRef[id]; ok {
+			out = append(out, *c)
+		}
+	}
+	rank := map[string]int{}
+	for i, col := range kanbanColumns {
+		rank[col] = i
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if rank[out[i].Column] != rank[out[j].Column] {
+			return rank[out[i].Column] < rank[out[j].Column]
+		}
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out
+}
+
+// gatherKanban reads everything the board needs from the agent dir.
+func gatherKanban(dir, onlyWorkspace string, now time.Time) []KanbanCard {
+	state := watch.LoadState(dir)
+	in := kanbanInputs{
+		events:  watch.RecentEvents(dir, 60),
+		ignored: state.IsIgnored,
+		moved:   watch.LoadStateLog(dir),
+		fixes:   state.Fixes,
+		packets: map[string][]handoff.Packet{},
+		now:     now,
+	}
+	if rep, err := readBoard(dir); err == nil {
+		in.sessions = rep.State.Sessions
+	}
+	if registry, err := workspace.Load(agentRegistryPath(dir)); err == nil {
+		for _, ws := range registry.Workspaces {
+			if onlyWorkspace != "" && ws.ID != onlyWorkspace {
+				continue
+			}
+			if list := handoff.List(ws.AbsPath); len(list) > 0 {
+				in.packets[ws.ID] = list
+			}
+		}
+	}
+	cards := buildKanban(in)
+	if onlyWorkspace == "" {
+		return cards
+	}
+	kept := cards[:0]
+	for _, c := range cards {
+		if c.Workspace == onlyWorkspace {
+			kept = append(kept, c)
+		}
+	}
+	return kept
+}
+
+var agentKanbanCmd = &cobra.Command{
+	Use:   "kanban",
+	Short: "One card per ticket: Inbox, Ready, Running, Blocked, Review, Done",
+	Long: `The board corgi derives from what it knows — the inbox, the unattended runs,
+the sessions on each branch, the handoffs, the tracker's own columns. A card
+is Running because a run or a session is on it, Review because a pull request
+is open, Blocked because the breaker tripped or a run said so, Ready because
+a handoff or a deferred run is waiting. Nobody drags a card into a column;
+moving a ticket moves it on the tracker (corgi agent watch move).
+
+  corgi agent kanban
+  corgi agent kanban --workspace api --json`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		dir := mustAgentDir()
+		ws, _ := cmd.Flags().GetString("workspace")
+		cards := gatherKanban(dir, ws, time.Now())
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"columns": kanbanColumns, "cards": cards})
+			return
+		}
+		if len(cards) == 0 {
+			fmt.Println("No cards: nothing in the inbox, no runs, no handoffs.")
+			return
+		}
+		for _, col := range kanbanColumns {
+			var rows []KanbanCard
+			for _, c := range cards {
+				if c.Column == col {
+					rows = append(rows, c)
+				}
+			}
+			if len(rows) == 0 {
+				continue
+			}
+			fmt.Printf("%s (%d)\n", col, len(rows))
+			for _, c := range rows {
+				line := fmt.Sprintf("  %-14s %s", c.Ref, clipTitle(c.Why, 60))
+				if c.Session != nil {
+					line += " · " + c.Session.Label
+				}
+				if c.Fix != nil && len(c.Fix.PRs) > 0 {
+					line += " · " + c.Fix.PRs[0]
+				}
+				fmt.Println(line)
+			}
+		}
+	},
+}
+
+func init() {
+	agentKanbanCmd.Flags().String("workspace", "", "only this workspace's cards")
+	agentCmd.AddCommand(agentKanbanCmd)
+}

--- a/cmd/agent_kanban.go
+++ b/cmd/agent_kanban.go
@@ -9,6 +9,7 @@ import (
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/handoff"
 	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
 	"andriiklymiuk/corgi/utils/agent/watch"
 	"andriiklymiuk/corgi/utils/agent/workspace"
 	"github.com/spf13/cobra"
@@ -47,7 +48,17 @@ type KanbanCard struct {
 	Session   *CardSess `json:"session,omitempty"`
 	Fix       *CardFix  `json:"fix,omitempty"`
 	Handoff   *CardHand `json:"handoff,omitempty"`
+	// Cost is what the ticket has cost so far: the unattended runs (with
+	// claude's own receipt) plus every session that sat on its branch.
+	Cost      *CardCost `json:"cost,omitempty"`
 	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type CardCost struct {
+	USD      float64 `json:"usd,omitempty"`
+	Tokens   int64   `json:"tokens"`
+	Runs     int     `json:"runs"`
+	Sessions int     `json:"sessions"`
 }
 
 type CardSess struct {
@@ -81,6 +92,8 @@ type kanbanInputs struct {
 	sessions []sessions.Session
 	packets  map[string][]handoff.Packet // by workspace id
 	now      time.Time
+	// sessionTokens is a seam: what one session has spent, from its transcript.
+	sessionTokens func(s sessions.Session) (int64, bool)
 }
 
 func buildKanban(in kanbanInputs) []KanbanCard {
@@ -176,6 +189,15 @@ func buildKanban(in kanbanInputs) []KanbanCard {
 			_ = id
 			c.Session = &CardSess{ID: s.ID, Label: firstNonEmpty(s.Display, s.Label), Status: string(s.Status)}
 			c.Branch = s.Branch
+			if in.sessionTokens != nil {
+				if tok, ok := in.sessionTokens(s); ok {
+					if c.Cost == nil {
+						c.Cost = &CardCost{}
+					}
+					c.Cost.Tokens += tok
+					c.Cost.Sessions++
+				}
+			}
 			if c.Column == ColInbox || c.Column == ColReady {
 				c.Column, c.Why = ColRunning, "session "+c.Session.Label+" is on "+s.Branch
 			}
@@ -206,11 +228,20 @@ func buildKanban(in kanbanInputs) []KanbanCard {
 		}
 	}
 
-	// Blocked wins over everything but Done: a wall is a wall.
+	// Blocked wins over everything but Done: a wall is a wall. And every
+	// card says what it has cost so far.
 	if in.fixes != nil {
 		for _, c := range byRef {
 			if b, ok := in.fixes.Blocked(c.Workspace, c.Ref); ok && c.Column != ColDone {
 				c.Column, c.Why, c.Blocked, c.BlockedBy = ColBlocked, b.Reason, b.Reason, b.By
+			}
+			if cost := in.fixes.CostFor(c.Workspace, c.Ref); cost.Runs > 0 {
+				if c.Cost == nil {
+					c.Cost = &CardCost{}
+				}
+				c.Cost.USD += cost.USD
+				c.Cost.Tokens += cost.Tokens
+				c.Cost.Runs = cost.Runs
 			}
 		}
 	}
@@ -247,6 +278,13 @@ func gatherKanban(dir, onlyWorkspace string, now time.Time) []KanbanCard {
 	}
 	if rep, err := readBoard(dir); err == nil {
 		in.sessions = rep.State.Sessions
+	}
+	in.sessionTokens = func(s sessions.Session) (int64, bool) {
+		if s.Cwd == "" || sessions.Placeholder(s.ID) {
+			return 0, false
+		}
+		t, ok := usage.ForSession(s.ConfigDir, s.Cwd, s.ID)
+		return t.Total(), ok
 	}
 	if registry, err := workspace.Load(agentRegistryPath(dir)); err == nil {
 		for _, ws := range registry.Workspaces {
@@ -315,6 +353,9 @@ moving a ticket moves it on the tracker (corgi agent watch move).
 				if c.Fix != nil && len(c.Fix.PRs) > 0 {
 					line += " · " + c.Fix.PRs[0]
 				}
+				if c.Cost != nil {
+					line += " · " + costLine(*c.Cost)
+				}
 				fmt.Println(line)
 			}
 		}
@@ -324,4 +365,30 @@ moving a ticket moves it on the tracker (corgi agent watch move).
 func init() {
 	agentKanbanCmd.Flags().String("workspace", "", "only this workspace's cards")
 	agentCmd.AddCommand(agentKanbanCmd)
+}
+
+// costLine is "1.2M tok · $0.84 · 3 runs" — the tokens always, the money
+// when a run reported it.
+func costLine(c CardCost) string {
+	parts := []string{humanTokens(c.Tokens) + " tok"}
+	if c.USD > 0 {
+		parts = append(parts, fmt.Sprintf("$%.2f", c.USD))
+	}
+	if c.Runs > 0 {
+		parts = append(parts, plural(c.Runs, "run", "runs"))
+	}
+	if c.Sessions > 0 {
+		parts = append(parts, plural(c.Sessions, "session", "sessions"))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func humanTokens(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.0fk", float64(n)/1_000)
+	}
+	return fmt.Sprint(n)
 }

--- a/cmd/agent_kanban_test.go
+++ b/cmd/agent_kanban_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/handoff"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/watch"
+)
+
+// The column is worked out, never dragged: a run puts a card in Running, a
+// pull request in Review, the breaker in Blocked, a handoff in Ready, a
+// merged ticket in Done — and Blocked beats everything but Done.
+func TestTheKanbanDerivesEveryColumn(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	fixes := watch.LoadFixLog(dir)
+	moved := watch.LoadStateLog(dir)
+	events := []watch.Event{
+		{Key: "k-inbox", Ref: "ABC-1", Workspace: "api", Kind: watch.KindIssueNew, Title: "new thing", State: "Todo", At: now},
+		{Key: "k-run", Ref: "ABC-2", Workspace: "api", Kind: watch.KindIssueNew, State: "Todo", At: now},
+		{Key: "k-review", Ref: "ABC-3", Workspace: "api", Kind: watch.KindIssueNew, State: "Todo", At: now},
+		{Key: "k-blocked", Ref: "ABC-4", Workspace: "api", Kind: watch.KindIssueNew, State: "Todo", At: now},
+		{Key: "k-done", Ref: "ABC-5", Workspace: "api", Kind: watch.KindIssueNew, State: "Done", At: now},
+		{Key: "k-ignored", Ref: "ABC-6", Workspace: "api", Kind: watch.KindIssueNew, State: "Todo", At: now},
+		{Key: "k-session", Ref: "ABC-7", Workspace: "api", Kind: watch.KindIssueNew, State: "Todo", At: now},
+	}
+	fixes.StartFor(events[1], now.Add(-time.Minute))
+	fixes.StartFor(events[2], now.Add(-time.Hour))
+	fixes.Finish("k-review", []string{"https://github.com/a/b/pull/3"}, "", "", now.Add(-30*time.Minute))
+	fixes.Block("api", "ABC-4", "no token", watch.BlockedByBreaker, now)
+	packets := map[string][]handoff.Packet{"api": {
+		{Ref: "ABC-8", State: handoff.StateInputRequired, Next: "web side", WrittenAt: now},
+		{Ref: "ABC-4", State: handoff.StateInputRequired, Next: "x", WrittenAt: now},
+	}}
+	sess := []sessions.Session{{ID: "s1", Label: "api", Display: "api", Status: sessions.StatusWorking, Branch: "feature/ABC-7/thing"}}
+
+	cards := buildKanban(kanbanInputs{events: events, ignored: func(k string) bool { return k == "k-ignored" },
+		moved: moved, fixes: fixes, sessions: sess, packets: packets, now: now})
+
+	got := map[string]KanbanCard{}
+	for _, c := range cards {
+		got[c.Ref] = c
+	}
+	want := map[string]string{"ABC-1": ColInbox, "ABC-2": ColRunning, "ABC-3": ColReview, "ABC-4": ColBlocked, "ABC-5": ColDone, "ABC-7": ColRunning, "ABC-8": ColReady}
+	for ref, col := range want {
+		if got[ref].Column != col {
+			t.Errorf("%s: %s (%s), want %s", ref, got[ref].Column, got[ref].Why, col)
+		}
+	}
+	if _, ok := got["ABC-6"]; ok {
+		t.Error("an ignored ticket has no card")
+	}
+	if got["ABC-7"].Session == nil || got["ABC-7"].Branch != "feature/ABC-7/thing" {
+		t.Error("the session and its branch are on the card")
+	}
+	if got["ABC-3"].Fix == nil || len(got["ABC-3"].Fix.PRs) != 1 {
+		t.Error("the run's pull request is on the card")
+	}
+	if got["ABC-4"].Handoff == nil || got["ABC-4"].Blocked != "no token" {
+		t.Error("a blocked card keeps its handoff and says why")
+	}
+	if cards[0].Column != ColInbox || cards[len(cards)-1].Column != ColDone {
+		t.Errorf("columns in order: %s … %s", cards[0].Column, cards[len(cards)-1].Column)
+	}
+}

--- a/cmd/agent_routine.go
+++ b/cmd/agent_routine.go
@@ -1,0 +1,262 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/command"
+	"andriiklymiuk/corgi/utils/agent/config"
+	"andriiklymiuk/corgi/utils/agent/daemon"
+	"andriiklymiuk/corgi/utils/agent/watch"
+	"github.com/spf13/cobra"
+)
+
+// A routine is a run on a clock: the digest at 08:30, the PR babysitter
+// every two hours, the dependency triage on Monday. It runs through the
+// same runner as an unattended fix — caps, quiet hours, budget, log, cost —
+// and its report is one inbox row.
+var agentRoutineCmd = &cobra.Command{
+	Use:   "routine",
+	Short: "Runs on a clock: digest, babysit-pr, deps, release-notes, flaky, doc-drift, or your own",
+	Long: `Routines run in a workspace on a schedule, through the daemon, with the same
+caps, quiet hours and budget as an unattended fix. Each report is one row in
+the inbox with the log behind it.
+
+  corgi agent routine catalog                              # what corgi knows how to run
+  corgi agent routine add digest                           # on its default schedule (daily 08:30)
+  corgi agent routine add babysit-pr --schedule "every 2h"
+  corgi agent routine add nightly-e2e --prompt "run corgi test --e2e and open a ticket per failure" --schedule "daily 03:00"
+  corgi agent routine list
+  corgi agent routine run digest                           # now, ignoring the clock
+  corgi agent routine rm digest
+
+A schedule is "daily HH:MM", "every 6h" (at least 5m) or "weekly Mon HH:MM".
+Restart the daemon after add or rm: corgi agent restart.`,
+}
+
+var agentRoutineCatalogCmd = &cobra.Command{
+	Use:   "catalog",
+	Short: "The routines corgi knows how to run",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if utils.JSONOutput {
+			utils.PrintJSON(watch.Catalog)
+			return
+		}
+		for _, k := range watch.Catalog {
+			fmt.Printf("%-14s %-18s %s\n", k.Name, k.Default, k.What)
+		}
+	},
+}
+
+var agentRoutineAddCmd = &cobra.Command{
+	Use:   "add <kind|name>",
+	Short: "Schedule a routine in this workspace",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := mustAgentDir()
+		id, err := watchTargetWorkspace(dir, cmd.Flags())
+		if err != nil {
+			return err
+		}
+		path := agentUserConfigPath(dir)
+		user, err := config.LoadUser(path)
+		if err != nil {
+			return err
+		}
+		if user == nil {
+			user = &config.UserConfig{}
+		}
+		if user.Workspaces == nil {
+			user.Workspaces = map[string]config.WorkspaceConfig{}
+		}
+		name := strings.TrimSpace(args[0])
+		prompt, _ := cmd.Flags().GetString("prompt")
+		schedule, _ := cmd.Flags().GetString("schedule")
+		model, _ := cmd.Flags().GetString("model")
+		r := config.Routine{Name: name, Prompt: strings.TrimSpace(prompt), Schedule: strings.TrimSpace(schedule), Model: model}
+		if k, ok := watch.CatalogKind(name); ok && r.Prompt == "" {
+			r.Kind = k.Name
+			if r.Schedule == "" {
+				r.Schedule = k.Default
+			}
+		}
+		if r.Kind == "" && r.Prompt == "" {
+			return fmt.Errorf("%q is not in the catalog (corgi agent routine catalog); give your own --prompt", name)
+		}
+		if r.Schedule == "" {
+			return fmt.Errorf("--schedule is required for your own routine: \"daily HH:MM\", \"every 6h\" or \"weekly Mon HH:MM\"")
+		}
+		sched, err := watch.ParseSchedule(r.Schedule)
+		if err != nil {
+			return err
+		}
+		entry := user.Workspaces[id]
+		kept := entry.Routines[:0]
+		for _, x := range entry.Routines {
+			if !strings.EqualFold(x.Name, r.Name) {
+				kept = append(kept, x)
+			}
+		}
+		entry.Routines = append(kept, r)
+		user.Workspaces[id] = entry
+		if err := writeUserConfig(path, user); err != nil {
+			return err
+		}
+		what := r.Prompt
+		if r.Kind != "" {
+			k, _ := watch.CatalogKind(r.Kind)
+			what = k.What
+		}
+		utils.Infof("✓ %s in %s: %s — %s\n", r.Name, id, sched.String(), clipTitle(what, 70))
+		utils.Info("restart the daemon to pick it up: corgi agent restart")
+		return nil
+	},
+}
+
+var agentRoutineListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Every routine, every workspace",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		dir := mustAgentDir()
+		user, err := config.LoadUser(agentUserConfigPath(dir))
+		if err != nil || user == nil {
+			fmt.Println("No routines.")
+			return
+		}
+		type row struct {
+			Workspace string `json:"workspace"`
+			Name      string `json:"name"`
+			Kind      string `json:"kind,omitempty"`
+			Schedule  string `json:"schedule"`
+			Off       bool   `json:"off,omitempty"`
+			LastRun   string `json:"lastRun,omitempty"`
+		}
+		var rows []row
+		last := watch.LoadFixLog(dir)
+		for ws, entry := range user.Workspaces {
+			for _, r := range entry.Routines {
+				lr := ""
+				for _, f := range last.RecentFixes(ws, 200) {
+					if f.Ref == "routine/"+firstNonEmpty(r.Name, r.Kind) {
+						lr = roughAge(time.Since(f.StartedAt)) + " ago · " + f.Outcome()
+						break
+					}
+				}
+				rows = append(rows, row{Workspace: ws, Name: r.Name, Kind: r.Kind, Schedule: r.Schedule, Off: r.Off, LastRun: lr})
+			}
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"routines": rows})
+			return
+		}
+		if len(rows) == 0 {
+			fmt.Println("No routines. Add one: corgi agent routine add digest")
+			return
+		}
+		for _, r := range rows {
+			state := ""
+			if r.Off {
+				state = " (off)"
+			}
+			fmt.Printf("%-12s %-14s %-18s %s%s\n", r.Workspace, r.Name, r.Schedule, r.LastRun, state)
+		}
+	},
+}
+
+var agentRoutineRmCmd = &cobra.Command{
+	Use:   "rm <name>",
+	Short: "Remove a routine from this workspace",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := mustAgentDir()
+		id, err := watchTargetWorkspace(dir, cmd.Flags())
+		if err != nil {
+			return err
+		}
+		path := agentUserConfigPath(dir)
+		user, err := config.LoadUser(path)
+		if err != nil || user == nil {
+			return fmt.Errorf("no routines in %s", id)
+		}
+		entry := user.Workspaces[id]
+		kept := entry.Routines[:0]
+		found := false
+		for _, x := range entry.Routines {
+			if strings.EqualFold(x.Name, args[0]) {
+				found = true
+				continue
+			}
+			kept = append(kept, x)
+		}
+		if !found {
+			return fmt.Errorf("no routine %q in %s", args[0], id)
+		}
+		entry.Routines = kept
+		user.Workspaces[id] = entry
+		if err := writeUserConfig(path, user); err != nil {
+			return err
+		}
+		utils.Infof("✓ removed %s from %s (after corgi agent restart)\n", args[0], id)
+		return nil
+	},
+}
+
+var agentRoutineRunCmd = &cobra.Command{
+	Use:   "run <name>",
+	Short: "Run a routine now, ignoring the clock",
+	Long: `Hands the routine to the daemon right away, the way a watch event would
+arrive: it runs with the caps, the log and the cost, and reports to the inbox.
+The daemon has to be running.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := mustAgentDir()
+		id, err := watchTargetWorkspace(dir, cmd.Flags())
+		if err != nil {
+			return err
+		}
+		specs, err := loadWatchSpecs(dir)
+		if err != nil {
+			return err
+		}
+		for _, spec := range specs {
+			if spec.Workspace != id {
+				continue
+			}
+			for _, r := range spec.Routines {
+				if !strings.EqualFold(r.Name, args[0]) && !strings.EqualFold(r.Kind, args[0]) {
+					continue
+				}
+				e, ok := daemon.RoutineEvent(id, r, time.Now())
+				if !ok {
+					return fmt.Errorf("routine %q has nothing to run", args[0])
+				}
+				info, _ := daemon.ReadInfo(dir)
+				if info == nil || !info.Commands {
+					return fmt.Errorf("the daemon is not running: corgi agent serve, or corgi agent up")
+				}
+				if _, err := command.Write(dir, command.Command{Action: command.ActionWatch, Source: "routine run", WatchEvent: &e}); err != nil {
+					return err
+				}
+				daemon.Nudge(info)
+				utils.Infof("✓ %s handed to the daemon — its report lands in the inbox; log: corgi agent watch --json\n", e.Title)
+				return nil
+			}
+		}
+		return fmt.Errorf("no routine %q in %s (corgi agent routine list)", args[0], id)
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{agentRoutineAddCmd, agentRoutineRmCmd, agentRoutineRunCmd} {
+		c.Flags().String("workspace", "", "the workspace (default: the one you are in)")
+	}
+	agentRoutineAddCmd.Flags().String("schedule", "", "\"daily HH:MM\", \"every 6h\" or \"weekly Mon HH:MM\" (a catalog kind has a default)")
+	agentRoutineAddCmd.Flags().String("prompt", "", "your own routine: what the run should do")
+	agentRoutineAddCmd.Flags().String("model", "", "the model to run it on (default: the workspace policy's execute model)")
+	agentRoutineCmd.AddCommand(agentRoutineCatalogCmd, agentRoutineAddCmd, agentRoutineListCmd, agentRoutineRmCmd, agentRoutineRunCmd)
+	agentCmd.AddCommand(agentRoutineCmd)
+}

--- a/cmd/agent_scope.go
+++ b/cmd/agent_scope.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/scope"
+	"github.com/spf13/cobra"
+)
+
+var agentScopeCmd = &cobra.Command{
+	Use:   "scope",
+	Short: "The contract a ticket's change stays inside: paths, a diff budget, done-when",
+	Long: `A scope is written once the spec is agreed and enforced while the session
+runs: a write outside its paths is refused with the way to widen; a diff over
+its budget is reported once at the end of the turn, not found at review.
+Both hooks are installed by ` + "`corgi agent track enable`" + ` and silent on a branch
+with no scope.
+
+  corgi agent scope set ABC-123 --path "api/limits/**" --path "web/src/limits/**" \\
+    --lines 400 --tests 2 --done "429 carries Retry-After" --done "banner on the web"
+  corgi agent scope add ABC-123 --path "shared/types.ts"     # widen, on the record
+  corgi agent scope show [ABC-123]
+  corgi agent scope clear ABC-123`,
+}
+
+var agentScopeSetCmd = &cobra.Command{
+	Use:   "set <ref>",
+	Short: "Write a ticket's scope",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := scopeDir(cmd)
+		f := cmd.Flags()
+		paths, _ := f.GetStringArray("path")
+		lines, _ := f.GetInt("lines")
+		tests, _ := f.GetInt("tests")
+		done, _ := f.GetStringArray("done")
+		s := scope.Scope{Ref: strings.ToUpper(strings.TrimSpace(args[0])), Paths: paths, Lines: lines, Tests: tests, Done: done, SetAt: time.Now()}
+		if old, err := scope.Read(dir, s.Ref); err == nil {
+			// A budget raised on the record keeps the paths it had, and the
+			// paths it was given keep the budget it had.
+			if len(s.Paths) == 0 {
+				s.Paths = old.Paths
+			}
+			if s.Lines == 0 {
+				s.Lines = old.Lines
+			}
+			if s.Tests == 0 {
+				s.Tests = old.Tests
+			}
+			if len(s.Done) == 0 {
+				s.Done = old.Done
+			}
+			s.Widenings = old.Widenings
+		}
+		if err := scope.Write(dir, s); err != nil {
+			exitWithError("agent_scope", err, 1)
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(s)
+			return
+		}
+		fmt.Printf("✓ scope for %s: %s\n", s.Ref, scopeLine(s))
+	},
+}
+
+var agentScopeAddCmd = &cobra.Command{
+	Use:   "add <ref> --path <glob>",
+	Short: "Widen a ticket's scope by one path, on the record",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := scopeDir(cmd)
+		paths, _ := cmd.Flags().GetStringArray("path")
+		if len(paths) == 0 {
+			exitWithError("agent_scope", fmt.Errorf("--path is required"), 2)
+		}
+		var s scope.Scope
+		var err error
+		for _, p := range paths {
+			if s, err = scope.Widen(dir, strings.ToUpper(strings.TrimSpace(args[0])), p, "session"); err != nil {
+				exitWithError("agent_scope", err, 1)
+			}
+		}
+		fmt.Printf("✓ %s now also covers %s (%d widening%s on the record)\n", s.Ref, strings.Join(paths, ", "), len(s.Widenings), plural2(len(s.Widenings)))
+	},
+}
+
+var agentScopeShowCmd = &cobra.Command{
+	Use:   "show [ref]",
+	Short: "Print a ticket's scope, or every scope here",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := scopeDir(cmd)
+		if len(args) == 1 {
+			s, err := scope.Read(dir, strings.ToUpper(strings.TrimSpace(args[0])))
+			if err != nil {
+				exitWithError("agent_scope", fmt.Errorf("no scope for %s in %s", args[0], dir), 2)
+			}
+			if utils.JSONOutput {
+				utils.PrintJSON(s)
+				return
+			}
+			fmt.Printf("%s: %s\n", s.Ref, scopeLine(s))
+			for _, d := range s.Done {
+				fmt.Printf("  done when: %s\n", d)
+			}
+			for _, w := range s.Widenings {
+				fmt.Printf("  widened: %s (%s)\n", w.Path, w.At.Local().Format("Jan 2 15:04"))
+			}
+			return
+		}
+		list := scope.List(dir)
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"workspace": dir, "scopes": list})
+			return
+		}
+		if len(list) == 0 {
+			fmt.Printf("No scopes in %s\n", scope.Dir(dir))
+			return
+		}
+		for _, s := range list {
+			fmt.Printf("%-12s %s\n", s.Ref, scopeLine(s))
+		}
+	},
+}
+
+var agentScopeClearCmd = &cobra.Command{
+	Use:   "clear <ref>",
+	Short: "Remove a ticket's scope",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := scope.Remove(scopeDir(cmd), strings.ToUpper(strings.TrimSpace(args[0]))); err != nil {
+			exitWithError("agent_scope", err, 1)
+		}
+		fmt.Printf("cleared %s\n", args[0])
+	},
+}
+
+func scopeLine(s scope.Scope) string {
+	var parts []string
+	if len(s.Paths) > 0 {
+		parts = append(parts, strings.Join(s.Paths, ", "))
+	} else {
+		parts = append(parts, "any path")
+	}
+	if s.Lines > 0 {
+		parts = append(parts, fmt.Sprintf("≤ %d lines", s.Lines))
+	}
+	if s.Tests > 0 {
+		parts = append(parts, fmt.Sprintf("≤ %d new test files", s.Tests))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func scopeDir(cmd *cobra.Command) string {
+	if d, _ := cmd.Flags().GetString("dir"); d != "" {
+		return d
+	}
+	cwd, _ := os.Getwd()
+	if root := scopeWorkspaceRoot(cwd); root != "" {
+		return root
+	}
+	return cwd
+}
+
+func plural2(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func init() {
+	for _, c := range []*cobra.Command{agentScopeSetCmd, agentScopeAddCmd, agentScopeShowCmd, agentScopeClearCmd} {
+		c.Flags().String("dir", "", "the workspace (default: the one containing the current directory)")
+	}
+	agentScopeSetCmd.Flags().StringArray("path", nil, "a glob the change may touch, relative to the workspace (repeatable; ** crosses directories)")
+	agentScopeSetCmd.Flags().Int("lines", 0, "diff budget: added plus removed lines")
+	agentScopeSetCmd.Flags().Int("tests", 0, "how many new test files at most")
+	agentScopeSetCmd.Flags().StringArray("done", nil, "what finished means, one line (repeatable)")
+	agentScopeAddCmd.Flags().StringArray("path", nil, "a glob to add (repeatable)")
+	agentScopeCmd.AddCommand(agentScopeSetCmd, agentScopeAddCmd, agentScopeShowCmd, agentScopeClearCmd)
+	agentCmd.AddCommand(agentScopeCmd)
+}

--- a/cmd/agent_sessions.go
+++ b/cmd/agent_sessions.go
@@ -297,12 +297,18 @@ func formatSlot(sl sessions.Slot) string {
 	if sl.Status == sessions.StatusLimited && sl.Limit == sessions.LimitOverload {
 		word = "OVERLOAD"
 	}
+	if sl.Drift != "" && sl.Status == sessions.StatusWorking {
+		word = "DRIFT"
+	}
 	line := fmt.Sprintf("%s %s %s %-18s %-10s", key, pin, statusGlyph(sl.Status), clipTitle(sl.Label, 18), word)
 	if detail := firstNonEmpty(sl.Note, sl.Detail); detail != "" {
 		line += " " + clipTitle(detail, 24)
 	}
 	if !sl.ResumeAt.IsZero() {
 		line += " · continues " + sl.ResumeAt.Local().Format("15:04")
+	}
+	if sl.Drift != "" {
+		line += " · " + clipTitle(sl.Drift, 48)
 	}
 	line += "  " + sl.Profile + " · " + string(sl.Host)
 	if sl.Context > 0 {

--- a/cmd/agent_setup.go
+++ b/cmd/agent_setup.go
@@ -400,8 +400,13 @@ type agentCheck struct {
 	Fix    string `json:"fix,omitempty"`
 }
 
-func runAgentDoctor(_ *cobra.Command, _ []string) {
-	checks := collectAgentChecks()
+func runAgentDoctor(cmd *cobra.Command, _ []string) {
+	var checks []agentCheck
+	if only, _ := cmd.Flags().GetBool("security"); only {
+		checks = checkSecurity()
+	} else {
+		checks = append(collectAgentChecks(), checkSecurity()...)
+	}
 
 	if utils.JSONOutput {
 		utils.PrintJSON(checks)
@@ -689,5 +694,6 @@ func init() {
 
 	agentScanCmd.Flags().Bool("dry-run", false, "Show what would be registered without changing anything")
 
+	agentDoctorCmd.Flags().Bool("security", false, "only the security checks: deny rules, the secrets hook, permissions, isolation, tunnel exposure")
 	agentCmd.AddCommand(agentInitCmd, agentScanCmd, agentDoctorCmd)
 }

--- a/cmd/agent_track.go
+++ b/cmd/agent_track.go
@@ -36,11 +36,18 @@ const (
 	hookEmit      = "corgi agent hook emit"
 	hookTabTitle  = "corgi agent hook tab"
 	hookContext   = "corgi agent hook context"
+	hookScope     = "corgi agent hook scope"
+	hookBudget    = "corgi agent hook budget"
 	// trackMarkers identify corgi's tracking hooks in a settings file, so
 	// enable and disable never touch anyone else's.
 	trackMarkerEmit    = "agent hook emit"
 	trackMarkerTab     = "agent hook tab"
 	trackMarkerContext = "agent hook context"
+	trackMarkerScope   = "agent hook scope"
+	trackMarkerBudget  = "agent hook budget"
+	// writingTools are the tools a scope can refuse: the ones that change a
+	// file.
+	writingTools = "Edit|Write|MultiEdit|NotebookEdit"
 	// promptingTools are the tools worth a PreToolUse event: the ones that
 	// can raise a permission prompt or a question. Reads and searches fire
 	// dozens of times a turn and change nothing a key shows.
@@ -90,15 +97,22 @@ var trackedEvents = []struct {
 	// Context adds the synchronous hook that hands the session what the
 	// daemon knows: other sessions here, the budget, the last brief.
 	Context bool
+	// Scope and Budget add the hooks that keep a session inside the scope
+	// its ticket agreed (see agent_hook_scope.go); silent without one.
+	Scope  bool
+	Budget bool
+	// NoEmit is an entry that exists only for its extra hook.
+	NoEmit bool
 }{
 	{Event: "SessionStart", Matcher: "startup|resume|clear|fork", Context: true},
 	{Event: "UserPromptSubmit", Title: true},
 	{Event: "PreToolUse", Matcher: promptingTools},
+	{Event: "PreToolUse", Matcher: writingTools, Scope: true, NoEmit: true},
 	{Event: "PostToolUse"},
 	{Event: "PostToolUseFailure"},
 	{Event: "PermissionRequest"},
 	{Event: "Notification", Matcher: "permission_prompt|idle_prompt|agent_needs_input|elicitation_dialog|elicitation_url_dialog", Title: true},
-	{Event: "Stop", Title: true},
+	{Event: "Stop", Title: true, Budget: true},
 	{Event: "StopFailure", Title: true},
 	{Event: "SessionEnd"},
 	{Event: "CwdChanged"},
@@ -276,14 +290,30 @@ func enableTrackingIn(path, bin string, tabTitle bool) error {
 	if hooks == nil {
 		hooks = map[string]any{}
 	}
+	seen := map[string]bool{}
 	for _, ev := range trackedEvents {
-		entries := stripTrackingHooks(hooks[ev.Event])
-		handlers := []any{map[string]any{"type": "command", "command": hookCommand(bin, hookEmit), "async": true}}
+		var entries []any
+		if !seen[ev.Event] {
+			entries = stripTrackingHooks(hooks[ev.Event])
+			seen[ev.Event] = true
+		} else {
+			entries, _ = hooks[ev.Event].([]any)
+		}
+		var handlers []any
+		if !ev.NoEmit {
+			handlers = append(handlers, map[string]any{"type": "command", "command": hookCommand(bin, hookEmit), "async": true})
+		}
 		if ev.Title && tabTitle {
 			handlers = append(handlers, map[string]any{"type": "command", "command": hookCommand(bin, hookTabTitle)})
 		}
 		if ev.Context {
 			handlers = append(handlers, map[string]any{"type": "command", "command": hookCommand(bin, hookContext), "timeout": 5})
+		}
+		if ev.Scope {
+			handlers = append(handlers, map[string]any{"type": "command", "command": hookCommand(bin, hookScope), "timeout": 5})
+		}
+		if ev.Budget {
+			handlers = append(handlers, map[string]any{"type": "command", "command": hookCommand(bin, hookBudget), "timeout": 15})
 		}
 		entry := map[string]any{"hooks": handlers}
 		if ev.Matcher != "" {
@@ -333,7 +363,7 @@ func stripTrackingHooks(existing any) []any {
 	out := []any{}
 	for _, entry := range list {
 		text := marshalCompact(entry)
-		if strings.Contains(text, trackMarkerEmit) || strings.Contains(text, trackMarkerTab) || strings.Contains(text, trackMarkerContext) {
+		if strings.Contains(text, trackMarkerEmit) || strings.Contains(text, trackMarkerTab) || strings.Contains(text, trackMarkerContext) || strings.Contains(text, trackMarkerScope) || strings.Contains(text, trackMarkerBudget) {
 			continue
 		}
 		out = append(out, entry)
@@ -366,27 +396,32 @@ func trackingHooksStale(path string) bool {
 	}
 	tab := strings.Contains(marshalCompact(hooks), trackMarkerTab)
 	for _, ev := range trackedEvents {
-		if !eventHookCurrent(hooks[ev.Event], ev.Matcher, ev.Context, ev.Title && tab) {
+		if !eventHookCurrent(hooks[ev.Event], ev.Matcher, ev.Context, ev.Title && tab, ev.Scope, ev.Budget, ev.NoEmit) {
 			return true
 		}
 	}
 	return false
 }
 
-// eventHookCurrent checks one event's corgi entry: the matcher this version
-// uses, and the extra handlers it now installs.
-func eventHookCurrent(existing any, matcher string, wantContext, wantTab bool) bool {
+// eventHookCurrent checks one event's corgi entry with the given matcher:
+// the extra handlers this version installs are there, and nothing else.
+func eventHookCurrent(existing any, matcher string, wantContext, wantTab, wantScope, wantBudget, noEmit bool) bool {
 	list, _ := existing.([]any)
 	for _, entry := range list {
 		text := marshalCompact(entry)
-		if !strings.Contains(text, trackMarkerEmit) {
+		obj, _ := entry.(map[string]any)
+		got, _ := obj["matcher"].(string)
+		mine := strings.Contains(text, trackMarkerEmit) || strings.Contains(text, trackMarkerScope) || strings.Contains(text, trackMarkerBudget)
+		if !mine || got != matcher {
 			continue
 		}
-		obj, _ := entry.(map[string]any)
-		if got, _ := obj["matcher"].(string); got != matcher {
+		if noEmit == strings.Contains(text, trackMarkerEmit) {
 			return false
 		}
 		if wantContext != strings.Contains(text, trackMarkerContext) {
+			return false
+		}
+		if wantScope != strings.Contains(text, trackMarkerScope) || wantBudget != strings.Contains(text, trackMarkerBudget) {
 			return false
 		}
 		return wantTab == strings.Contains(text, trackMarkerTab)

--- a/cmd/agent_watch.go
+++ b/cmd/agent_watch.go
@@ -120,6 +120,9 @@ var agentWatchEnableCmd = &cobra.Command{
 		if flags.Changed("isolate") {
 			wc.Isolate, _ = flags.GetBool("isolate")
 		}
+		if flags.Changed("no-retry") {
+			wc.NoRetry, _ = flags.GetBool("no-retry")
+		}
 		if flags.Changed("lease") {
 			wc.Lease, _ = flags.GetBool("lease")
 		}
@@ -683,7 +686,7 @@ func loadWatchSpecs(dir string) ([]daemon.WatchSpec, error) {
 		spec := daemon.WatchSpec{Workspace: w.ID, Dir: w.AbsPath, ConfigDir: expandTilde(resolved.ConfigDir), Project: wc.Project, Repos: wc.Repos,
 			Rules:    watch.Rules{Enabled: true, Labels: wc.Labels, States: wc.States, Assignee: wc.Assignee, Comments: wc.Comments, PRs: wc.PRs, CI: wc.CI, Reviews: wc.Reviews, From: wc.From},
 			Interval: 3 * time.Minute, Action: "notify", SkipPermissions: resolved.DangerouslySkipPermissions,
-			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, ReviewStatus: wc.ReviewStatus}
+			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, NoRetry: wc.NoRetry, ReviewStatus: wc.ReviewStatus}
 		if wc.Action == "fix" {
 			spec.Action = "fix"
 		}
@@ -980,6 +983,7 @@ func init() {
 	f.String("review-status", "", "Column a ticket moves to once a run opened a pull request for it, e.g. \"In Review\"")
 	f.Bool("lease", false, "Claim a ticket on the tracker before working it, so a second machine watching the same board leaves it alone")
 	f.Bool("isolate", false, "Give every unattended run its own worktrees on a corgi/<ref> branch, so it never touches your checkout")
+	f.Bool("no-retry", false, "Leave deferred fixes to a manual `watch run` instead of starting them when the budget returns")
 	f.Bool("reviews", false, "Also pull requests someone asked me to review — theirs, not mine")
 	f.Bool("ci", false, "Also builds that went red on something of mine — the one kind that brings its own test for done")
 	f.String("from", "", "Only comments and reviews from these people (comma separated); empty is anyone")

--- a/cmd/agent_watch.go
+++ b/cmd/agent_watch.go
@@ -680,13 +680,19 @@ func loadWatchSpecs(dir string) ([]daemon.WatchSpec, error) {
 		resolved := config.Resolve(w.ID, repo, user)
 		wc := resolved.Watch
 		if wc == nil || !wc.Enabled {
+			// No watch, but routines on a clock still need a spec to run
+			// under: the caps and the log, no sources, no polling.
+			if len(resolved.Routines) > 0 {
+				out = append(out, daemon.WatchSpec{Workspace: w.ID, Dir: w.AbsPath, ConfigDir: expandTilde(resolved.ConfigDir),
+					SkipPermissions: resolved.DangerouslySkipPermissions, Models: resolved.Models, Routines: resolved.Routines})
+			}
 			continue
 		}
 		secrets := watch.LoadSecretsFor(dir, w.ID)
 		spec := daemon.WatchSpec{Workspace: w.ID, Dir: w.AbsPath, ConfigDir: expandTilde(resolved.ConfigDir), Project: wc.Project, Repos: wc.Repos,
 			Rules:    watch.Rules{Enabled: true, Labels: wc.Labels, States: wc.States, Assignee: wc.Assignee, Comments: wc.Comments, PRs: wc.PRs, CI: wc.CI, Reviews: wc.Reviews, From: wc.From},
 			Interval: 3 * time.Minute, Action: "notify", SkipPermissions: resolved.DangerouslySkipPermissions,
-			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, NoRetry: wc.NoRetry, ReviewStatus: wc.ReviewStatus, Models: resolved.Models}
+			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, NoRetry: wc.NoRetry, ReviewStatus: wc.ReviewStatus, Models: resolved.Models, Routines: resolved.Routines}
 		if wc.Action == "fix" {
 			spec.Action = "fix"
 		}

--- a/cmd/agent_watch.go
+++ b/cmd/agent_watch.go
@@ -565,6 +565,7 @@ func runAgentWatchStatus(_ *cobra.Command, _ []string) {
 			URL       string    `json:"url,omitempty"`
 			State     string    `json:"state,omitempty"`
 			At        time.Time `json:"at"`
+			Blocked   string    `json:"blocked,omitempty"`
 		}
 		events := []eventRow{}
 		moved := watch.LoadStateLog(dir)
@@ -582,8 +583,12 @@ func runAgentWatchStatus(_ *cobra.Command, _ []string) {
 			if watch.Settled(e, current) != "" {
 				continue
 			}
-			events = append(events, eventRow{Key: e.Key, Ref: e.Ref, Kind: string(e.Kind),
-				Workspace: e.Workspace, Title: firstLineOf(e.Title), URL: e.URL, State: current, At: e.At})
+			er := eventRow{Key: e.Key, Ref: e.Ref, Kind: string(e.Kind),
+				Workspace: e.Workspace, Title: firstLineOf(e.Title), URL: e.URL, State: current, At: e.At}
+			if b, ok := state.Fixes.Blocked(e.Workspace, e.Ref); ok {
+				er.Blocked = b.Reason
+			}
+			events = append(events, er)
 		}
 		utils.PrintJSON(map[string]any{"workspaces": out, "polls": state.Summaries(), "fixes": fixes, "events": events})
 		return

--- a/cmd/agent_watch.go
+++ b/cmd/agent_watch.go
@@ -117,6 +117,9 @@ var agentWatchEnableCmd = &cobra.Command{
 			v, _ := flags.GetString("review-status")
 			wc.ReviewStatus = strings.TrimSpace(v)
 		}
+		if flags.Changed("isolate") {
+			wc.Isolate, _ = flags.GetBool("isolate")
+		}
 		if flags.Changed("lease") {
 			wc.Lease, _ = flags.GetBool("lease")
 		}
@@ -675,7 +678,7 @@ func loadWatchSpecs(dir string) ([]daemon.WatchSpec, error) {
 		spec := daemon.WatchSpec{Workspace: w.ID, Dir: w.AbsPath, ConfigDir: expandTilde(resolved.ConfigDir), Project: wc.Project, Repos: wc.Repos,
 			Rules:    watch.Rules{Enabled: true, Labels: wc.Labels, States: wc.States, Assignee: wc.Assignee, Comments: wc.Comments, PRs: wc.PRs, CI: wc.CI, Reviews: wc.Reviews, From: wc.From},
 			Interval: 3 * time.Minute, Action: "notify", SkipPermissions: resolved.DangerouslySkipPermissions,
-			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, ReviewStatus: wc.ReviewStatus}
+			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, ReviewStatus: wc.ReviewStatus}
 		if wc.Action == "fix" {
 			spec.Action = "fix"
 		}
@@ -971,6 +974,7 @@ func init() {
 	f.String("pickup", "", "Column a ticket moves to when it is picked up, e.g. \"In Progress\"; empty writes nothing")
 	f.String("review-status", "", "Column a ticket moves to once a run opened a pull request for it, e.g. \"In Review\"")
 	f.Bool("lease", false, "Claim a ticket on the tracker before working it, so a second machine watching the same board leaves it alone")
+	f.Bool("isolate", false, "Give every unattended run its own worktrees on a corgi/<ref> branch, so it never touches your checkout")
 	f.Bool("reviews", false, "Also pull requests someone asked me to review — theirs, not mine")
 	f.Bool("ci", false, "Also builds that went red on something of mine — the one kind that brings its own test for done")
 	f.String("from", "", "Only comments and reviews from these people (comma separated); empty is anyone")

--- a/cmd/agent_watch.go
+++ b/cmd/agent_watch.go
@@ -686,7 +686,7 @@ func loadWatchSpecs(dir string) ([]daemon.WatchSpec, error) {
 		spec := daemon.WatchSpec{Workspace: w.ID, Dir: w.AbsPath, ConfigDir: expandTilde(resolved.ConfigDir), Project: wc.Project, Repos: wc.Repos,
 			Rules:    watch.Rules{Enabled: true, Labels: wc.Labels, States: wc.States, Assignee: wc.Assignee, Comments: wc.Comments, PRs: wc.PRs, CI: wc.CI, Reviews: wc.Reviews, From: wc.From},
 			Interval: 3 * time.Minute, Action: "notify", SkipPermissions: resolved.DangerouslySkipPermissions,
-			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, NoRetry: wc.NoRetry, ReviewStatus: wc.ReviewStatus}
+			MaxFixesPerHour: wc.MaxFixesPerHour, MaxFixesPerDay: wc.MaxFixesPerDay, Quiet: wc.Quiet, FixKinds: wc.FixKinds, Lease: wc.Lease, Isolate: wc.Isolate, NoRetry: wc.NoRetry, ReviewStatus: wc.ReviewStatus, Models: resolved.Models}
 		if wc.Action == "fix" {
 			spec.Action = "fix"
 		}

--- a/cmd/agent_watch_block.go
+++ b/cmd/agent_watch_block.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/watch"
+	"github.com/spf13/cobra"
+)
+
+// Blocked is a column, not a failure: the ticket waits for a person, and no
+// unattended run touches it until someone says the wall is gone.
+var agentWatchBlockCmd = &cobra.Command{
+	Use:   "block <REF> <reason>",
+	Short: "Keep unattended runs off a ticket until you unblock it",
+	Long: `Marks a ticket blocked: the inbox shows the reason, the workpad comment
+carries it, and the unattended mode leaves it alone. corgi does this itself
+after two failed runs in a row, or when a run's handoff says it is blocked on
+a missing tool, credential or secret.
+
+  corgi agent watch block ABC-123 "needs the payments sandbox key"
+  corgi agent watch unblock ABC-123`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := mustAgentDir()
+		id, err := watchTargetWorkspace(dir, cmd.Flags())
+		if err != nil {
+			exitWithError("agent_watch_block", err, 2)
+		}
+		ref := strings.TrimSpace(args[0])
+		watch.LoadFixLog(dir).Block(id, ref, args[1], watch.BlockedByPerson, time.Now())
+		if _, _, err := watchWriter(dir, id); err == nil {
+			writeWorkpad(dir, id, ref, "Blocked", strings.TrimSpace(args[1])+"\n\n`corgi agent watch unblock "+ref+"` once it is fixed.")
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"workspace": id, "ref": ref, "blocked": true, "reason": args[1]})
+			return
+		}
+		fmt.Printf("%s blocked: %s\n", ref, args[1])
+	},
+}
+
+var agentWatchUnblockCmd = &cobra.Command{
+	Use:   "unblock <REF>",
+	Short: "Let unattended runs work a blocked ticket again",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		dir := mustAgentDir()
+		id, err := watchTargetWorkspace(dir, cmd.Flags())
+		if err != nil {
+			exitWithError("agent_watch_unblock", err, 2)
+		}
+		ref := strings.TrimSpace(args[0])
+		if !watch.LoadFixLog(dir).Unblock(id, ref) {
+			exitWithError("agent_watch_unblock", fmt.Errorf("%s is not blocked in %s", ref, id), 2)
+		}
+		if _, _, err := watchWriter(dir, id); err == nil {
+			writeWorkpad(dir, id, ref, "Blocked", "")
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(map[string]any{"workspace": id, "ref": ref, "blocked": false})
+			return
+		}
+		fmt.Printf("%s unblocked — the next matching event runs\n", ref)
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{agentWatchBlockCmd, agentWatchUnblockCmd} {
+		c.Flags().String("workspace", "", "the workspace the ticket belongs to (default: the one you are in)")
+	}
+	agentWatchCmd.AddCommand(agentWatchBlockCmd, agentWatchUnblockCmd)
+}

--- a/cmd/agent_watch_undo.go
+++ b/cmd/agent_watch_undo.go
@@ -10,6 +10,7 @@ import (
 
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/watch"
+	"andriiklymiuk/corgi/utils/agent/workspace"
 )
 
 var agentWatchUndoCmd = &cobra.Command{
@@ -75,6 +76,20 @@ func runAgentWatchUndo(cmd *cobra.Command, args []string) {
 			_ = watch.LoadStateLog(dir).Set(run.Key, back, time.Now())
 		}
 	}
+	// An isolated run's worktrees go too, unless they hold uncommitted work.
+	if run.Branch != "" {
+		if registry, err := workspace.Load(agentRegistryPath(dir)); err == nil {
+			ws, _ := registry.Find(run.Workspace)
+			removed, kept, err := releaseFixWorktrees(ws.AbsPath, run.Branch)
+			if err != nil {
+				problems = append(problems, firstLineOf(err.Error()))
+			}
+			plan.WorktreesRemoved = removed
+			for _, k := range kept {
+				problems = append(problems, "kept "+k+": it has uncommitted work")
+			}
+		}
+	}
 	// The event goes back in the inbox: undoing a run means it was not done.
 	st := watch.LoadState(dir)
 	st.Unsee(run.Key)
@@ -89,6 +104,8 @@ type undoPlan struct {
 	Closed    []string `json:"closed,omitempty"`
 	MoveBack  string   `json:"moveBack,omitempty"`
 	Moved     bool     `json:"moved,omitempty"`
+	// WorktreesRemoved is what an isolated run left that undo cleaned up.
+	WorktreesRemoved []string `json:"worktreesRemoved,omitempty"`
 }
 
 func reportUndo(p undoPlan, problems []string) {

--- a/cmd/agent_watch_workpad.go
+++ b/cmd/agent_watch_workpad.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"andriiklymiuk/corgi/utils/agent/watch"
+	"github.com/spf13/cobra"
+)
+
+var agentWatchWorkpadCmd = &cobra.Command{
+	Use:   "workpad <REF> <section> [text]",
+	Short: "Write one section of the ticket's corgi comment",
+	Long: `A ticket gets one corgi comment — the workpad — with a section per thing:
+the spec, the pull requests, the latest handoff, a blocker. Writing a section
+rewrites it in place; the comment is created the first time. Empty text
+removes the section.
+
+  corgi agent watch workpad ABC-123 Spec - < docs/stories/ABC-123.md
+  corgi agent watch workpad ABC-123 Blocked "no GITLAB_TOKEN for the web repo"
+  corgi agent watch workpad ABC-123 Blocked ""
+
+Text is the third argument, or stdin when it is "-".`,
+	Args: cobra.RangeArgs(2, 3),
+	Run: func(cmd *cobra.Command, args []string) {
+		text := ""
+		if len(args) == 3 {
+			text = args[2]
+		}
+		if text == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				exitWithError("agent_watch_workpad", err, 1)
+			}
+			text = string(data)
+		}
+		section := strings.TrimSpace(args[1])
+		runTrackerWrite(cmd, "agent_watch_workpad", args[0], func(ctx context.Context, w watch.Writer, ref string) (string, error) {
+			if err := watch.UpsertWorkpad(ctx, w, ref, section, text); err != nil {
+				return "", err
+			}
+			if strings.TrimSpace(text) == "" {
+				return fmt.Sprintf("%s: section %q removed from the workpad", ref, section), nil
+			}
+			return fmt.Sprintf("%s: workpad section %q written", ref, section), nil
+		})
+	},
+}
+
+func init() {
+	agentWatchWorkpadCmd.Flags().String("workspace", "", "the workspace whose tracker token to use (default: the one you are in)")
+	agentWatchCmd.AddCommand(agentWatchWorkpadCmd)
+}

--- a/cmd/docs_check.go
+++ b/cmd/docs_check.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"andriiklymiuk/corgi/utils"
+	"github.com/spf13/cobra"
+)
+
+// Docs go stale in two ways corgi can see without a table nobody maintains:
+// a document that names something the diff changed, and a CLAUDE.md pointer
+// (file:line) that no longer lands where it says. Both are read from the
+// changed surface and the tree; no config.
+
+var docsCheckCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Docs that mention what the diff changed, and pointers that no longer land",
+	Long: `Reads the stack's changed surface (exported symbols, routes, contracts,
+migrations, config) against a base branch, then finds every Markdown file that
+names one of them — those are the docs to re-read. Also checks the file:line
+pointers in CLAUDE.md, AGENTS.md and .claude/rules against the tree.
+
+  corgi docs check
+  corgi docs check --base develop --json
+  corgi docs check --branch feature/ABC-123/limits
+
+Exit 1 when something needs a look, so it can gate a merge.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		base, _ := cmd.Flags().GetString("base")
+		branch, _ := cmd.Flags().GetString("branch")
+		composePath, _ := cmd.Flags().GetString("filename")
+		corgi, dir, err := loadComposeForAgent(composePath)
+		if err != nil {
+			exitWithError("docs_check", err, 1)
+		}
+		out, err := mcpSurface(composePath, base, branch)
+		if err != nil {
+			exitWithError("docs_check", err, 1)
+		}
+		repos := out.(map[string]any)["repos"].([]utils.RepoSurface)
+		roots := []string{dir}
+		for _, d := range utils.ServiceDirs(corgi, nil) {
+			roots = append(roots, d)
+		}
+		report := checkDocs(roots, repos)
+		if utils.JSONOutput {
+			utils.PrintJSON(report)
+		} else {
+			printDocsReport(report)
+		}
+		if len(report.Mentions) > 0 || len(report.StalePointers) > 0 {
+			exitProcess(1)
+		}
+	},
+}
+
+type docMention struct {
+	Doc  string `json:"doc"`
+	Line int    `json:"line"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	Op   string `json:"op"`
+	Path string `json:"path"`
+}
+
+type stalePointer struct {
+	Doc     string `json:"doc"`
+	Line    int    `json:"line"`
+	Pointer string `json:"pointer"`
+	Why     string `json:"why"`
+}
+
+type docsReport struct {
+	Mentions      []docMention   `json:"mentions"`
+	StalePointers []stalePointer `json:"stalePointers"`
+	DocsScanned   int            `json:"docsScanned"`
+}
+
+var pointerRe = regexp.MustCompile(`\b([A-Za-z0-9_./-]+\.(?:go|ts|tsx|js|py|rb|rs|java|kt|swift|sql|ya?ml|md)):(\d+)\b`)
+
+func checkDocs(roots []string, repos []utils.RepoSurface) docsReport {
+	var report docsReport
+	names := map[string]utils.SurfaceChange{}
+	for _, r := range repos {
+		for _, c := range r.Changes {
+			if c.Kind == "config" || c.Kind == "migration" {
+				continue
+			}
+			name := c.Name
+			if c.Kind == "route" {
+				if i := strings.Index(name, " "); i > 0 {
+					name = name[i+1:]
+				}
+			}
+			if len(name) >= 4 {
+				names[name] = c
+			}
+		}
+	}
+	seen := map[string]bool{}
+	for _, root := range roots {
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				switch d.Name() {
+				case ".git", "node_modules", "vendor", "dist", "build", ".next", "corgi_services", ".corgi":
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(d.Name(), ".md") || seen[path] {
+				return nil
+			}
+			seen[path] = true
+			report.DocsScanned++
+			scanDoc(path, filepath.Dir(path), names, &report)
+			return nil
+		})
+	}
+	sort.Slice(report.Mentions, func(i, j int) bool {
+		if report.Mentions[i].Doc != report.Mentions[j].Doc {
+			return report.Mentions[i].Doc < report.Mentions[j].Doc
+		}
+		return report.Mentions[i].Line < report.Mentions[j].Line
+	})
+	return report
+}
+
+func scanDoc(path, dir string, names map[string]utils.SurfaceChange, report *docsReport) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	base := filepath.Base(path)
+	pointerDoc := base == "CLAUDE.md" || base == "AGENTS.md" || strings.Contains(filepath.ToSlash(path), "/.claude/rules/")
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64<<10), 1<<20)
+	n := 0
+	for sc.Scan() {
+		n++
+		line := sc.Text()
+		for name, c := range names {
+			if strings.Contains(line, name) && wordBounded(line, name) {
+				report.Mentions = append(report.Mentions, docMention{Doc: path, Line: n, Name: c.Name, Kind: c.Kind, Op: c.Op, Path: c.Path})
+			}
+		}
+		if !pointerDoc {
+			continue
+		}
+		for _, m := range pointerRe.FindAllStringSubmatch(line, -1) {
+			target := m[1]
+			want, _ := strconv.Atoi(m[2])
+			abs := target
+			if !filepath.IsAbs(abs) {
+				abs = filepath.Join(dir, target)
+			}
+			total, err := countFileLines(abs)
+			switch {
+			case err != nil:
+				report.StalePointers = append(report.StalePointers, stalePointer{Doc: path, Line: n, Pointer: m[0], Why: "no such file"})
+			case want > total:
+				report.StalePointers = append(report.StalePointers, stalePointer{Doc: path, Line: n, Pointer: m[0], Why: fmt.Sprintf("the file has %d lines", total)})
+			}
+		}
+	}
+}
+
+func wordBounded(line, name string) bool {
+	i := strings.Index(line, name)
+	for i >= 0 {
+		before := i == 0 || !isWordByte(line[i-1])
+		after := i+len(name) >= len(line) || !isWordByte(line[i+len(name)])
+		if before && after {
+			return true
+		}
+		j := strings.Index(line[i+1:], name)
+		if j < 0 {
+			return false
+		}
+		i += 1 + j
+	}
+	return false
+}
+
+func isWordByte(b byte) bool {
+	return b == '_' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func countFileLines(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	n := 0
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64<<10), 8<<20)
+	for sc.Scan() {
+		n++
+	}
+	return n, nil
+}
+
+func printDocsReport(r docsReport) {
+	if len(r.Mentions) == 0 && len(r.StalePointers) == 0 {
+		fmt.Printf("✓ %d docs scanned: none name what changed, every pointer lands\n", r.DocsScanned)
+		return
+	}
+	if len(r.Mentions) > 0 {
+		fmt.Printf("Docs that name what the diff changed (%d) — re-read these:\n", len(r.Mentions))
+		for _, m := range r.Mentions {
+			fmt.Printf("  %s:%d  `%s` (%s %s in %s)\n", m.Doc, m.Line, m.Name, m.Op, m.Kind, m.Path)
+		}
+	}
+	if len(r.StalePointers) > 0 {
+		fmt.Printf("Pointers that no longer land (%d):\n", len(r.StalePointers))
+		for _, p := range r.StalePointers {
+			fmt.Printf("  %s:%d  %s — %s\n", p.Doc, p.Line, p.Pointer, p.Why)
+		}
+	}
+}
+
+func init() {
+	docsCheckCmd.Flags().String("base", "", "base branch (default: main)")
+	docsCheckCmd.Flags().String("branch", "", "check the existing worktrees of this branch instead of the checkouts")
+	docsCmd.AddCommand(docsCheckCmd)
+}

--- a/cmd/docs_check_test.go
+++ b/cmd/docs_check_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+// A doc that names a changed symbol or route is one to re-read; a CLAUDE.md
+// pointer past the end of its file, or to no file, is stale.
+func TestDocsCheckFindsMentionsAndStalePointers(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, body string) {
+		p := filepath.Join(root, rel)
+		_ = os.MkdirAll(filepath.Dir(p), 0o755)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("docs/limits.md", "# Limits\n\nCall `CheckLimit` before a request.\nPOST /limits/reset clears it.\n")
+	write("docs/other.md", "Nothing about CheckLimits here (a longer word).\n")
+	write("api/limits.go", "package api\nfunc CheckLimit() {}\n")
+	write("CLAUDE.md", "See api/limits.go:2 for the check and api/limits.go:40 for the reset; also api/gone.go:1.\n")
+	repos := []utils.RepoSurface{{Service: "api", Changes: []utils.SurfaceChange{
+		{Kind: "symbol", Name: "CheckLimit", Op: "changed", Path: "api/limits.go", Breaking: true},
+		{Kind: "route", Name: "POST /limits/reset", Op: "added", Path: "api/routes.go"},
+		{Kind: "config", Name: "go.mod", Op: "changed", Path: "go.mod"},
+	}}}
+	r := checkDocs([]string{root}, repos)
+	if r.DocsScanned != 3 {
+		t.Fatalf("scanned %d docs", r.DocsScanned)
+	}
+	if len(r.Mentions) != 2 {
+		t.Fatalf("mentions: %+v", r.Mentions)
+	}
+	if r.Mentions[0].Doc != filepath.Join(root, "docs", "limits.md") || r.Mentions[0].Name != "CheckLimit" || r.Mentions[1].Name != "POST /limits/reset" {
+		t.Fatalf("mentions: %+v", r.Mentions)
+	}
+	if len(r.StalePointers) != 2 {
+		t.Fatalf("stale pointers: %+v", r.StalePointers)
+	}
+	if r.StalePointers[0].Why != "the file has 2 lines" || r.StalePointers[1].Why != "no such file" {
+		t.Fatalf("why: %+v", r.StalePointers)
+	}
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -337,6 +337,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		mux.Handle("/launch/new", bearerAuth(token, http.HandlerFunc(launchNewHandler), deviceStore))
 		mux.Handle("/launch/events", bearerAuth(token, http.HandlerFunc(launchEventsHandler), deviceStore))
 		mux.Handle("/launch/kanban", bearerAuth(token, http.HandlerFunc(launchKanbanHandler), deviceStore))
+		mux.Handle("/launch/run", bearerAuth(token, http.HandlerFunc(launchRunHandler), deviceStore))
 		mux.Handle("/launch/work-on", bearerAuth(token, http.HandlerFunc(launchWorkOnHandler), deviceStore))
 		mux.Handle("/launch/ticket", bearerAuth(token, http.HandlerFunc(launchTicketHandler), deviceStore))
 		mux.Handle("/launch/devices", bearerAuth(token, http.HandlerFunc(launchDevicesHandler), deviceStore))

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -338,6 +338,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		mux.Handle("/launch/events", bearerAuth(token, http.HandlerFunc(launchEventsHandler), deviceStore))
 		mux.Handle("/launch/kanban", bearerAuth(token, http.HandlerFunc(launchKanbanHandler), deviceStore))
 		mux.Handle("/launch/run", bearerAuth(token, http.HandlerFunc(launchRunHandler), deviceStore))
+		mux.Handle("/launch/fresh", bearerAuth(token, http.HandlerFunc(launchFreshHandler), deviceStore))
 		mux.Handle("/launch/work-on", bearerAuth(token, http.HandlerFunc(launchWorkOnHandler), deviceStore))
 		mux.Handle("/launch/ticket", bearerAuth(token, http.HandlerFunc(launchTicketHandler), deviceStore))
 		mux.Handle("/launch/devices", bearerAuth(token, http.HandlerFunc(launchDevicesHandler), deviceStore))

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -631,8 +631,9 @@ func loadComposeCached(cmd *cobra.Command, composePath string) (*utils.CorgiComp
 	return corgi, nil
 }
 
-// loadComposeForMCP loads just the parsed compose.
-func loadComposeForMCP(composePath string) (*utils.CorgiCompose, error) {
+// loadComposeForMCP loads just the parsed compose. A variable so a tool
+// test can hand it a stack without a file.
+var loadComposeForMCP = func(composePath string) (*utils.CorgiCompose, error) {
 	ctx, err := loadComposeCtx(composePath)
 	if err != nil {
 		return nil, err
@@ -1785,6 +1786,8 @@ func registerMCPTools(s *server.MCPServer) {
 			Profile:     r.GetString("profile", ""),
 		})
 	}))
+
+	addStackTools(s, composeOpt, serviceOpt)
 
 	s.AddTool(mcp.NewTool("corgi_db_query",
 		mcp.WithDescription("Run one non-interactive query inside a running db_service container through its driver's own client (psql, redis-cli, mongosh, …); write the query in that client's syntax. Returns {service, output, truncated}. The db_service must already be up (corgi_up). Writes are not blocked — a mutating statement runs, so call corgi_db_snapshot first and corgi_db_restore to undo. Disabled over a public tunnel unless CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1."),

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -336,6 +336,7 @@ func serveMCPHTTP(s *server.MCPServer, addr, token string, opts mcpHTTPOpts) {
 		mux.Handle("/launch/send", bearerAuth(token, http.HandlerFunc(launchSendHandler), deviceStore))
 		mux.Handle("/launch/new", bearerAuth(token, http.HandlerFunc(launchNewHandler), deviceStore))
 		mux.Handle("/launch/events", bearerAuth(token, http.HandlerFunc(launchEventsHandler), deviceStore))
+		mux.Handle("/launch/kanban", bearerAuth(token, http.HandlerFunc(launchKanbanHandler), deviceStore))
 		mux.Handle("/launch/work-on", bearerAuth(token, http.HandlerFunc(launchWorkOnHandler), deviceStore))
 		mux.Handle("/launch/ticket", bearerAuth(token, http.HandlerFunc(launchTicketHandler), deviceStore))
 		mux.Handle("/launch/devices", bearerAuth(token, http.HandlerFunc(launchDevicesHandler), deviceStore))

--- a/cmd/mcp_agent.go
+++ b/cmd/mcp_agent.go
@@ -245,7 +245,11 @@ func registerAgentMCPTools(s *server.MCPServer) {
 		mcp.WithString("base", mcp.Description("Base branch to compare against (default: main)")),
 		mcp.WithString("branch", mcp.Description("Diff the existing worktrees of this branch instead of the main checkouts. Does not create anything — run corgi_worktrees_materialize first.")),
 		mcp.WithBoolean("includePatch", mcp.Description("Include the unified diff per file (default true)")),
+		mcp.WithBoolean("surface", mcp.Description("Only the changed surface: exported symbols, routes, contracts, migrations and config that changed, per repository, with removals and signature changes marked breaking. Read this before the diff. Returns {repos, markdown}.")),
 	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
+		if r.GetBool("surface", false) {
+			return mcpSurface(r.GetString("composePath", ""), r.GetString("base", ""), r.GetString("branch", ""))
+		}
 		return mcpDiff(
 			r.GetString("composePath", ""),
 			r.GetString("base", ""),
@@ -253,6 +257,24 @@ func registerAgentMCPTools(s *server.MCPServer) {
 			r.GetBool("includePatch", true),
 		)
 	}))
+}
+
+// mcpSurface is corgi_diff with surface: the public slice of the change,
+// as a list and as the Markdown block a pull request body carries.
+func mcpSurface(composePath, base, branch string) (any, error) {
+	out, err := mcpDiff(composePath, base, branch, true)
+	if err != nil {
+		return nil, err
+	}
+	stack, ok := out.(*utils.StackDiff)
+	if !ok {
+		return nil, fmt.Errorf("unexpected diff shape")
+	}
+	repos := make([]utils.RepoSurface, 0, len(stack.Repos))
+	for _, rd := range stack.Repos {
+		repos = append(repos, utils.SurfaceOf(rd))
+	}
+	return map[string]any{"base": stack.Base, "repos": repos, "markdown": utils.SurfaceMarkdown(repos)}, nil
 }
 
 func mcpAgentStatus() (any, error) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -3500,6 +3500,8 @@ func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 		// Blocked is why unattended runs leave this ticket alone, when they do.
 		Blocked   string `json:"blocked,omitempty"`
 		BlockedBy string `json:"blockedBy,omitempty"`
+		// Priority is 0 urgent, 1 high, 2 the rest, from the ticket's labels.
+		Priority int `json:"priority"`
 	}
 	out := []row{}
 	// The events log keeps the column a ticket arrived in. A move made since
@@ -3524,7 +3526,7 @@ func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		r := row{Key: e.Key, Kind: string(e.Kind), Ref: e.Ref, Title: firstLineOf(e.Title),
-			URL: e.URL, Workspace: e.Workspace, At: e.At, Actionable: daemon.FixPrompt(e) != "", State: current}
+			URL: e.URL, Workspace: e.Workspace, At: e.At, Actionable: daemon.FixPrompt(e) != "", State: current, Priority: watch.Priority(e)}
 		if b, ok := fixLog.Blocked(e.Workspace, e.Ref); ok {
 			r.Blocked, r.BlockedBy = b.Reason, b.By
 		}
@@ -3564,6 +3566,9 @@ func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 	// your own backlog ticket whatever repo it came from, and within a rank
 	// the one that has waited longest goes first.
 	sort.SliceStable(out, func(i, j int) bool {
+		if pi, pj := out[i].Priority, out[j].Priority; pi != pj {
+			return pi < pj
+		}
 		ri, rj := waitingRank(out[i].Kind), waitingRank(out[j].Kind)
 		if ri != rj {
 			return ri < rj

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -1277,6 +1277,7 @@ const launcherPageHTML = `<!doctype html>
   .newchat button{font:inherit;font-size:.76rem;font-weight:500;padding:.34rem .8rem;border-radius:.45rem;border:1px solid var(--accent);
       background:var(--accent);color:#fff;cursor:pointer;flex:0 0 auto}
   .newchat button:disabled{opacity:.5}
+  .runlog{font:.68rem/1.35 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;overflow-wrap:anywhere;max-height:60vh;overflow:auto;background:var(--card2);border:1px solid var(--hair);border-radius:.5rem;padding:.5rem;margin:.4rem 0 0}
   .kb{display:flex;gap:.6rem;overflow-x:auto;padding-bottom:.5rem;scroll-snap-type:x mandatory}
   .kb .kcol{flex:0 0 78vw;max-width:340px;scroll-snap-align:start;background:var(--card);border:1px solid var(--hair);border-radius:.7rem;padding:.5rem}
   .kb .kcol h3{margin:0 0 .4rem;font-size:.8rem;letter-spacing:.06em;text-transform:uppercase;opacity:.75;display:flex;justify-content:space-between}
@@ -2130,6 +2131,41 @@ const launcherPageHTML = `<!doctype html>
     document.body.appendChild(scrim);
   }
 
+  // What a run said, on the phone: the tail of its log, the handoff it left,
+  // what it opened and what it cost. The one screen for "what happened".
+  async function runSheet(fx) {
+    const scrim = document.createElement('div');
+    scrim.className = 'scrim';
+    const sheet = document.createElement('div');
+    sheet.className = 'sheet';
+    const close = () => scrim.remove();
+    scrim.onclick = e => { if (e.target === scrim) close(); };
+    const grab = document.createElement('div'); grab.className = 'grab';
+    const h = document.createElement('h3');
+    h.textContent = fx.ref + (fx.running ? ' · running' : '');
+    const pre = document.createElement('pre');
+    pre.className = 'runlog';
+    pre.textContent = 'loading…';
+    sheet.append(grab, h, pre);
+    scrim.appendChild(sheet);
+    document.body.appendChild(scrim);
+    try {
+      const r = await fetch('/launch/run?key=' + encodeURIComponent(fx.key) + '&tail=200', { headers: auth });
+      const j = await r.json();
+      if (!r.ok) { pre.textContent = j.error || 'no log'; return; }
+      const meta = document.createElement('p');
+      meta.className = 'etitle';
+      const bits = [];
+      if (j.outcome) bits.push(j.outcome);
+      if (j.spentPercent) bits.push(j.spentPercent + '% of the 5h window');
+      if (j.handover) bits.push(j.handover);
+      meta.textContent = bits.join(' · ');
+      sheet.insertBefore(meta, pre);
+      pre.textContent = j.log || '(the log is empty)';
+      pre.scrollTop = pre.scrollHeight;
+    } catch { pre.textContent = 'no connection'; }
+  }
+
   // The kanban: one card per ticket, column worked out by corgi. A card is
   // moved on the tracker, worked on, or unblocked — the column follows.
   async function loadKanban() {
@@ -2465,6 +2501,10 @@ const launcherPageHTML = `<!doctype html>
         if (t.textContent) card.appendChild(t);
         const row = document.createElement('div');
         row.className = 'erow';
+        const log = document.createElement('button');
+        log.textContent = 'Log';
+        log.onclick = () => runSheet(fx);
+        row.appendChild(log);
         for (const pr of fx.prs || []) {
           if (!/^https:\/\//.test(pr)) continue;
           const a = document.createElement('a');
@@ -3357,6 +3397,56 @@ const watchBatchMax = 10
 
 // launchEventsHandler lists what the watch has seen, newest first, so the
 // phone can show the tracker issues and reviews waiting for a decision.
+// launchRunHandler is one unattended run's log tail and record, for the
+// phone: what it did, what it left, what it cost.
+func launchRunHandler(w http.ResponseWriter, r *http.Request) {
+	dir, err := agentDir()
+	if err != nil {
+		writeLaunchError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	key := strings.TrimSpace(r.URL.Query().Get("key"))
+	if key == "" {
+		writeLaunchError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	tail := 200
+	if n, err := strconv.Atoi(r.URL.Query().Get("tail")); err == nil && n > 0 && n <= 2000 {
+		tail = n
+	}
+	out := map[string]any{"key": key}
+	for _, rec := range watch.LoadFixLog(dir).RecentFixes("", 200) {
+		if rec.Key != key {
+			continue
+		}
+		out["ref"] = firstNonEmptyString(rec.Ref, rec.Key)
+		out["workspace"] = rec.Workspace
+		out["running"] = !rec.Done()
+		out["startedAt"] = rec.StartedAt
+		out["outcome"] = rec.Outcome()
+		if len(rec.PRs) > 0 {
+			out["prs"] = rec.PRs
+		}
+		if rec.Handover != "" {
+			out["handover"] = rec.Handover
+		}
+		if rec.SpentPercent > 0 {
+			out["spentPercent"] = rec.SpentPercent
+		}
+		if rec.Branch != "" {
+			out["branch"] = rec.Branch
+		}
+		break
+	}
+	log := daemon.RunLog(dir, key, tail)
+	if _, known := out["ref"]; !known && log == "" {
+		writeLaunchError(w, http.StatusNotFound, "no run for that key")
+		return
+	}
+	out["log"] = log
+	writeLaunchJSON(w, out)
+}
+
 // launchKanbanHandler is the derived board: one card per ticket with its
 // column and why, plus the columns each tracker can move a ticket to.
 func launchKanbanHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -2133,6 +2133,13 @@ const launcherPageHTML = `<!doctype html>
 
   // What a run said, on the phone: the tail of its log, the handoff it left,
   // what it opened and what it cost. The one screen for "what happened".
+  function humanTokens(n) {
+    n = Number(n) || 0;
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+    if (n >= 1e3) return Math.round(n / 1e3) + 'k';
+    return String(n);
+  }
+
   async function runSheet(fx) {
     const scrim = document.createElement('div');
     scrim.className = 'scrim';
@@ -2157,6 +2164,7 @@ const launcherPageHTML = `<!doctype html>
       meta.className = 'etitle';
       const bits = [];
       if (j.outcome) bits.push(j.outcome);
+      if (j.tokens) bits.push(humanTokens(j.tokens) + ' tok' + (j.costUSD ? ' · $' + j.costUSD.toFixed(2) : ''));
       if (j.spentPercent) bits.push(j.spentPercent + '% of the 5h window');
       if (j.handover) bits.push(j.handover);
       meta.textContent = bits.join(' · ');
@@ -2210,6 +2218,13 @@ const launcherPageHTML = `<!doctype html>
         if (c.session) { const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = 'session ' + c.session.label + ' · ' + (STATUS_WORD[c.session.status] || c.session.status); card.appendChild(m); }
         if (c.branch) { const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = c.branch; card.appendChild(m); }
         if (c.handoff && c.handoff.next) { const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = 'next: ' + c.handoff.next; card.appendChild(m); }
+        if (c.cost) {
+          const bits = [humanTokens(c.cost.tokens) + ' tok'];
+          if (c.cost.usd) bits.push('$' + c.cost.usd.toFixed(2));
+          if (c.cost.runs) bits.push(c.cost.runs + (c.cost.runs === 1 ? ' run' : ' runs'));
+          if (c.cost.sessions) bits.push(c.cost.sessions + (c.cost.sessions === 1 ? ' session' : ' sessions'));
+          const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = bits.join(' · '); card.appendChild(m);
+        }
         const row = document.createElement('div'); row.className = 'erow';
         const ev = { key: c.key, ref: c.ref, workspace: c.workspace, kind: c.kind, url: c.url };
         if (c.url && /^https:\/\//.test(c.url)) {
@@ -3432,6 +3447,9 @@ func launchRunHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if rec.SpentPercent > 0 {
 			out["spentPercent"] = rec.SpentPercent
+		}
+		if rec.Tokens > 0 {
+			out["tokens"], out["costUSD"] = rec.Tokens, rec.CostUSD
 		}
 		if rec.Branch != "" {
 			out["branch"] = rec.Branch

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -1914,6 +1914,7 @@ const launcherPageHTML = `<!doctype html>
         row.appendChild(dot); row.appendChild(label);
         let detail = s.detail || STATUS_WORD[s.status] || '';
         if (s.status === 'limited' && s.limit === 'overload') detail = 'API overloaded';
+        if (s.drift && s.drift.length) detail = 'drifting: ' + s.drift[0];
         if (s.resumeAt) detail += (detail ? ' · ' : '') + 'continues ' + clock(s.resumeAt);
         if (s.context && s.context.percent >= 50) detail += (detail ? ' · ' : '') + 'ctx ' + s.context.percent + '%';
         if (detail) {
@@ -2047,6 +2048,20 @@ const launcherPageHTML = `<!doctype html>
       button('Send\u2026', '', () => {
         const text = window.prompt('Type into ' + name);
         if (text && text.trim()) boardAction('send', { session: s.id, text: text.trim() });
+      });
+    }
+    // A drifting session gets the one way out the phone can offer: a clean
+    // restart from a handoff, same account, same worktree.
+    if (s.drift && s.drift.length && s.status !== 'gone') {
+      button('Fresh', 'bad', async (e) => {
+        if (!confirm('Restart ' + name + ' clean from a handoff?\n' + s.drift.join('\n'))) return;
+        const b = e.currentTarget; b.disabled = true;
+        try {
+          const r = await fetch('/launch/fresh', { method: 'POST', headers: auth, body: JSON.stringify({ session: s.id }) });
+          const j = await r.json().catch(() => ({}));
+          if (!r.ok) { toast(j.error || 'could not restart it', true); b.disabled = false; return; }
+          toast(j.done || 'restarting'); setTimeout(loadBoard, 4000);
+        } catch { toast('no connection', true); b.disabled = false; }
       });
     }
     if (s.pr) {
@@ -3236,6 +3251,39 @@ func launchAnswerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	launchBoardCommand(w, command.Command{Action: command.ActionAnswer, SessionID: session.ID, Answer: answer, Source: "phone"})
+}
+
+// launchFreshHandler restarts a drifting session clean, under the same
+// account, from a handoff: `corgi agent carry <id> --fresh` run as itself,
+// so the phone and the CLI do exactly the same thing.
+func launchFreshHandler(w http.ResponseWriter, r *http.Request) {
+	setLaunchHeaders(w)
+	if r.Method != http.MethodPost {
+		writeLaunchError(w, http.StatusMethodNotAllowed, "POST {session} to restart it clean from a handoff")
+		return
+	}
+	var req struct {
+		Session string `json:"session"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&req); err != nil {
+		writeLaunchError(w, http.StatusBadRequest, "could not read the request")
+		return
+	}
+	session, code, msg := launchSessionFor(req.Session)
+	if code != 0 {
+		writeLaunchError(w, code, msg)
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		exe = "corgi"
+	}
+	out, err := exec.Command(exe, "agent", "carry", session.ID, "--fresh", "--json").CombinedOutput()
+	if err != nil {
+		writeLaunchError(w, http.StatusBadGateway, firstLineOf(strings.TrimSpace(string(out))+" "+err.Error()))
+		return
+	}
+	writeLaunchJSON(w, map[string]any{"done": "restarting " + firstNonEmpty(session.Display, session.Label) + " clean, from a handoff"})
 }
 
 func launchSendHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -1277,6 +1277,19 @@ const launcherPageHTML = `<!doctype html>
   .newchat button{font:inherit;font-size:.76rem;font-weight:500;padding:.34rem .8rem;border-radius:.45rem;border:1px solid var(--accent);
       background:var(--accent);color:#fff;cursor:pointer;flex:0 0 auto}
   .newchat button:disabled{opacity:.5}
+  .kb{display:flex;gap:.6rem;overflow-x:auto;padding-bottom:.5rem;scroll-snap-type:x mandatory}
+  .kb .kcol{flex:0 0 78vw;max-width:340px;scroll-snap-align:start;background:var(--card);border:1px solid var(--hair);border-radius:.7rem;padding:.5rem}
+  .kb .kcol h3{margin:0 0 .4rem;font-size:.8rem;letter-spacing:.06em;text-transform:uppercase;opacity:.75;display:flex;justify-content:space-between}
+  .kb .kcol h3 span{opacity:.7}
+  .kb .kcard{background:var(--card2);border:1px solid var(--hair);border-radius:.55rem;padding:.45rem .55rem;margin:.3rem 0}
+  .kb .kcard .kref{font-weight:600;font-size:.85rem}
+  .kb .kcard .kws{font-size:.7rem;opacity:.6;margin-left:.4rem}
+  .kb .kcard .kwhy{font-size:.75rem;opacity:.85;margin:.15rem 0}
+  .kb .kcard .ktitle{font-size:.78rem;opacity:.7;margin:0 0 .3rem;overflow-wrap:anywhere}
+  .kb .kcard .kmeta{font-size:.7rem;opacity:.7;margin:.1rem 0}
+  .kb .kcard.blocked{border-color:#E4695B}
+  .kb .kcard.running{border-color:#5B8DEF}
+  .kb .empty{font-size:.75rem;opacity:.5;padding:.4rem .2rem}
   .ev{background:var(--card2);border:1px solid var(--hair);border-radius:.6rem;padding:.5rem .65rem;margin:.3rem 0}
   .ev .eref{font-weight:600;font-size:.82rem}
   .ev .ekind{font-size:.66rem;text-transform:uppercase;letter-spacing:.04em;opacity:.6;margin-left:.35rem}
@@ -1483,6 +1496,7 @@ const launcherPageHTML = `<!doctype html>
   <p id="hostnote" class="hostnote" hidden></p>
   <div class="tabs" id="tabs" role="tablist">
     <button role="tab" data-tab="inbox" aria-selected="true">Inbox<span class="n" id="n-inbox"></span></button>
+    <button role="tab" data-tab="kanban" aria-selected="false">Board<span class="n" id="n-kanban"></span></button>
     <button role="tab" data-tab="sessions" aria-selected="false">Sessions<span class="n" id="n-sessions"></span></button>
     <button role="tab" data-tab="stacks" aria-selected="false">Stacks<span class="n" id="n-stacks"></span></button>
     <button role="tab" data-tab="laptop" aria-selected="false">Laptop</button>
@@ -1493,6 +1507,9 @@ const launcherPageHTML = `<!doctype html>
   <div data-pane="inbox">
     <section id="inbox" class="board" hidden></section>
     <section id="newchat" class="board" hidden></section>
+  </div>
+  <div data-pane="kanban" hidden>
+    <section id="kanban" class="board" hidden></section>
   </div>
   <div data-pane="sessions" hidden>
     <section id="board" class="board" hidden></section>
@@ -1863,6 +1880,7 @@ const launcherPageHTML = `<!doctype html>
       const j = await r.json();
       renderNewChat(j);
       loadInbox();
+      loadKanban();
       const sessions = (j.sessions || []).filter(s => s.status !== 'gone');
       tabCount('sessions', sessions.length);
       if (!sessions.length) { box.hidden = true; return; }
@@ -2068,7 +2086,7 @@ const launcherPageHTML = `<!doctype html>
       const j = await r.json().catch(() => ({}));
       if (!r.ok) { if (!quiet) toast(j.error || 'that did not go through', true); return false; }
       // A batch says one thing at the end rather than a toast per row.
-      if (!quiet) { toast(j.done || 'done'); setTimeout(loadInbox, 600); }
+      if (!quiet) { toast(j.done || 'done'); setTimeout(() => { loadInbox(); loadKanban(); }, 600); }
       return true;
     } catch { if (!quiet) toast('no connection', true); return false; }
   }
@@ -2110,6 +2128,81 @@ const launcherPageHTML = `<!doctype html>
     sheet.appendChild(mine);
     scrim.appendChild(sheet);
     document.body.appendChild(scrim);
+  }
+
+  // The kanban: one card per ticket, column worked out by corgi. A card is
+  // moved on the tracker, worked on, or unblocked — the column follows.
+  async function loadKanban() {
+    const box = document.getElementById('kanban');
+    let cards = [], columns = [], boards = {};
+    try {
+      const r = await fetch('/launch/kanban', { headers: auth });
+      if (!r.ok) { box.hidden = true; return; }
+      const j = await r.json();
+      cards = j.cards || []; columns = j.columns || []; boards = j.boards || {};
+    } catch { box.hidden = true; tabCount('kanban', 0); return; }
+    const live = cards.filter(c => c.column !== 'Done').length;
+    tabCount('kanban', live);
+    if (!cards.length) { box.hidden = true; return; }
+    box.hidden = false;
+    box.innerHTML = '';
+    const wrap = document.createElement('div');
+    wrap.className = 'kb';
+    for (const col of columns) {
+      const rows = cards.filter(c => c.column === col);
+      const kc = document.createElement('div');
+      kc.className = 'kcol';
+      const h = document.createElement('h3');
+      h.textContent = col;
+      const n = document.createElement('span'); n.textContent = String(rows.length);
+      h.appendChild(n);
+      kc.appendChild(h);
+      if (!rows.length) {
+        const e = document.createElement('div'); e.className = 'empty'; e.textContent = '—';
+        kc.appendChild(e);
+      }
+      for (const c of rows) {
+        const card = document.createElement('div');
+        card.className = 'kcard' + (col === 'Blocked' ? ' blocked' : col === 'Running' ? ' running' : '');
+        const head = document.createElement('div');
+        const ref = document.createElement('span'); ref.className = 'kref'; ref.textContent = c.ref;
+        head.appendChild(ref);
+        if (c.workspace) { const w = document.createElement('span'); w.className = 'kws'; w.textContent = c.workspace; head.appendChild(w); }
+        card.appendChild(head);
+        if (c.title) { const t = document.createElement('p'); t.className = 'ktitle'; t.textContent = c.title; card.appendChild(t); }
+        const why = document.createElement('p'); why.className = 'kwhy'; why.textContent = c.why || ''; card.appendChild(why);
+        if (c.session) { const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = 'session ' + c.session.label + ' · ' + (STATUS_WORD[c.session.status] || c.session.status); card.appendChild(m); }
+        if (c.branch) { const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = c.branch; card.appendChild(m); }
+        if (c.handoff && c.handoff.next) { const m = document.createElement('p'); m.className = 'kmeta'; m.textContent = 'next: ' + c.handoff.next; card.appendChild(m); }
+        const row = document.createElement('div'); row.className = 'erow';
+        const ev = { key: c.key, ref: c.ref, workspace: c.workspace, kind: c.kind, url: c.url };
+        if (c.url && /^https:\/\//.test(c.url)) {
+          const a = document.createElement('a'); a.className = 'eopen'; a.href = c.url; a.target = '_blank'; a.rel = 'noopener noreferrer'; a.textContent = 'Open'; row.appendChild(a);
+        }
+        if (c.fix && (c.fix.prs || []).length) {
+          const a = document.createElement('a'); a.className = 'eopen'; a.href = c.fix.prs[0]; a.target = '_blank'; a.rel = 'noopener noreferrer'; a.textContent = 'Open PR'; row.appendChild(a);
+        }
+        if (col === 'Blocked' && c.key) {
+          const ub = document.createElement('button'); ub.className = 'primary'; ub.textContent = 'Unblock';
+          ub.onclick = () => { ub.disabled = true; ticket(ev, { do: 'unblock' }).finally(() => { ub.disabled = false; loadKanban(); }); };
+          row.appendChild(ub);
+        } else if ((col === 'Inbox' || col === 'Ready') && c.key && c.kind && c.kind.startsWith('issue.')) {
+          const go = document.createElement('button'); go.className = 'primary'; go.textContent = 'Work on it';
+          go.onclick = () => { go.disabled = true; workOn(ev).finally(() => { go.disabled = false; loadKanban(); }); };
+          row.appendChild(go);
+        }
+        const board = boards[c.workspace] || {};
+        if ((board.columns || []).length && c.key) {
+          const mv = document.createElement('button'); mv.textContent = 'Move…';
+          mv.onclick = () => moveSheet(ev, board.columns);
+          row.appendChild(mv);
+        }
+        if (row.children.length) card.appendChild(row);
+        kc.appendChild(card);
+      }
+      wrap.appendChild(kc);
+    }
+    box.appendChild(wrap);
   }
 
   async function loadInbox() {
@@ -3264,6 +3357,35 @@ const watchBatchMax = 10
 
 // launchEventsHandler lists what the watch has seen, newest first, so the
 // phone can show the tracker issues and reviews waiting for a decision.
+// launchKanbanHandler is the derived board: one card per ticket with its
+// column and why, plus the columns each tracker can move a ticket to.
+func launchKanbanHandler(w http.ResponseWriter, r *http.Request) {
+	dir, err := agentDir()
+	if err != nil {
+		writeLaunchError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	cards := gatherKanban(dir, strings.TrimSpace(r.URL.Query().Get("workspace")), time.Now())
+	boards := map[string]any{}
+	cache := watch.LoadBoardCache(dir)
+	for _, c := range cards {
+		if c.Workspace == "" {
+			continue
+		}
+		if _, seen := boards[c.Workspace]; seen {
+			continue
+		}
+		if info := cache.Get(c.Workspace); info.Has() {
+			names := make([]string, 0, len(info.Statuses))
+			for _, st := range info.Statuses {
+				names = append(names, st.Name)
+			}
+			boards[c.Workspace] = map[string]any{"columns": names, "me": info.Me.Name}
+		}
+	}
+	writeLaunchJSON(w, map[string]any{"columns": kanbanColumns, "cards": cards, "boards": boards})
+}
+
 func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 	setLaunchHeaders(w)
 	if r.Method != http.MethodGet {

--- a/cmd/mcp_launcher.go
+++ b/cmd/mcp_launcher.go
@@ -1281,6 +1281,7 @@ const launcherPageHTML = `<!doctype html>
   .ev .eref{font-weight:600;font-size:.82rem}
   .ev .ekind{font-size:.66rem;text-transform:uppercase;letter-spacing:.04em;opacity:.6;margin-left:.35rem}
   .ev .etitle{font-size:.78rem;opacity:.85;margin:.15rem 0 .4rem;overflow-wrap:anywhere}
+  .eblocked{margin:6px 0 0;font-size:13px;color:#E4695B}
   .ev .erow{display:flex;gap:.4rem;align-items:center}
   .ev a.eopen{font-size:.76rem;text-decoration:none;padding:.45rem .75rem;border-radius:.45rem;
     border:1px solid var(--line);color:inherit;min-height:2rem;display:inline-flex;align-items:center}
@@ -2267,9 +2268,27 @@ const launcherPageHTML = `<!doctype html>
           t.textContent = ev.title;
           card.appendChild(t);
         }
+        // Blocked is a column of its own: the reason, and the one button
+        // that puts the ticket back in front of the unattended mode.
+        if (ev.blocked) {
+          const b = document.createElement('p');
+          b.className = 'eblocked';
+          b.textContent = 'Blocked' + (ev.blockedBy === 'breaker' ? ' after repeated failures' : ev.blockedBy === 'run' ? ' by the run' : '') + ': ' + ev.blocked;
+          card.appendChild(b);
+        }
 
         const row = document.createElement('div');
         row.className = 'erow';
+        if (ev.blocked) {
+          const ub = document.createElement('button');
+          ub.className = 'primary';
+          ub.textContent = 'Unblock';
+          ub.onclick = () => {
+            ub.disabled = true;
+            ticket(ev, { do: 'unblock' }).finally(() => { ub.disabled = false; });
+          };
+          row.appendChild(ub);
+        }
         if (ev.url && /^https:\/\//.test(ev.url)) {
           const a = document.createElement('a');
           a.className = 'eopen';
@@ -2279,7 +2298,7 @@ const launcherPageHTML = `<!doctype html>
           a.textContent = ev.kind && ev.kind.startsWith('pr.') ? 'Open PR' : 'Open issue';
           row.appendChild(a);
         }
-        if (ev.actionable) {
+        if (ev.actionable && !ev.blocked) {
           const go = document.createElement('button');
           go.className = 'primary';
           go.textContent = 'Work on it';
@@ -3266,6 +3285,9 @@ func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 		At         time.Time `json:"at"`
 		Actionable bool      `json:"actionable"`
 		State      string    `json:"state,omitempty"`
+		// Blocked is why unattended runs leave this ticket alone, when they do.
+		Blocked   string `json:"blocked,omitempty"`
+		BlockedBy string `json:"blockedBy,omitempty"`
 	}
 	out := []row{}
 	// The events log keeps the column a ticket arrived in. A move made since
@@ -3274,6 +3296,7 @@ func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 	// The inbox is what is still waiting. Seen is not the test — every
 	// delivered event is seen — so it is the dismissed ones that leave.
 	state := watch.LoadState(dir)
+	fixLog := watch.LoadFixLog(dir)
 	for _, e := range watch.RecentEvents(dir, 40) {
 		if state.IsIgnored(e.Key) {
 			continue
@@ -3288,11 +3311,15 @@ func launchEventsHandler(w http.ResponseWriter, r *http.Request) {
 		if watch.Settled(e, current) != "" {
 			continue
 		}
-		out = append(out, row{Key: e.Key, Kind: string(e.Kind), Ref: e.Ref, Title: firstLineOf(e.Title),
-			URL: e.URL, Workspace: e.Workspace, At: e.At, Actionable: daemon.FixPrompt(e) != "", State: current})
+		r := row{Key: e.Key, Kind: string(e.Kind), Ref: e.Ref, Title: firstLineOf(e.Title),
+			URL: e.URL, Workspace: e.Workspace, At: e.At, Actionable: daemon.FixPrompt(e) != "", State: current}
+		if b, ok := fixLog.Blocked(e.Workspace, e.Ref); ok {
+			r.Blocked, r.BlockedBy = b.Reason, b.By
+		}
+		out = append(out, r)
 	}
 	fixes := []map[string]any{}
-	for _, r := range watch.LoadFixLog(dir).RecentFixes("", 25) {
+	for _, r := range fixLog.RecentFixes("", 25) {
 		row := map[string]any{"key": r.Key, "ref": firstNonEmptyString(r.Ref, r.Key), "workspace": r.Workspace,
 			"running": !r.Done(), "startedAt": r.StartedAt, "outcome": r.Outcome()}
 		if len(r.PRs) > 0 {
@@ -3369,6 +3396,19 @@ func launchTicketHandler(w http.ResponseWriter, r *http.Request) {
 		writeLaunchJSON(w, map[string]any{"done": "ignored " + firstNonEmptyString(event.Ref, event.Key)})
 		return
 	}
+	// Unblocking is a person's call too: it lets the unattended mode back on
+	// the ticket and clears the reason from the workpad.
+	if strings.TrimSpace(req.Do) == "unblock" {
+		if !watch.LoadFixLog(dir).Unblock(event.Workspace, event.Ref) {
+			writeLaunchError(w, http.StatusBadRequest, event.Ref+" is not blocked")
+			return
+		}
+		if _, _, err := watchWriter(dir, event.Workspace); err == nil {
+			go writeWorkpad(dir, event.Workspace, event.Ref, "Blocked", "")
+		}
+		writeLaunchJSON(w, map[string]any{"done": "unblocked " + event.Ref})
+		return
+	}
 	if event.Workspace == "" {
 		writeLaunchError(w, http.StatusBadRequest, "that event belongs to no workspace")
 		return
@@ -3430,7 +3470,7 @@ func launchTicketHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		writeLaunchJSON(w, map[string]any{"done": ref + " is yours"})
 	default:
-		writeLaunchError(w, http.StatusBadRequest, "do is move, assign, merge, close or ignore")
+		writeLaunchError(w, http.StatusBadRequest, "do is move, assign, merge, close, ignore or unblock")
 	}
 }
 

--- a/cmd/mcp_stack_tools.go
+++ b/cmd/mcp_stack_tools.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// The running, seeded stack is the one thing a session here has that a
+// session anywhere else does not. These tools finish that: hit a service by
+// name, ask the database how it would run a query.
+
+const httpBodyMax = 64 << 10
+
+type httpArgs struct {
+	ComposePath string
+	Service     string
+	Method      string
+	Path        string
+	Body        string
+	Headers     map[string]string
+}
+
+func addStackTools(s *server.MCPServer, composeOpt, serviceOpt mcp.ToolOption) {
+	s.AddTool(mcp.NewTool("corgi_http",
+		mcp.WithDescription("Send one HTTP request to a running service of the stack by its name — corgi knows the port — and return {status, headers, body, truncated, ms}. For checking a route the way a client would: GET /health, POST /limits with a JSON body. Body is capped at 64 KB. The service must be up (corgi_up); the request goes to 127.0.0.1, never over a tunnel."),
+		composeOpt,
+		serviceOpt,
+		mcp.WithString("path", mcp.Required(), mcp.Description("Path with query, e.g. /api/limits?user=1")),
+		mcp.WithString("method", mcp.Description("GET (default), POST, PUT, PATCH, DELETE")),
+		mcp.WithString("body", mcp.Description("Request body; JSON is sent as application/json unless headers say otherwise")),
+		mcp.WithObject("headers", mcp.Description("Extra headers, e.g. {\"Authorization\": \"Bearer …\"}")),
+	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
+		headers := map[string]string{}
+		if raw, ok := r.GetArguments()["headers"].(map[string]any); ok {
+			for k, v := range raw {
+				headers[k] = fmt.Sprint(v)
+			}
+		}
+		return mcpHTTP(httpArgs{
+			ComposePath: r.GetString("composePath", ""),
+			Service:     r.GetString("service", ""),
+			Method:      r.GetString("method", "GET"),
+			Path:        r.GetString("path", ""),
+			Body:        r.GetString("body", ""),
+			Headers:     headers,
+		})
+	}))
+
+	s.AddTool(mcp.NewTool("corgi_explain",
+		mcp.WithDescription("Ask a postgres-family db_service how it would run a query: EXPLAIN (or EXPLAIN ANALYZE when analyze is true — the query then actually runs, so not on a mutating statement) through psql. Returns {service, plan, truncated}. For finding the sequential scan behind a slow endpoint. Disabled over a public tunnel unless CORGI_MCP_ALLOW_DANGEROUS_TUNNEL=1."),
+		composeOpt,
+		mcp.WithString("service", mcp.Required(), mcp.Description("db_service name")),
+		mcp.WithString("query", mcp.Required(), mcp.Description("The SQL to explain")),
+		mcp.WithBoolean("analyze", mcp.Description("EXPLAIN ANALYZE: run it and report real timings (default false)")),
+	), jsonHandler(func(r mcp.CallToolRequest) (any, error) {
+		if !dangerousTunnelToolsAllowed(mcpPublicTunnelActive.Load()) {
+			return nil, fmt.Errorf("%s", dangerousToolBlockedMsg)
+		}
+		return mcpExplain(r.GetString("composePath", ""), r.GetString("service", ""), r.GetString("query", ""), r.GetBool("analyze", false))
+	}))
+}
+
+func mcpHTTP(a httpArgs) (any, error) {
+	if strings.TrimSpace(a.Service) == "" || strings.TrimSpace(a.Path) == "" {
+		return nil, fmt.Errorf("%s: service and path are required", utils.ErrUsage)
+	}
+	corgi, err := loadComposeForMCP(a.ComposePath)
+	if err != nil {
+		return nil, composeLoadError(err)
+	}
+	port, _, ok := serviceTunnelInfo(corgi, a.Service)
+	if !ok {
+		return nil, fmt.Errorf("%s: no service called %q in this stack", utils.ErrServiceNotFound, a.Service)
+	}
+	if port == 0 {
+		return nil, fmt.Errorf("%s: service %q declares no port", utils.ErrUsage, a.Service)
+	}
+	path := a.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	method := strings.ToUpper(strings.TrimSpace(a.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	var body io.Reader
+	if a.Body != "" {
+		body = strings.NewReader(a.Body)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("http://127.0.0.1:%d%s", port, path), body)
+	if err != nil {
+		return nil, err
+	}
+	if a.Body != "" && a.Headers["Content-Type"] == "" && looksLikeJSON(a.Body) {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range a.Headers {
+		req.Header.Set(k, v)
+	}
+	started := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s did not answer on :%d — is it up? (%v)", utils.ErrServiceNotFound, a.Service, port, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, httpBodyMax+1))
+	truncated := len(raw) > httpBodyMax
+	if truncated {
+		raw = raw[:httpBodyMax]
+	}
+	headers := map[string]string{}
+	for _, k := range []string{"Content-Type", "Content-Length", "Location", "Retry-After", "X-Request-Id", "Cache-Control"} {
+		if v := resp.Header.Get(k); v != "" {
+			headers[k] = v
+		}
+	}
+	return map[string]any{
+		"service": a.Service, "url": req.URL.String(), "status": resp.StatusCode,
+		"headers": headers, "body": string(raw), "truncated": truncated,
+		"ms": time.Since(started).Milliseconds(),
+	}, nil
+}
+
+func looksLikeJSON(s string) bool {
+	t := strings.TrimSpace(s)
+	return strings.HasPrefix(t, "{") || strings.HasPrefix(t, "[")
+}
+
+func mcpExplain(composePath, service, query string, analyze bool) (any, error) {
+	query = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(query), ";"))
+	if query == "" {
+		return nil, fmt.Errorf("%s: query is required", utils.ErrUsage)
+	}
+	prefix := "EXPLAIN "
+	if analyze {
+		prefix = "EXPLAIN (ANALYZE, BUFFERS) "
+	}
+	res, err := mcpDBQuery(dbQueryArgs{ComposePath: composePath, Service: service, Query: prefix + query + ";"})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"service": service, "plan": res.Output, "truncated": res.Truncated,
+		"hint": explainHint(res.Output)}, nil
+}
+
+// explainHint is the one line a plan is usually read for.
+func explainHint(plan string) string {
+	var hints []string
+	if strings.Contains(plan, "Seq Scan") {
+		hints = append(hints, "a sequential scan: an index on the filtered column would change it")
+	}
+	if strings.Contains(plan, "Nested Loop") && strings.Contains(plan, "Seq Scan") {
+		hints = append(hints, "a nested loop over a scan: the inner side runs once per outer row")
+	}
+	if strings.Contains(plan, "Sort") && strings.Contains(plan, "external") {
+		hints = append(hints, "a sort that spilled to disk: work_mem or an index in that order")
+	}
+	return strings.Join(hints, "; ")
+}

--- a/cmd/mcp_stack_tools_test.go
+++ b/cmd/mcp_stack_tools_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+// corgi_http hits a service by name on the port the compose file declares,
+// sends JSON as JSON, and caps the body.
+func TestCorgiHTTPTalksToAServiceByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", "abc")
+		if r.Method == http.MethodPost && r.Header.Get("Content-Type") == "application/json" && r.URL.Path == "/limits" {
+			w.WriteHeader(201)
+			w.Write([]byte(strings.Repeat("x", httpBodyMax+10)))
+			return
+		}
+		w.Write([]byte("ok " + r.URL.RawQuery))
+	}))
+	defer srv.Close()
+	_, portStr, _ := strings.Cut(strings.TrimPrefix(srv.URL, "http://127.0.0.1:"), "")
+	port, _ := strconv.Atoi(portStr)
+
+	orig := loadComposeForMCP
+	defer func() { loadComposeForMCP = orig }()
+	loadComposeForMCP = func(string) (*utils.CorgiCompose, error) {
+		return &utils.CorgiCompose{Services: []utils.Service{{ServiceName: "api", Port: port}}}, nil
+	}
+
+	out, err := mcpHTTP(httpArgs{Service: "api", Path: "health?x=1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.(map[string]any)
+	if got["status"] != 200 || got["body"] != "ok x=1" || got["headers"].(map[string]string)["X-Request-Id"] != "abc" {
+		t.Fatalf("get: %+v", got)
+	}
+	out, err = mcpHTTP(httpArgs{Service: "api", Path: "/limits", Method: "post", Body: `{"user":1}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = out.(map[string]any)
+	if got["status"] != 201 || got["truncated"] != true || len(got["body"].(string)) != httpBodyMax {
+		t.Fatalf("post: status %v truncated %v len %d", got["status"], got["truncated"], len(got["body"].(string)))
+	}
+	if _, err := mcpHTTP(httpArgs{Service: "nope", Path: "/"}); err == nil || !strings.Contains(err.Error(), "no service") {
+		t.Fatal("an unknown service is named")
+	}
+}
+
+func TestExplainHintReadsThePlan(t *testing.T) {
+	if h := explainHint("Seq Scan on users  (cost=0.00..35.50 rows=2550 width=4)"); !strings.Contains(h, "sequential scan") {
+		t.Fatalf("hint: %s", h)
+	}
+	if h := explainHint("Index Scan using users_pkey on users"); h != "" {
+		t.Fatalf("an index scan needs no hint: %s", h)
+	}
+}

--- a/cmd/surface.go
+++ b/cmd/surface.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	"andriiklymiuk/corgi/utils"
+	"github.com/spf13/cobra"
+)
+
+// The changed surface on the command line, for a person or a skill that has
+// no MCP handy: the same list corgi_diff --surface returns.
+var surfaceCmd = &cobra.Command{
+	Use:   "surface",
+	Short: "What a reviewer reads first: the public slice of the stack's diff",
+	Long: `Lists the exported symbols, routes, contracts, migrations and config files the
+current branches changed in every repository of the stack, against a base
+branch, with removals and signature changes marked breaking. No toolchain
+needed: it reads the diff. Paste the Markdown into the pull request body;
+review it before the diff.
+
+  corgi surface
+  corgi surface --base develop --json
+  corgi surface --branch feature/ABC-123/limits   # the branch's worktrees`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		base, _ := cmd.Flags().GetString("base")
+		branch, _ := cmd.Flags().GetString("branch")
+		composePath, _ := cmd.Flags().GetString("filename")
+		out, err := mcpSurface(composePath, base, branch)
+		if err != nil {
+			exitWithError("surface", err, 1)
+		}
+		if utils.JSONOutput {
+			utils.PrintJSON(out)
+			return
+		}
+		fmt.Print(out.(map[string]any)["markdown"])
+	},
+}
+
+func init() {
+	surfaceCmd.Flags().String("base", "", "base branch (default: main)")
+	surfaceCmd.Flags().String("branch", "", "diff the existing worktrees of this branch instead of the checkouts")
+	rootCmd.AddCommand(surfaceCmd)
+}

--- a/cmd/watch_isolate.go
+++ b/cmd/watch_isolate.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"andriiklymiuk/corgi/utils"
+)
+
+// The daemon asks for worktrees by workspace directory and branch; loading a
+// compose file goes through globals, so one at a time.
+var isolateMu sync.Mutex
+
+// isolateFixWorktrees gives every repository of the stack in dir a worktree
+// on branch and returns the directories, for an unattended run to work in.
+func isolateFixWorktrees(dir, branch string) ([]string, error) {
+	isolateMu.Lock()
+	defer isolateMu.Unlock()
+	composePath := ""
+	for _, name := range []string{utils.CorgiComposeDefaultName, "corgi-compose.yaml"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			composePath = filepath.Join(dir, name)
+			break
+		}
+	}
+	if composePath == "" {
+		return nil, fmt.Errorf("no corgi-compose.yml in %s", dir)
+	}
+	corgi, _, err := loadComposeForAgent(composePath)
+	if err != nil {
+		return nil, err
+	}
+	set, err := utils.MaterializeBranchAcrossRepos(corgi, dir, branch, nil)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var dirs []string
+	for _, w := range set.Worktrees {
+		if w.Skipped != "" || w.Dir == "" || seen[w.Dir] {
+			continue
+		}
+		seen[w.Dir] = true
+		dirs = append(dirs, w.Dir)
+	}
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("no repository in %s could take a worktree", dir)
+	}
+	return dirs, nil
+}
+
+// releaseFixWorktrees removes an isolated run's worktrees, keeping any with
+// uncommitted work and saying so.
+func releaseFixWorktrees(dir, branch string) (removed, kept []string, err error) {
+	if strings.TrimSpace(branch) == "" {
+		return nil, nil, nil
+	}
+	return utils.ReleaseBranchWorktreesReport(dir, branch)
+}

--- a/cmd/watch_pickup.go
+++ b/cmd/watch_pickup.go
@@ -109,7 +109,24 @@ func markDelivered(agentD, workspaceID string, e watch.Event, prs []string) {
 	}
 	_ = watch.LoadStateLog(agentD).Set(e.Key, status, time.Now())
 	// Say what it opened, on the ticket, so the board is not the only place
-	// the link exists.
-	_ = w.Comment(ctx, e.Ref, "corgi opened "+strings.Join(prs, " ")+" for this.")
+	// the link exists — in the one corgi comment, not a new one each time.
+	_ = watch.UpsertWorkpad(ctx, w, e.Ref, "Pull requests", strings.Join(prs, "\n"))
 	utils.Infof("corgi: %s → %s\n", e.Ref, status)
+}
+
+// writeWorkpad sets one section of a ticket's workpad comment from the
+// daemon, for the runner to leave the handoff or a blocker on the ticket.
+func writeWorkpad(agentD, workspaceID, ref, section, text string) {
+	if strings.TrimSpace(ref) == "" {
+		return
+	}
+	w, _, err := watchWriter(agentD, workspaceID)
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), pickupTimeout)
+	defer cancel()
+	if err := watch.UpsertWorkpad(ctx, w, ref, section, text); err != nil {
+		utils.Infof("corgi: workpad on %s: %v\n", ref, err)
+	}
 }

--- a/plugins/corgi/evals/README.md
+++ b/plugins/corgi/evals/README.md
@@ -1,0 +1,15 @@
+# Skill evals
+
+Two checks keep the plugin honest after every edit to a skill:
+
+1. **Activation** — does the right skill fire on its own for a realistic
+   prompt, and stay quiet for a near miss? `scripts/skill-activation.sh` runs
+   each prompt through `claude -p --max-turns 1 --allowedTools Skill` and
+   reads which skill was invoked. Works with any Claude Code; needs a login.
+2. **Outcome** — `claude plugin eval plugins/corgi` runs the cases here
+   (`<case>/prompt.md` + `graders/*.md`) with a no-plugin baseline arm and a
+   score threshold. Early access at the time of writing; the cases follow the
+   documented shape and the CI job tolerates the command being unavailable.
+
+Add a case when a skill gains a rule someone once broke: the prompt that
+broke it, and a grader that would have caught it.

--- a/plugins/corgi/evals/agent-leaves-a-handoff/graders/fires-agent.md
+++ b/plugins/corgi/evals/agent-leaves-a-handoff/graders/fires-agent.md
@@ -1,0 +1,6 @@
+---
+type: tool_used
+tool: Skill
+argument_contains: agent
+---
+Handoffs are the agent skill's job.

--- a/plugins/corgi/evals/agent-leaves-a-handoff/graders/uses-the-command.md
+++ b/plugins/corgi/evals/agent-leaves-a-handoff/graders/uses-the-command.md
@@ -1,0 +1,5 @@
+---
+type: regex
+pattern: corgi agent handoff --ref ABC-7
+---
+The packet is written with the command, one flag per item, not as prose in a comment.

--- a/plugins/corgi/evals/agent-leaves-a-handoff/prompt.md
+++ b/plugins/corgi/evals/agent-leaves-a-handoff/prompt.md
@@ -1,0 +1,1 @@
+I hit my usage limit on ABC-7 half-way through; the api side is done, the web banner is not. Leave a handoff for whoever picks it up next.

--- a/plugins/corgi/evals/review-reads-surface-first/graders/fires-review.md
+++ b/plugins/corgi/evals/review-reads-surface-first/graders/fires-review.md
@@ -1,0 +1,6 @@
+---
+type: tool_used
+tool: Skill
+argument_contains: review
+---
+A pull request link with "review" fires the review skill, not stories.

--- a/plugins/corgi/evals/review-reads-surface-first/graders/surface-first.md
+++ b/plugins/corgi/evals/review-reads-surface-first/graders/surface-first.md
@@ -1,0 +1,4 @@
+---
+type: llm
+---
+Score 1 if, before reading implementation lines, the assistant reads or produces the changed surface (the PR body's "Changed surface" section, `corgi surface`, or corgi_diff with surface) and names any breaking line. Score 0 if it goes straight to the diff.

--- a/plugins/corgi/evals/review-reads-surface-first/prompt.md
+++ b/plugins/corgi/evals/review-reads-surface-first/prompt.md
@@ -1,0 +1,1 @@
+Review this PR: https://github.com/acme/api/pull/42

--- a/plugins/corgi/evals/stories-routes-a-ticket/graders/bug-lane.md
+++ b/plugins/corgi/evals/stories-routes-a-ticket/graders/bug-lane.md
@@ -1,0 +1,4 @@
+---
+type: llm
+---
+Score 1 if the assistant treats this as a bug: it reproduces or reads logs first, writes a regression test that fails before the fix, and does not write a plan file or fan out to subagents. Score 0 if it plans it like a feature or starts editing without reproducing.

--- a/plugins/corgi/evals/stories-routes-a-ticket/graders/fires-stories.md
+++ b/plugins/corgi/evals/stories-routes-a-ticket/graders/fires-stories.md
@@ -1,0 +1,6 @@
+---
+type: tool_used
+tool: Skill
+argument_contains: stories
+---
+The stories skill is the one for a ticket named by key.

--- a/plugins/corgi/evals/stories-routes-a-ticket/prompt.md
+++ b/plugins/corgi/evals/stories-routes-a-ticket/prompt.md
@@ -1,0 +1,1 @@
+Do this story: ABC-123 — "Login returns 500 when the email has a plus sign". It is labelled bug.

--- a/plugins/corgi/monitors/monitors.json
+++ b/plugins/corgi/monitors/monitors.json
@@ -1,0 +1,9 @@
+{
+  "monitors": [
+    {
+      "command": "corgi logs --all --idle 0 --grep '(?i)\\b(error|panic|fatal|exception|traceback|5[0-9]{2} )\\b' --silent",
+      "when": "on-skill-invoke:debug",
+      "description": "error lines from every running service of the stack, while the debug skill works"
+    }
+  ]
+}

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -742,8 +742,10 @@ runs `/corgi:review <url>` in address-feedback mode, never a fresh review.
 Budget: at most 3 fixes an hour and 10 a day (`--max-per-hour`,
 `--max-per-day`), none in `--quiet 23:00-07:00`, none at 95 % of a usage
 window; a fix past that is deferred with the reason in the notification,
-never retried by the daemon on its own — `corgi agent watch run` hands it
-back. A fix runs unattended only for a workspace enabled with
+and starts on its own once the cap, the quiet hours or the budget has
+passed — most urgent first (labels `urgent`, `p0`, `p1`, `critical`, then
+`high`, `p2`), one per poll round; `--no-retry` leaves them to
+`corgi agent watch run`. A fix runs unattended only for a workspace enabled with
 `corgi agent init --dangerously-skip-permissions`. Rules live in the user
 config under `workspaces.<id>.watch` (`labels`, `states`, `assignee`,
 `comments`, `prs`, `repos`, `project`, `interval`, `action`,
@@ -762,6 +764,56 @@ workspace holding an override. `--clear --local` drops one.
 When the user asks "can corgi listen to new Jira/Linear issues or PR
 comments and fix them", this is the answer: enable watch with `--action fix`,
 add tokens, restart the daemon; webhooks for instant reaction.
+
+### Handoffs, the workpad, blocked, the kanban
+
+A run that stops part-way leaves a **handoff**: a typed packet, never a
+transcript, at `.corgi/corgi_services/handoffs/<ref>.json` with a Markdown
+twin. Write one yourself when you stop with work remaining, before a carry,
+or when you are blocked:
+
+```bash
+corgi agent handoff --ref ABC-123 --done "api returns 429" --remaining "web banner" \
+  --decision "5h sliding window" --uncertain "retry on the phone?" --next "web banner" \
+  --verify "corgi test --changed"        # runs it now, records exit + head
+corgi agent handoff show ABC-123         # the packet; says how many commits since
+corgi agent handoff verify ABC-123       # re-runs its check at the current head
+corgi agent handoff --ref ABC-123 --blocked "no GITLAB_TOKEN for the web repo"
+```
+
+The ref defaults to the ticket key in the branch name. A packet with a
+secret or a TODO is refused. The next run — unattended, or a new session on
+the branch (the SessionStart context says "handoff for ABC-123: read … first")
+— re-runs the packet's check at the current head before trusting its done
+list; a check that fails, or a branch that moved, means start from the
+ticket and the diff. `corgi agent carry` writes a draft packet before it
+moves a session, and past 85 % context (or `--fresh`) starts the new session
+clean with the packet as its first prompt.
+
+The **workpad** is the one corgi comment on a ticket, sections rewritten in
+place: `Spec`, `Pull requests`, `Handoff`, `Blocked`. Post the spec there
+(`corgi agent watch workpad ABC-123 Spec - < docs/stories/ABC-123.md`); corgi
+adds the PRs a run opened, the handoff it left, the reason it is blocked.
+The first line of the comment is `corgi · workpad`; never write a second.
+
+**Blocked** is a column: two failed runs in a row on one ticket trip the
+breaker; a handoff in state `blocked` or `auth-required` blocks it; a person
+can too (`corgi agent watch block ABC-123 "needs the sandbox key"`). A
+blocked ticket takes no budget and no run until `corgi agent watch unblock
+ABC-123` (also on the phone). A quota hit or a missing credential never
+counts as a failure.
+
+`corgi agent watch enable --isolate` gives every unattended run its own
+worktrees on `corgi/<ref>`, one per repository, so a run never touches the
+checkout; `watch undo` releases them (keeping any with uncommitted work).
+
+`corgi agent kanban [--workspace X] [--json]` is one card per ticket in a
+column corgi works out — Inbox, Ready (deferred, or a handoff waiting),
+Running (a run or a session on the branch), Blocked, Review (a PR is open),
+Done — with the session, the branch, the PRs, the handoff's next step and
+what the ticket has cost (runs keep claude's own receipt; sessions on the
+branch add their transcripts). The phone's Board tab draws the same. Moving a
+card is `watch move`; nobody drags one into Running.
 
 ## Things not to do
 

--- a/plugins/corgi/skills/agent/SKILL.md
+++ b/plugins/corgi/skills/agent/SKILL.md
@@ -807,6 +807,45 @@ counts as a failure.
 worktrees on `corgi/<ref>`, one per repository, so a run never touches the
 checkout; `watch undo` releases them (keeping any with uncommitted work).
 
+### Scope, drift, models, routines, hardening
+
+**Scope** is the contract a ticket's change stays inside, written after the
+spec is agreed (the stories skill does it): `corgi agent scope set ABC-123
+--path "api/limits/**" --lines 400 --tests 2 --done "…"`. Two hooks
+`corgi agent track enable` installs hold the session to it: a write outside
+the paths is refused with the way to widen (`corgi agent scope add ABC-123
+--path …` — do it when the change needs it, and say why in the PR), and a
+diff over budget is reported once when the turn ends (trim it, or raise the
+budget on the record). Both are silent on a branch with no scope.
+
+**Drift** is what the daemon concludes from the numbers on a live session:
+context ≥ 85 %, the same tool failing three times running, a diff twice the
+scope's budget (or past 800 lines with none), files outside the scope. The
+key says `DRIFT` with the first reason; the phone offers **Fresh** — a clean
+restart from a handoff under the same account (`corgi agent carry <session>
+--fresh`). The other ways out are `/compact`, `/rewind`, or splitting the
+branch by plan task.
+
+**Models** are a policy per phase in the user config (`models:` under a
+workspace or `defaults:`): `plan` and `review` on opus, `execute` and
+`triage` on sonnet/haiku, `escalate` after a failed run, `kinds:` per event.
+`corgi agent claude --model auto` starts on the policy's `auto` (opusplan by
+default); the unattended runner picks per kind and steps up after a failure.
+
+**Routines** are runs on a clock through the same runner: `corgi agent
+routine add digest` (daily 08:30), `babysit-pr` (every 2h), `deps`,
+`release-notes`, `flaky`, `doc-drift`, or `--prompt "…" --schedule "daily
+03:00"`. Each report is one inbox row with the log behind it; `routine run
+<name>` runs one now. Caps, quiet hours and budget apply.
+
+**Hardening**: `corgi agent harden` writes deny rules for secrets and
+destruction plus a hook that refuses to write a credential into a file, into
+the workspace's `.claude/settings.local.json`; `corgi agent doctor
+--security` says what is still loose. `corgi surface` is the changed public
+surface of the stack's diff (first section of every PR body, first thing a
+review reads); `corgi docs check` the docs that name what changed and the
+CLAUDE.md pointers that no longer land.
+
 `corgi agent kanban [--workspace X] [--json]` is one card per ticket in a
 column corgi works out — Inbox, Ready (deferred, or a handoff waiting),
 Running (a run or a session on the branch), Blocked, Review (a PR is open),

--- a/plugins/corgi/skills/corgi/references/mcp-tools.md
+++ b/plugins/corgi/skills/corgi/references/mcp-tools.md
@@ -34,6 +34,8 @@ them.
 | `corgi_env` | `composePath?, service?, key?` | `{service: {KEY: {value, source}}}` | real values — never echo into a transcript. Pass `service` or `key`; unfiltered output is capped at 40 vars per service |
 | `corgi_exec` | `service, command, ensureDeps?, serviceBranch?, serviceDir?` | `{exitCode, output, truncated, durationMs}` | one-off command in the service's resolved env; **tunnel-gated** |
 | `corgi_test` | `service?, profile?, ensureDeps?, changed?, base?, e2e?, serviceBranch?, serviceDir?` | `{services[], passed, note?}` | runs each `test` script; starts nothing. `changed: true` (with `base`, default `main`) is the smallest set for this diff; `e2e: true` runs the compose `e2e:` block |
+| `corgi_http` | `service, path, method?, body?, headers?` | `{status, headers, body, truncated, ms}` | one request to a running service by name on 127.0.0.1; JSON body sent as JSON; body capped at 64 KB. The way to check a route as a client would |
+| `corgi_explain` | `service, query, analyze?` | `{service, plan, truncated, hint}` | EXPLAIN (or EXPLAIN ANALYZE, which runs the query) on a postgres-family db; the hint names the sequential scan or spilled sort; **tunnel-gated** |
 | `corgi_db_query` | `service, query` | `{service, output, truncated}` | driver's own client syntax; writes are not blocked; **tunnel-gated**. Take a `corgi_db_snapshot` before a mutating query |
 | `corgi_db_snapshot` | `service?, name?, force?` | `{service, name, archive, sizeBytes}` | postgres-family only; refused while `corgi_up` services run (databases-only or after `corgi_down`) |
 | `corgi_db_restore` | `name, service?, force?` | `{service, archive}` | **wipes the data volume**; **tunnel-gated** |

--- a/plugins/corgi/skills/review/SKILL.md
+++ b/plugins/corgi/skills/review/SKILL.md
@@ -224,6 +224,18 @@ Hand a review subagent: that PR's diff + title/body + the repo's standards note
 + (if any) the intent note from P1.5. Scope **strictly to the diff** — don't
 review untouched code.
 
+**Surface first, then the diff.** Before a line of implementation, read the
+changed surface — the PR body's `## Changed surface` section when the author
+left one, else make it: `corgi surface --base <base>` from the checkout (or
+`corgi_diff` with `surface: true` over the stack). It lists the exported
+symbols, routes, contracts, migrations and config that changed, removals and
+signature changes marked breaking. Every breaking line is a question the
+review must answer — who calls it, is the caller in this PR or another, does
+the ticket ask for it — before the diff is opened. A change whose surface is
+"nothing public changed" is reviewed for behaviour and tests only. Say in the
+summary comment what the surface was; a reviewer who reads only that line
+should know whether to look closer.
+
 **Hunt for:**
 - Correctness bugs.
 - Missing or weak tests.

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -672,6 +672,17 @@ issue link.
   **draft** PR as _in progress_ and revert this move — the review state only sticks once
   the PR is marked _ready_. Set it once; don't fight a revert.
 - **Cross-link** siblings + merge order in each multi-repo PR/MR body.
+- **Evidence in the body, always.** A reviewer who did not watch the run needs
+  four things to trust it, and they never appear on their own: a `## Evidence`
+  section with (1) **changed files with a reason each** — one line per file or
+  group, why it changed, not what; (2) **commands run and their results** — the
+  test, build and check commands verbatim with pass/fail, so a reviewer can
+  re-run exactly that; (3) **tests → acceptance criteria** — each new or changed
+  test mapped to the criterion it protects, core flow first; a criterion with no
+  test says so; (4) **known limitations and residual risk** — what was left out,
+  what could still go wrong, in one line each. Facts only, no adjectives; skip
+  nothing you did, invent nothing you did not. Multi-repo → per PR, its own
+  files. Before the `Deferred` list and the risk card.
 - **Run-locally line in the body** — the same one-paste
   `corgi run --service-branch <svc>=<branch> … --with-deps` (Grouped report) so a
   reviewer spins the branch up without hunting.

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -710,6 +710,13 @@ issue link.
   **draft** PR as _in progress_ and revert this move — the review state only sticks once
   the PR is marked _ready_. Set it once; don't fight a revert.
 - **Cross-link** siblings + merge order in each multi-repo PR/MR body.
+- **Changed surface at the top of the body.** `corgi surface --branch <branch>`
+  (or `corgi_diff` with `surface: true`) prints the `## Changed surface` block:
+  exported symbols, routes, contracts, migrations and config this PR changed,
+  removals and signature changes marked breaking. Paste it first — it is what a
+  reviewer reads before the diff, and a breaking line with no caller updated in
+  the same batch is a bug you should have caught here. Re-run after every push
+  in the Phase 5.5 loop.
 - **Evidence in the body, always.** A reviewer who did not watch the run needs
   four things to trust it, and they never appear on their own: a `## Evidence`
   section with (1) **changed files with a reason each** — one line per file or

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -383,6 +383,25 @@ record, and a visual/QA defect is what a human must re-verify.
 
 Branch: `feature/<issue-key>/<kebab-slug>`, same name in every affected repo.
 
+**Write the scope before the first edit.** The spec named the files or areas
+that change and what done means; put that on the record so the hooks hold you
+to it while you work:
+
+```bash
+corgi agent scope set <issue-key> --path "api/limits/**" --path "web/src/limits/**" \
+  --lines <diff budget> --tests <new test files> --done "<criterion>" --done "…"
+```
+
+Paths are workspace-relative globs (`**` crosses directories; a directory
+covers what is in it). The line budget is the spec's honest guess at the diff
+(adjustment ≈ 60, bug ≈ 150, feature ≈ 400 per service) and the test budget one
+file per acceptance criterion, core flow first. From then on a write outside the
+paths is refused with the way to widen — `corgi agent scope add <key> --path …`
+— and widening is fine when the change needs it; say why in the PR. A diff over
+budget is reported once when the turn ends: trim it, or raise the budget on the
+record (`scope set --lines N`) with one line in the PR saying why. Never widen
+silently, never disable the hook.
+
 **Get `<issue-key>` from the tracker, don't invent it** (auto-link token):
 
 - **Linear** — `get_issue` → `identifier` (`ABC-123`) + suggested `gitBranchName`.

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -717,6 +717,12 @@ issue link.
   reviewer reads before the diff, and a breaking line with no caller updated in
   the same batch is a bug you should have caught here. Re-run after every push
   in the Phase 5.5 loop.
+- **Docs that name what changed.** `corgi docs check --branch <branch>` lists
+  every Markdown file that mentions a symbol or route the batch changed, and
+  every `file:line` pointer in CLAUDE.md or `.claude/rules` that no longer
+  lands. Fix the ones the change made wrong in the same PR; list the rest under
+  `Deferred` with the file name. A stale doc is a bug the reviewer cannot see
+  in the diff.
 - **Evidence in the body, always.** A reviewer who did not watch the run needs
   four things to trust it, and they never appear on their own: a `## Evidence`
   section with (1) **changed files with a reason each** — one line per file or

--- a/plugins/corgi/skills/stories/SKILL.md
+++ b/plugins/corgi/skills/stories/SKILL.md
@@ -40,6 +40,25 @@ superpowers checkpoints.
 **Tier ≠ span.** Complexity axis vs single/multi-service (Phase 4). Multi-service
 adjustment is still an adjustment. Most stories = adjustments → fastest path.
 
+**How the tier is picked.** `--mode bug|feature|adjustment` in the invocation
+wins. Else the ticket's own words: type or labels `bug`, `defect`, `regression`,
+`incident`, `hotfix` → **Bug**; `feature`, `story`, `epic`, `design` → **Feature**;
+anything else → **Adjustment** until Phase 1 proves otherwise. If the diff fits
+one sentence, it is an adjustment whatever the label says.
+
+**Risk lane — always a plan, whatever the size.** A change that touches
+migrations, auth, sessions, permissions, payments, billing, secrets or a
+cross-service contract gets Feature rigor even when it is three lines: the
+interface or schema change is written and confirmed first (Phase 2 gate never
+collapses for it), and the spec names the rollback. The workspace may extend
+the list with `riskPaths:` under its entry in the user agent config.
+
+**Bug lane — logs first, theories second.** Before a hypothesis: reproduce
+against the running stack (`corgi run`, `corgi logs <svc> --errors-only`,
+`corgi_wait_for_log`), quote the failing line or request, then write the
+regression test that fails on `<base>`, then the smallest fix. No plan file, no
+subagent fan-out: a bug is a straight line from the log to the test.
+
 **Express lane — small-surface adjustment.** Reuses the Phase 2 fast-path's _tier +
 span_ bar — **adjustment/bug, single service, no cross-service contract** — but NOT
 its "one item / one sentence / no open question" half: that gates the approval

--- a/scripts/skill-activation.sh
+++ b/scripts/skill-activation.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Does the right corgi skill fire on its own? Each line: expected skill (or
+# "none") and a prompt. Runs one turn with only the Skill tool allowed and
+# reads what was invoked. Needs a logged-in Claude Code; ~1 cent a line.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+plugin="$(pwd)/plugins/corgi"
+pass=0; fail=0
+while IFS='|' read -r want prompt; do
+  [[ -z "$want" || "$want" == \#* ]] && continue
+  out=$(claude -p "$prompt" --max-turns 1 --allowedTools Skill --output-format json --plugin-dir "$plugin" 2>/dev/null || true)
+  got=$(printf '%s' "$out" | grep -oE '"skill"\s*:\s*"[^"]+"' | head -1 | sed -E 's/.*"([^"]+)"$/\1/' || true)
+  got=${got:-none}
+  if [[ "$got" == *"$want"* ]] || { [[ "$want" == none ]] && [[ "$got" == none ]]; }; then
+    pass=$((pass+1)); printf '✓ %-10s %s\n' "$got" "$prompt"
+  else
+    fail=$((fail+1)); printf '✗ want %-10s got %-10s %s\n' "$want" "$got" "$prompt"
+  fi
+done <<'CASES'
+stories|do ABC-123
+stories|implement https://linear.app/acme/issue/ABC-9/limits and https://linear.app/acme/issue/ABC-10/banner
+review|review https://github.com/acme/api/pull/42
+run|run the stack with the tunnel and logs
+debug|the api is down, what is wrong
+setup|I just installed corgi, set everything up
+agent|leave a handoff for ABC-7, the web side is not done
+none|what is the capital of France
+CASES
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -112,6 +112,9 @@ type WorkspaceConfig struct {
 	// Watch asks the daemon to poll the tracker and code host for this
 	// workspace and act on new issues and review comments.
 	Watch *WatchConfig `yaml:"watch"`
+	// Models is which model does which kind of work, so a plan is thought
+	// through on the strong one and a red build fixed on the cheap one.
+	Models *ModelPolicy `yaml:"models"`
 	// DangerouslySkipPermissions runs the session with permission prompts off,
 	// removing the main defence against it acting on instructions injected into
 	// a file it read. Trusted config only by construction — RepoConfig has no
@@ -284,6 +287,106 @@ type WatchConfig struct {
 	PickupStatus string `yaml:"pickupStatus,omitempty"`
 }
 
+// ModelPolicy names a model per phase of work. Empty fields take the
+// defaults; Kinds overrides the unattended runner per event kind.
+type ModelPolicy struct {
+	// Auto is what `corgi agent claude --model auto` starts with; opusplan
+	// (Opus to plan, Sonnet to execute) unless told otherwise.
+	Auto string `yaml:"auto,omitempty"`
+	// Plan, Execute, Review and Triage are the phases a run goes through.
+	Plan    string `yaml:"plan,omitempty"`
+	Execute string `yaml:"execute,omitempty"`
+	Review  string `yaml:"review,omitempty"`
+	Triage  string `yaml:"triage,omitempty"`
+	// Escalate is what the next run uses after a failed one on the same
+	// ticket: a harder problem gets the stronger model, not another try.
+	Escalate string `yaml:"escalate,omitempty"`
+	// Kinds maps an unattended event kind (issue.new, ci.failed, …) to a
+	// model, beating the phase defaults.
+	Kinds map[string]string `yaml:"kinds,omitempty"`
+}
+
+// Defaults for the policy: plan and review on the strong model, execution
+// and triage on the cheap one.
+const (
+	ModelAutoDefault     = "opusplan"
+	ModelPlanDefault     = "opus"
+	ModelExecuteDefault  = "sonnet"
+	ModelReviewDefault   = "opus"
+	ModelTriageDefault   = "haiku"
+	ModelEscalateDefault = "opus"
+)
+
+// ForAuto is the interactive default.
+func (m *ModelPolicy) ForAuto() string {
+	return pick(m, func(p ModelPolicy) string { return p.Auto }, ModelAutoDefault)
+}
+
+// ForKind is the runner's model for one event kind: the kind's own entry,
+// else the phase it belongs to. A fresh ticket is planned; a red build, a
+// comment or a review reply is executed; a review someone asked for is
+// reviewed.
+func (m *ModelPolicy) ForKind(kind string) string {
+	if m != nil && m.Kinds != nil {
+		if v := strings.TrimSpace(m.Kinds[kind]); v != "" {
+			return v
+		}
+	}
+	switch kind {
+	case "issue.new":
+		return pick(m, func(p ModelPolicy) string { return p.Plan }, ModelPlanDefault)
+	case "review.requested":
+		return pick(m, func(p ModelPolicy) string { return p.Review }, ModelReviewDefault)
+	default:
+		return pick(m, func(p ModelPolicy) string { return p.Execute }, ModelExecuteDefault)
+	}
+}
+
+// ForEscalation is the model after a failed run.
+func (m *ModelPolicy) ForEscalation() string {
+	return pick(m, func(p ModelPolicy) string { return p.Escalate }, ModelEscalateDefault)
+}
+
+func pick(m *ModelPolicy, get func(ModelPolicy) string, def string) string {
+	if m != nil {
+		if v := strings.TrimSpace(get(*m)); v != "" {
+			return v
+		}
+	}
+	return def
+}
+
+func overlayModels(base, over *ModelPolicy) *ModelPolicy {
+	if over == nil {
+		return base
+	}
+	if base == nil {
+		return over
+	}
+	merged := *base
+	for _, f := range []struct {
+		dst *string
+		src string
+	}{
+		{&merged.Auto, over.Auto}, {&merged.Plan, over.Plan}, {&merged.Execute, over.Execute},
+		{&merged.Review, over.Review}, {&merged.Triage, over.Triage}, {&merged.Escalate, over.Escalate},
+	} {
+		if strings.TrimSpace(f.src) != "" {
+			*f.dst = f.src
+		}
+	}
+	if len(over.Kinds) > 0 {
+		merged.Kinds = map[string]string{}
+		for k, v := range base.Kinds {
+			merged.Kinds[k] = v
+		}
+		for k, v := range over.Kinds {
+			merged.Kinds[k] = v
+		}
+	}
+	return &merged
+}
+
 // overlayWatch replaces base with over, keeping base's caps and quiet
 // hours where over left them unset, so defaults: can carry a budget for
 // every watched workspace.
@@ -364,6 +467,7 @@ func overlay(base, over WorkspaceConfig) WorkspaceConfig {
 		base.WakeLock = over.WakeLock
 	}
 	base.Watch = overlayWatch(base.Watch, over.Watch)
+	base.Models = overlayModels(base.Models, over.Models)
 	// Booleans that grant capability are OR-ed rather than overwritten, so a
 	// per-workspace entry cannot silently turn off a default the user set.
 	base.InheritAPIKey = base.InheritAPIKey || over.InheritAPIKey

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -115,6 +115,9 @@ type WorkspaceConfig struct {
 	// Models is which model does which kind of work, so a plan is thought
 	// through on the strong one and a red build fixed on the cheap one.
 	Models *ModelPolicy `yaml:"models"`
+	// Routines are runs on a clock: the morning digest, the PR babysitter.
+	// Each is a catalog kind or a prompt, and a schedule.
+	Routines []Routine `yaml:"routines,omitempty"`
 	// DangerouslySkipPermissions runs the session with permission prompts off,
 	// removing the main defence against it acting on instructions injected into
 	// a file it read. Trusted config only by construction — RepoConfig has no
@@ -285,6 +288,18 @@ type WatchConfig struct {
 	// — "In Progress", say. Empty writes nothing: a tracker corgi has not
 	// been told to move tickets on is left alone.
 	PickupStatus string `yaml:"pickupStatus,omitempty"`
+}
+
+// Routine is one scheduled run. Kind names a catalog entry (digest,
+// babysit-pr, deps, release-notes, flaky, doc-drift); Prompt is a run of
+// the user's own; Schedule is "daily HH:MM", "every 6h" or "weekly Mon HH:MM".
+type Routine struct {
+	Name     string `yaml:"name"`
+	Kind     string `yaml:"kind,omitempty"`
+	Prompt   string `yaml:"prompt,omitempty"`
+	Schedule string `yaml:"schedule"`
+	Model    string `yaml:"model,omitempty"`
+	Off      bool   `yaml:"off,omitempty"`
 }
 
 // ModelPolicy names a model per phase of work. Empty fields take the
@@ -468,6 +483,9 @@ func overlay(base, over WorkspaceConfig) WorkspaceConfig {
 	}
 	base.Watch = overlayWatch(base.Watch, over.Watch)
 	base.Models = overlayModels(base.Models, over.Models)
+	if len(over.Routines) > 0 {
+		base.Routines = over.Routines
+	}
 	// Booleans that grant capability are OR-ed rather than overwritten, so a
 	// per-workspace entry cannot silently turn off a default the user set.
 	base.InheritAPIKey = base.InheritAPIKey || over.InheritAPIKey

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -255,6 +255,10 @@ type WatchConfig struct {
 	// machine watching the same board leaves it alone. Off by default: it
 	// posts a comment, which not every board wants.
 	Lease bool `yaml:"lease,omitempty"`
+	// NoRetry stops the daemon from starting a deferred fix on its own once
+	// the cap, the quiet hours or the budget that stopped it has passed.
+	// Off by default: a fix that waited for budget runs when budget returns.
+	NoRetry bool `yaml:"noRetry,omitempty"`
 	// Isolate gives every unattended run its own git worktrees, one per
 	// repository, on a branch named after the ticket — so a run never
 	// touches your checkout and two runs on one repo do not collide. Off by

--- a/utils/agent/config/config.go
+++ b/utils/agent/config/config.go
@@ -255,6 +255,11 @@ type WatchConfig struct {
 	// machine watching the same board leaves it alone. Off by default: it
 	// posts a comment, which not every board wants.
 	Lease bool `yaml:"lease,omitempty"`
+	// Isolate gives every unattended run its own git worktrees, one per
+	// repository, on a branch named after the ticket — so a run never
+	// touches your checkout and two runs on one repo do not collide. Off by
+	// default: it takes disk and a branch per ticket.
+	Isolate bool `yaml:"isolate,omitempty"`
 	// Reviews reports pull requests someone asked me to review.
 	Reviews bool `yaml:"reviews,omitempty"`
 	// CI reports builds that went red on something of mine.

--- a/utils/agent/config/config_test.go
+++ b/utils/agent/config/config_test.go
@@ -375,3 +375,22 @@ func TestApplyProfileEmptyNameIsANoOp(t *testing.T) {
 		t.Fatalf("empty profile must pass through, got %+v, %v", got, err)
 	}
 }
+
+// The model policy: strong model to plan and review, cheap one to execute,
+// a kind's own entry beats the phase, and a workspace overlays defaults
+// field by field.
+func TestModelPolicyPicksByPhaseAndKind(t *testing.T) {
+	var none *ModelPolicy
+	if none.ForAuto() != ModelAutoDefault || none.ForKind("issue.new") != ModelPlanDefault || none.ForKind("ci.failed") != ModelExecuteDefault || none.ForKind("review.requested") != ModelReviewDefault || none.ForEscalation() != ModelEscalateDefault {
+		t.Fatal("nil policy is the defaults")
+	}
+	base := &ModelPolicy{Execute: "sonnet[1m]", Kinds: map[string]string{"ci.failed": "haiku"}}
+	over := &ModelPolicy{Plan: "fable", Kinds: map[string]string{"issue.comment": "haiku"}}
+	m := overlayModels(base, over)
+	if m.ForKind("issue.new") != "fable" || m.ForKind("pr.comment") != "sonnet[1m]" || m.ForKind("ci.failed") != "haiku" || m.ForKind("issue.comment") != "haiku" {
+		t.Fatalf("overlay: %+v", m)
+	}
+	if base.Kinds["issue.comment"] != "" {
+		t.Fatal("overlay must not write into the base map")
+	}
+}

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -106,6 +106,10 @@ type Daemon struct {
 	// a run left, the reason it is blocked. Nil when the workspace has no
 	// tracker token.
 	Workpad func(workspace, ref, section, text string)
+	// Isolate gives a workspace's repositories worktrees on a branch and
+	// returns their directories, for a watch with isolate on. Nil means
+	// runs happen in the checkout.
+	Isolate func(dir, branch string) ([]string, error)
 	Events  *events.Log
 	// CaptureBrief probes what an ending session left on disk. Injected because
 	// enumerating a stack's repositories means parsing a compose file, which the

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -174,6 +174,9 @@ type Daemon struct {
 	// waits for the runners: a swap that launches after the runner wait has
 	// begun would add to a WaitGroup already being waited on.
 	swaps sync.WaitGroup
+	// runs counts unattended fixes in flight, so a test or a shutdown can
+	// wait for the last one to write its record.
+	runs sync.WaitGroup
 
 	// nudge wakes the command loop; the cross-process doorbell is SIGUSR1.
 	nudge chan struct{}

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -177,6 +177,8 @@ type Daemon struct {
 	// runs counts unattended fixes in flight, so a test or a shutdown can
 	// wait for the last one to write its record.
 	runs sync.WaitGroup
+	// routines remembers when each scheduled run last started.
+	routines *routineState
 
 	// nudge wakes the command loop; the cross-process doorbell is SIGUSR1.
 	nudge chan struct{}

--- a/utils/agent/daemon/daemon.go
+++ b/utils/agent/daemon/daemon.go
@@ -102,7 +102,11 @@ type Daemon struct {
 	// it: the work is done and it is waiting on a reviewer, which is a
 	// different column from the one it was picked up into.
 	Delivered func(workspace string, e watch.Event, prs []string)
-	Events    *events.Log
+	// Workpad writes one section of the ticket's corgi comment: the handoff
+	// a run left, the reason it is blocked. Nil when the workspace has no
+	// tracker token.
+	Workpad func(workspace, ref, section, text string)
+	Events  *events.Log
 	// CaptureBrief probes what an ending session left on disk. Injected because
 	// enumerating a stack's repositories means parsing a compose file, which the
 	// daemon has no business knowing about. Nil disables briefs entirely.

--- a/utils/agent/daemon/drift.go
+++ b/utils/agent/daemon/drift.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/scope"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+)
+
+// A session drifts when the numbers say it is no longer doing what it set
+// out to do: the context window nearly full, the same tool failing over
+// and over, a diff far past what the ticket agreed, files outside its
+// scope. The daemon does not fix that; it says so, once, and on every
+// surface, with the three ways out — rewind, split, fresh from a handoff.
+
+const (
+	driftContextAt = 85
+	driftFailsAt   = 3
+	// driftLinesFloor is the diff at which a branch with no scope is worth
+	// a look; a scope's own budget, doubled, is the line when there is one.
+	driftLinesFloor = 800
+)
+
+// driftDiff is a seam: the diff's size and the files it touches.
+var driftDiff = gitDriftDiff
+
+func gitDriftDiff(dir string) (lines int, files []string, ok bool) {
+	base := ""
+	for _, b := range []string{"origin/main", "origin/master", "main", "master"} {
+		out, err := exec.Command("git", "-C", dir, "merge-base", "HEAD", b).Output()
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			base = strings.TrimSpace(string(out))
+			break
+		}
+	}
+	if base == "" {
+		return 0, nil, false
+	}
+	out, err := exec.Command("git", "-C", dir, "diff", "--numstat", base).Output()
+	if err != nil {
+		return 0, nil, false
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 3 {
+			continue
+		}
+		a, _ := strconv.Atoi(f[0])
+		d, _ := strconv.Atoi(f[1])
+		lines += a + d
+		files = append(files, f[2])
+	}
+	return lines, files, true
+}
+
+// workspaceRootOf is a seam: the workspace a session's cwd belongs to.
+var workspaceRootOf = func(cwd string) string { return sessions.RepoRoot(cwd) }
+
+// driftReasons is what is wrong with a session right now, in the order a
+// person would want to hear it.
+func driftReasons(s sessions.Session) []string {
+	var reasons []string
+	if s.Context != nil && s.Context.Percent >= driftContextAt {
+		reasons = append(reasons, fmt.Sprintf("context %d%% full — /compact, or fresh from a handoff", s.Context.Percent))
+	}
+	if s.FailStreak >= driftFailsAt {
+		reasons = append(reasons, fmt.Sprintf("the same tool failed %d times running — step in, or /rewind to before the loop", s.FailStreak))
+	}
+	if s.Cwd == "" {
+		return reasons
+	}
+	root := workspaceRootOf(s.Cwd)
+	sc, hasScope := scope.Scope{}, false
+	if root != "" {
+		sc, hasScope = scope.ForBranch(root, s.Branch)
+	}
+	lines, files, ok := driftDiff(s.Cwd)
+	if !ok {
+		return reasons
+	}
+	limit := driftLinesFloor
+	if hasScope && sc.Lines > 0 {
+		limit = 2 * sc.Lines
+	}
+	if lines > limit {
+		what := "far past the usual size"
+		if hasScope && sc.Lines > 0 {
+			what = fmt.Sprintf("twice the %d-line budget", sc.Lines)
+		}
+		reasons = append(reasons, fmt.Sprintf("diff is %d lines, %s — split it, or trim to the spec", lines, what))
+	}
+	if hasScope && len(sc.Paths) > 0 {
+		var outside []string
+		for _, f := range files {
+			if !sc.Allows(f) {
+				outside = append(outside, f)
+			}
+		}
+		if len(outside) > 0 {
+			shown := outside
+			if len(shown) > 3 {
+				shown = append(shown[:3], "…")
+			}
+			reasons = append(reasons, fmt.Sprintf("%d file(s) outside the scope for %s: %s", len(outside), sc.Ref, strings.Join(shown, ", ")))
+		}
+	}
+	return reasons
+}
+
+// checkDrift runs on the minute sweep over live sessions, and notifies
+// once when a session starts drifting.
+func (d *Daemon) checkDrift(now time.Time) {
+	if d.Sessions == nil {
+		return
+	}
+	for _, s := range d.Sessions.Sessions() {
+		if s.Status != sessions.StatusWorking && s.Status != sessions.StatusNeedsInput && s.Status != sessions.StatusDone {
+			continue
+		}
+		reasons := driftReasons(s)
+		if _, began := d.Sessions.SetDrift(s.ID, reasons); began {
+			label := s.Display
+			if label == "" {
+				label = s.Label
+			}
+			go d.notifyAttention("corgi agent · "+label, "drifting: "+reasons[0], s.Folder)
+		}
+	}
+}

--- a/utils/agent/daemon/drift_test.go
+++ b/utils/agent/daemon/drift_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"andriiklymiuk/corgi/utils/agent/scope"
+	"andriiklymiuk/corgi/utils/agent/sessions"
+	"andriiklymiuk/corgi/utils/agent/usage"
+)
+
+// Drift is the numbers, not a feeling: a nearly full context, the same tool
+// failing again and again, a diff twice the budget, files outside the scope.
+func TestDriftIsReadFromTheNumbers(t *testing.T) {
+	origDiff, origRoot := driftDiff, workspaceRootOf
+	defer func() { driftDiff, workspaceRootOf = origDiff, origRoot }()
+	root := t.TempDir()
+	workspaceRootOf = func(string) string { return root }
+	if err := scope.Write(root, scope.Scope{Ref: "ABC-4", Paths: []string{"api/**"}, Lines: 200}); err != nil {
+		t.Fatal(err)
+	}
+	driftDiff = func(string) (int, []string, bool) { return 120, []string{"api/a.go"}, true }
+
+	calm := sessions.Session{Cwd: root, Branch: "feature/ABC-4/x", Context: &usage.Context{Percent: 40}}
+	if r := driftReasons(calm); len(r) != 0 {
+		t.Fatalf("calm: %v", r)
+	}
+	loud := calm
+	loud.Context = &usage.Context{Percent: 91}
+	loud.FailStreak = 4
+	driftDiff = func(string) (int, []string, bool) { return 500, []string{"api/a.go", "web/b.tsx", "web/c.tsx"}, true }
+	r := driftReasons(loud)
+	if len(r) != 4 {
+		t.Fatalf("four reasons: %v", r)
+	}
+	for i, want := range []string{"context 91%", "failed 4 times", "500 lines, twice the 200-line budget", "2 file(s) outside the scope for ABC-4: web/b.tsx, web/c.tsx"} {
+		if !strings.Contains(r[i], want) {
+			t.Errorf("reason %d lacks %q: %s", i, want, r[i])
+		}
+	}
+	// No scope: only the floor applies.
+	noScope := sessions.Session{Cwd: root, Branch: "main"}
+	driftDiff = func(string) (int, []string, bool) { return 500, []string{"x"}, true }
+	if r := driftReasons(noScope); len(r) != 0 {
+		t.Fatalf("500 lines with no scope is under the floor: %v", r)
+	}
+	driftDiff = func(string) (int, []string, bool) { return 900, []string{"x"}, true }
+	if r := driftReasons(noScope); len(r) != 1 || !strings.Contains(r[0], "far past the usual size") {
+		t.Fatalf("over the floor: %v", r)
+	}
+}

--- a/utils/agent/daemon/routines.go
+++ b/utils/agent/daemon/routines.go
@@ -1,0 +1,154 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/config"
+	"andriiklymiuk/corgi/utils/agent/watch"
+	"andriiklymiuk/corgi/utils/atomicfile"
+)
+
+// Routines run on a clock through the same runner as a fix, so the caps,
+// the quiet hours, the budget, the log, the cost and the handoff all apply.
+// The report is one inbox row: the run's headline, with the log behind it.
+
+type routineState struct {
+	mu   sync.Mutex
+	path string
+	Last map[string]time.Time `json:"last"` // "<workspace>/<name>" → started
+}
+
+func loadRoutineState(agentDir string) *routineState {
+	s := &routineState{path: filepath.Join(agentDir, "watch", "routines.json"), Last: map[string]time.Time{}}
+	if data, err := os.ReadFile(s.path); err == nil {
+		_ = json.Unmarshal(data, s)
+	}
+	if s.Last == nil {
+		s.Last = map[string]time.Time{}
+	}
+	return s
+}
+
+func (s *routineState) get(key string) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Last[key]
+}
+
+func (s *routineState) set(key string, at time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Last[key] = at
+	if data, err := json.MarshalIndent(s, "", "  "); err == nil {
+		_ = os.MkdirAll(filepath.Dir(s.path), 0o700)
+		_ = atomicfile.Write(s.path, data, 0o600)
+	}
+}
+
+// RoutineEvent is the synthetic event a routine runs as: the prompt in the
+// body, the name as the ref, so the fix log and the inbox tell it apart.
+func RoutineEvent(workspace string, r config.Routine, now time.Time) (watch.Event, bool) {
+	prompt := strings.TrimSpace(r.Prompt)
+	title := r.Name
+	if k, ok := watch.CatalogKind(r.Kind); ok && prompt == "" {
+		prompt = k.Prompt
+		if title == "" {
+			title = k.Name
+		}
+	}
+	if prompt == "" || title == "" {
+		return watch.Event{}, false
+	}
+	return watch.Event{
+		Key:       "routine:" + workspace + ":" + title + ":" + now.Format("20060102-1504"),
+		Source:    "routine",
+		Kind:      watch.KindRoutine,
+		Workspace: workspace,
+		Ref:       "routine/" + title,
+		Title:     title,
+		Body:      prompt,
+		At:        now,
+	}, true
+}
+
+// runRoutines starts every routine that is due, one per workspace per
+// tick, under the fix caps.
+func (d *Daemon) runRoutines(ctx context.Context, now time.Time) {
+	if d.watchState == nil {
+		return
+	}
+	if d.routines == nil {
+		d.routines = loadRoutineState(d.Dir)
+	}
+	for _, spec := range d.Watches {
+		for _, r := range spec.Routines {
+			if r.Off {
+				continue
+			}
+			sched, err := watch.ParseSchedule(r.Schedule)
+			if err != nil {
+				continue
+			}
+			key := spec.Workspace + "/" + firstNonEmpty(r.Name, r.Kind)
+			if !sched.Due(d.routines.get(key), now) {
+				continue
+			}
+			e, ok := RoutineEvent(spec.Workspace, r, now)
+			if !ok {
+				continue
+			}
+			if reason := fixDeferral(spec, d.watchState.Fixes, now); reason != "" {
+				utils.Infof("agent: routine %s waits: %s\n", e.Title, reason)
+				continue
+			}
+			if !d.claimFix(spec.Workspace, e.Ref) {
+				continue
+			}
+			d.routines.set(key, now)
+			d.watchState.Fixes.StartFor(e, now)
+			run := spec
+			if r.Model != "" {
+				run.Models = &config.ModelPolicy{Kinds: map[string]string{string(watch.KindRoutine): r.Model}}
+			}
+			utils.Infof("agent: routine %s starts in %s\n", e.Title, spec.Workspace)
+			d.spawnFix(ctx, run, e)
+			break // one per workspace per tick; the caps pace the rest
+		}
+	}
+}
+
+// routineReport turns a finished routine into an inbox row: the headline
+// the run was asked to start with, the rest behind the Log button.
+func (d *Daemon) routineReport(spec WatchSpec, e watch.Event, out string, failed error) {
+	if e.Kind != watch.KindRoutine {
+		return
+	}
+	headline := firstLine(strings.TrimSpace(out))
+	if failed != nil {
+		headline = "failed: " + failed.Error()
+	}
+	if headline == "" {
+		headline = "finished with nothing to say"
+	}
+	report := e
+	report.Key = e.Key + ":report"
+	report.Title = e.Title + " — " + clipText(headline, 160)
+	report.Body = ""
+	d.watchState.MarkSeen(report.Key)
+	d.appendWatchEvent(report)
+	go d.notifyAttention("corgi agent · "+spec.Workspace, e.Title+": "+clipText(headline, 160), spec.Workspace)
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/utils/agent/daemon/routines_test.go
+++ b/utils/agent/daemon/routines_test.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/config"
+	"andriiklymiuk/corgi/utils/agent/watch"
+)
+
+// A routine due on the clock starts through the fix runner, once, and its
+// report lands in the inbox as one row with the run's headline.
+func TestRoutinesRunOnTheClockAndReportToTheInbox(t *testing.T) {
+	d := dynDaemon(t)
+	d.loadWatchFiles()
+	d.fixBusy = map[string]*sync.Mutex{"api": {}}
+	spec := WatchSpec{Workspace: "api", Dir: t.TempDir(), Action: "notify",
+		Routines: []config.Routine{{Name: "digest", Kind: "digest", Schedule: "daily 08:30"}, {Name: "off", Kind: "deps", Schedule: "daily 08:30", Off: true}}}
+	d.Watches = []WatchSpec{spec}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	day := time.Date(2026, 9, 14, 0, 0, 0, 0, time.Local)
+	d.runRoutines(ctx, day.Add(8*time.Hour))
+	if len(d.watchState.Fixes.RecentFixes("api", 10)) != 0 {
+		t.Fatal("not before 08:30")
+	}
+	d.runRoutines(ctx, day.Add(9*time.Hour))
+	d.runs.Wait()
+	runs := d.watchState.Fixes.RecentFixes("api", 10)
+	if len(runs) != 1 || runs[0].Ref != "routine/digest" {
+		t.Fatalf("the due one starts, the off one does not: %+v", runs)
+	}
+	d.releaseFix("api", "routine/digest")
+	d.runRoutines(ctx, day.Add(10*time.Hour))
+	d.runs.Wait()
+	if len(d.watchState.Fixes.RecentFixes("api", 10)) != 1 {
+		t.Fatal("once a day")
+	}
+	if last := loadRoutineState(d.Dir).get("api/digest"); !last.Equal(day.Add(9 * time.Hour)) {
+		t.Fatalf("the start is remembered on disk: %v", last)
+	}
+
+	e, ok := RoutineEvent("api", config.Routine{Name: "digest", Kind: "digest"}, day)
+	if !ok || !strings.Contains(e.Body, "morning digest") || e.Ref != "routine/digest" {
+		t.Fatalf("event from the catalog: %+v", e)
+	}
+	d.routineReport(spec, e, "3 PRs green, 1 red\n- details…", nil)
+	rows := watch.RecentEvents(d.Dir, 5)
+	// Two rows: the cancelled run above reported its failure, and this one.
+	if len(rows) != 2 || rows[0].Kind != watch.KindRoutine || !strings.Contains(rows[0].Title, "digest — 3 PRs green, 1 red") || rows[0].Body != "" {
+		t.Fatalf("inbox row: %+v", rows)
+	}
+	if !strings.Contains(rows[1].Title, "failed:") {
+		t.Fatalf("a failed run reports too: %+v", rows[1])
+	}
+	if _, ok := RoutineEvent("api", config.Routine{Name: "x"}, day); ok {
+		t.Fatal("no kind, no prompt, nothing to run")
+	}
+}

--- a/utils/agent/daemon/sessions.go
+++ b/utils/agent/daemon/sessions.go
@@ -341,6 +341,7 @@ func (d *Daemon) reapSessions(ctx context.Context) {
 			d.sampleAccounts(now)
 			d.autoContinue(ctx, now)
 			d.checkDrift(now)
+			d.runRoutines(ctx, now)
 		}
 		d.flushSessions()
 	}

--- a/utils/agent/daemon/sessions.go
+++ b/utils/agent/daemon/sessions.go
@@ -340,6 +340,7 @@ func (d *Daemon) reapSessions(ctx context.Context) {
 			d.Sessions.Sweep(now)
 			d.sampleAccounts(now)
 			d.autoContinue(ctx, now)
+			d.checkDrift(now)
 		}
 		d.flushSessions()
 	}

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -593,6 +593,8 @@ func unattendedSuffix(spec WatchSpec, e watch.Event) string {
 		"Put this line at the end of the pull request body so whoever reviews it knows where it came from: " +
 		trail + "\n" +
 		"Say plainly at the end what you changed and what your own review found.\n" +
+		"The pull request body carries a `## Evidence` section — changed files with a reason each; the commands you ran with their results; " +
+		"each test mapped to the acceptance criterion it protects; known limitations and residual risk — facts, one line each.\n" +
 		"If you stop with work remaining, blocked, or unsure, leave a handoff for the next run before you end: " +
 		"`corgi agent handoff --ref " + e.Ref + " --done … --remaining … --decision … --uncertain … --next … --verify \"<the check you ran>\"` " +
 		"(one flag per item; short sentences; no secrets)."

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -34,11 +34,13 @@ type WatchSpec struct {
 	NoRetry bool
 	// Models picks the model per event kind, and the one to step up to
 	// after a failed run.
-	Models  *config.ModelPolicy
-	Project string   // tracker key prefix: ABC-123 belongs to ABC
-	Repos   []string // owner/repo
-	Rules   watch.Rules
-	Sources []watch.Source
+	Models *config.ModelPolicy
+	// Routines run on a clock in this workspace; see routines.go.
+	Routines []config.Routine
+	Project  string   // tracker key prefix: ABC-123 belongs to ABC
+	Repos    []string // owner/repo
+	Rules    watch.Rules
+	Sources  []watch.Source
 	// Skipped names the sources the rules can never use, so status can say
 	// why they are not polled.
 	Skipped  []string
@@ -235,6 +237,26 @@ func (d *Daemon) startWatches(ctx context.Context) {
 // else to the first one whose rules take it; the seen list keeps it single.
 func (d *Daemon) handleWatchEvent(ctx context.Context, e watch.Event) {
 	if d.watchers == nil {
+		return
+	}
+	// A routine handed in by `corgi agent routine run` names its workspace
+	// and skips the rules: someone asked for it now.
+	if e.Kind == watch.KindRoutine {
+		for _, spec := range d.Watches {
+			if spec.Workspace != e.Workspace || d.watchState == nil {
+				continue
+			}
+			if reason := fixDeferral(spec, d.watchState.Fixes, time.Now()); reason != "" {
+				utils.Infof("agent: routine %s waits: %s\n", e.Title, reason)
+				return
+			}
+			if !d.claimFix(spec.Workspace, e.Ref) {
+				return
+			}
+			d.watchState.Fixes.StartFor(e, time.Now())
+			d.spawnFix(ctx, spec, e)
+			return
+		}
 		return
 	}
 	for _, spec := range d.Watches {
@@ -510,6 +532,9 @@ func firstNonEmpty(a, b string) string {
 // the rules: one spec gate collapsed by the approval, draft PRs only,
 // never merge.
 var fixPrompts = map[watch.Kind]func(e watch.Event) string{
+	watch.KindRoutine: func(e watch.Event) string {
+		return e.Body
+	},
 	watch.KindIssueNew: func(e watch.Event) string {
 		return "I approve all changes; ship it and open draft PRs, then watch CI to green. /corgi:stories " + e.Ref + storyMode(e)
 	},
@@ -729,6 +754,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 		d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
 		d.mirrorHandoff(spec, e.Ref, started)
 		d.tripBreaker(spec, e, runErr.Error())
+		d.routineReport(spec, e, string(out), runErr)
 		go d.notifyAttentionAt("corgi agent · "+spec.Workspace,
 			fmt.Sprintf("fix for %s failed: %v — log: %s", e.Ref, runErr, logPath), spec.Workspace, e.URL)
 		return
@@ -746,6 +772,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
 	d.mirrorHandoff(spec, e.Ref, started)
 	d.blockIfRunSaidSo(spec, e, started)
+	d.routineReport(spec, e, string(out), nil)
 	// It opened something, so the ticket is no longer being worked on — it is
 	// waiting on a reviewer, and the board should say so without anyone
 	// dragging it.

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -15,6 +15,7 @@ import (
 
 	"andriiklymiuk/corgi/utils"
 	"andriiklymiuk/corgi/utils/agent/events"
+	"andriiklymiuk/corgi/utils/agent/handoff"
 	"andriiklymiuk/corgi/utils/agent/usage"
 	"andriiklymiuk/corgi/utils/agent/watch"
 )
@@ -534,7 +535,10 @@ func unattendedSuffix(spec WatchSpec, e watch.Event) string {
 		"and fix what you find — nobody has looked at this but you. " +
 		"Put this line at the end of the pull request body so whoever reviews it knows where it came from: " +
 		trail + "\n" +
-		"Say plainly at the end what you changed and what your own review found."
+		"Say plainly at the end what you changed and what your own review found.\n" +
+		"If you stop with work remaining, blocked, or unsure, leave a handoff for the next run before you end: " +
+		"`corgi agent handoff --ref " + e.Ref + " --done … --remaining … --decision … --uncertain … --next … --verify \"<the check you ran>\"` " +
+		"(one flag per item; short sentences; no secrets)."
 }
 
 // fixArgs is claude's argv for one event.
@@ -546,7 +550,10 @@ func fixArgs(spec WatchSpec, e watch.Event) []string {
 // second attempt continues rather than starting at the ticket again.
 func fixArgsWith(spec WatchSpec, e watch.Event, handover string) []string {
 	prompt := fixPrompt(e) + unattendedSuffix(spec, e)
-	if handover = strings.TrimSpace(handover); handover != "" {
+	if p, ok := packetFor(spec.Dir, e.Ref); ok {
+		prompt += "\n\nAn earlier run left a handoff for this ticket. Read it first; it is typed state, not a transcript. " +
+			"Its verification was re-run at the current head: " + packetTrust(spec.Dir, p) + "\n" + p.Markdown()
+	} else if handover = strings.TrimSpace(handover); handover != "" {
 		prompt += "\n\nAn earlier run on this stopped part-way. This is the last thing it said — " +
 			"treat it as notes, not as truth, and check anything it claims before building on it:\n" + handover
 	}
@@ -615,6 +622,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	// What the window was at before the run, so the receipt is the difference.
 	before, hadBefore := usage.ReadLimits(spec.ConfigDir)
 	handover := d.watchState.Fixes.LastHandover(spec.Workspace, e.Ref)
+	started := time.Now()
 	cmd := claudeCommand(ctx, spec.Dir, env, fixArgsWith(spec, e, handover)...)
 	cmd.Stdin = nil
 	out, runErr := cmd.Output()
@@ -624,7 +632,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 		d.watchState.Fixes.Finish(e.Key, nil, "", runErr.Error(), time.Now())
 		// What it managed to say before it stopped is worth more than the
 		// error on its own: the next attempt starts from there.
-		d.watchState.Fixes.SetHandover(e.Key, watch.TailLines(string(out), 6), time.Now())
+		d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
 		go d.notifyAttentionAt("corgi agent · "+spec.Workspace,
 			fmt.Sprintf("fix for %s failed: %v — log: %s", e.Ref, runErr, logPath), spec.Workspace, e.URL)
 		return
@@ -639,7 +647,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 		body += " — " + note
 	}
 	d.watchState.Fixes.Finish(e.Key, links, note, "", time.Now())
-	d.watchState.Fixes.SetHandover(e.Key, watch.TailLines(string(out), 6), time.Now())
+	d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
 	// It opened something, so the ticket is no longer being worked on — it is
 	// waiting on a reviewer, and the board should say so without anyone
 	// dragging it.
@@ -826,4 +834,66 @@ func (d *Daemon) refreshInboxStates(ctx context.Context, spec WatchSpec) {
 			}
 		}
 	}
+}
+
+// packetFor is the handoff an earlier run left for a ticket, if it is
+// recent enough to still describe the code.
+func packetFor(dir, ref string) (handoff.Packet, bool) {
+	p, err := handoff.Read(dir, ref)
+	if err != nil || time.Since(p.WrittenAt) > handoff.MaxAge {
+		return handoff.Packet{}, false
+	}
+	return p, true
+}
+
+// packetTrust re-runs the packet's own check so the next run knows whether
+// to build on it or to start from the ticket and the diff.
+func packetTrust(dir string, p handoff.Packet) string {
+	if p.Verification == nil {
+		return "it recorded no check, so trust nothing in it you have not confirmed."
+	}
+	v, ok := handoff.Verify(worktreeOf(dir, p), p, runShellQuiet)
+	if ok {
+		return fmt.Sprintf("`%s` passes at %s, so its done list can be trusted.", v.Cmd, shortSHA(v.At))
+	}
+	if n, err := handoff.CommitsSince(worktreeOf(dir, p), p.Where.Head); err == nil && n > 0 {
+		return fmt.Sprintf("`%s` exits %d and the branch moved %d commit(s) since — start from the ticket and the diff, not the packet.", v.Cmd, v.Exit, n)
+	}
+	return fmt.Sprintf("`%s` exits %d now — start from the ticket and the diff, not the packet.", v.Cmd, v.Exit)
+}
+
+// runHandover is what a run leaves for the next one: the packet it wrote
+// during the run when it wrote one, else the last lines it said.
+func runHandover(dir, ref string, started time.Time, out string) string {
+	if p, err := handoff.Read(dir, ref); err == nil && !p.WrittenAt.Before(started) {
+		return "handoff: " + p.Summary() + " — " + handoff.MarkdownPath(dir, ref)
+	}
+	return watch.TailLines(out, 6)
+}
+
+func worktreeOf(dir string, p handoff.Packet) string {
+	if p.Where.Worktree != "" {
+		return filepath.Join(dir, p.Where.Worktree)
+	}
+	return dir
+}
+
+func runShellQuiet(dir, command string) (int, error) {
+	c := exec.Command("sh", "-c", command)
+	c.Dir = dir
+	err := c.Run()
+	if err == nil {
+		return 0, nil
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode(), err
+	}
+	return 1, err
+}
+
+func shortSHA(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -25,10 +25,12 @@ type WatchSpec struct {
 	Workspace string
 	Dir       string
 	ConfigDir string
-	Project   string   // tracker key prefix: ABC-123 belongs to ABC
-	Repos     []string // owner/repo
-	Rules     watch.Rules
-	Sources   []watch.Source
+	// Isolate runs each fix in its own worktrees; see Daemon.Isolate.
+	Isolate bool
+	Project string   // tracker key prefix: ABC-123 belongs to ABC
+	Repos   []string // owner/repo
+	Rules   watch.Rules
+	Sources []watch.Source
 	// Skipped names the sources the rules can never use, so status can say
 	// why they are not polled.
 	Skipped  []string
@@ -623,7 +625,22 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	before, hadBefore := usage.ReadLimits(spec.ConfigDir)
 	handover := d.watchState.Fixes.LastHandover(spec.Workspace, e.Ref)
 	started := time.Now()
-	cmd := claudeCommand(ctx, spec.Dir, env, fixArgsWith(spec, e, handover)...)
+	args := fixArgsWith(spec, e, handover)
+	if spec.Isolate && d.Isolate != nil {
+		branch := FixBranch(e.Ref)
+		trees, err := d.Isolate(spec.Dir, branch)
+		if err != nil {
+			fmt.Fprintf(logFile, "\n=== could not isolate: %v\n", err)
+			d.watchState.Fixes.Finish(e.Key, nil, "", "could not create worktrees: "+err.Error(), time.Now())
+			go d.notifyAttentionAt("corgi agent · "+spec.Workspace,
+				fmt.Sprintf("fix for %s did not start: could not create worktrees: %v", e.Ref, err), spec.Workspace, e.URL)
+			return
+		}
+		d.watchState.Fixes.SetBranch(e.Key, branch)
+		args[1] += isolationNote(branch, trees)
+		fmt.Fprintf(logFile, "=== worktrees on %s: %s\n", branch, strings.Join(trees, ", "))
+	}
+	cmd := claudeCommand(ctx, spec.Dir, env, args...)
 	cmd.Stdin = nil
 	out, runErr := cmd.Output()
 	logFile.Write(out)
@@ -911,4 +928,20 @@ func (d *Daemon) mirrorHandoff(spec WatchSpec, ref string, started time.Time) {
 		return
 	}
 	go d.Workpad(spec.Workspace, ref, "Handoff", p.Markdown())
+}
+
+// FixBranch is the branch an isolated run works on: one per ticket, so a
+// second attempt lands in the same worktrees and undo knows what to remove.
+func FixBranch(ref string) string {
+	ref = strings.ToLower(strings.TrimSpace(ref))
+	ref = strings.NewReplacer("/", "-", "#", "-", " ", "-", ":", "-").Replace(ref)
+	return "corgi/" + ref
+}
+
+// isolationNote tells the run where to work. The stories skill would make
+// its own branch and worktrees; here they exist already.
+func isolationNote(branch string, trees []string) string {
+	return "\n\nThis run is isolated: every repository already has a worktree on branch `" + branch +
+		"`, created off its current HEAD. Work only in these directories and open the pull requests from this branch; " +
+		"do not create another branch and do not edit the main checkouts:\n- " + strings.Join(trees, "\n- ")
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,6 +28,8 @@ type WatchSpec struct {
 	ConfigDir string
 	// Isolate runs each fix in its own worktrees; see Daemon.Isolate.
 	Isolate bool
+	// NoRetry leaves deferred fixes to a manual run.
+	NoRetry bool
 	Project string   // tracker key prefix: ABC-123 belongs to ABC
 	Repos   []string // owner/repo
 	Rules   watch.Rules
@@ -211,6 +214,7 @@ func (d *Daemon) startWatches(ctx context.Context) {
 			Round: func(now time.Time) {
 				d.watchState.NewRound()
 				d.releaseHeld(spec, now)
+				d.retryDeferred(ctx, spec, now)
 				go d.refreshInboxStates(ctx, spec)
 			}}
 		d.watchers[spec.Workspace] = w
@@ -308,9 +312,47 @@ func (d *Daemon) releaseHeld(spec WatchSpec, now time.Time) {
 	go d.notifyAttention("corgi agent · "+spec.Workspace, body, spec.Workspace)
 }
 
+// retryDeferred starts the most urgent deferred fix for a workspace once
+// whatever stopped it — a cap, quiet hours, the budget — has passed. One
+// per round, so a backlog drains at the pace the caps allow rather than
+// all at once the minute the window resets.
+func (d *Daemon) retryDeferred(ctx context.Context, spec WatchSpec, now time.Time) {
+	if spec.NoRetry || spec.Action != "fix" || d.watchState == nil {
+		return
+	}
+	var queue []watch.Event
+	for _, e := range d.watchState.Fixes.DeferredEvents() {
+		if e.Workspace != spec.Workspace {
+			continue
+		}
+		if _, blocked := d.watchState.Fixes.Blocked(spec.Workspace, e.Ref); blocked {
+			continue
+		}
+		if d.watchState.IsIgnored(e.Key) {
+			continue
+		}
+		queue = append(queue, e)
+	}
+	if len(queue) == 0 {
+		return
+	}
+	if reason := fixDeferral(spec, d.watchState.Fixes, now); reason != "" {
+		return
+	}
+	sort.SliceStable(queue, func(i, j int) bool { return watch.Less(queue[i], queue[j]) })
+	e := queue[0]
+	if !d.claimFix(spec.Workspace, e.Ref) {
+		return
+	}
+	d.watchState.MarkSeen(e.Key)
+	d.watchState.Fixes.StartFor(e, now)
+	utils.Infof("agent: watch %s: deferred fix for %s starts now (%d more waiting)\n", spec.Workspace, e.Ref, len(queue)-1)
+	d.spawnFix(ctx, spec, e)
+}
+
 // startFix launches the fix, or says in one short note why not. A deferred
-// event leaves the seen list and waits in the fix log for a manual
-// `corgi agent watch run`; the daemon never retries it by itself.
+// event leaves the seen list and waits in the fix log until the daemon can
+// start it (retryDeferred) or someone runs `corgi agent watch run`.
 func (d *Daemon) startFix(ctx context.Context, spec WatchSpec, e watch.Event) string {
 	now := time.Now()
 	if reason := fixDeferral(spec, d.watchState.Fixes, now); reason != "" {
@@ -323,8 +365,16 @@ func (d *Daemon) startFix(ctx context.Context, spec WatchSpec, e watch.Event) st
 		return "a fix for it is already running"
 	}
 	d.watchState.Fixes.StartFor(e, now)
-	go d.runFix(ctx, spec, e)
+	d.spawnFix(ctx, spec, e)
 	return ""
+}
+
+func (d *Daemon) spawnFix(ctx context.Context, spec WatchSpec, e watch.Event) {
+	d.runs.Add(1)
+	go func() {
+		defer d.runs.Done()
+		d.runFix(ctx, spec, e)
+	}()
 }
 
 // fixDeferral says why a fix must not start now; "" means go ahead.

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -633,6 +633,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 		// What it managed to say before it stopped is worth more than the
 		// error on its own: the next attempt starts from there.
 		d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
+		d.mirrorHandoff(spec, e.Ref, started)
 		go d.notifyAttentionAt("corgi agent · "+spec.Workspace,
 			fmt.Sprintf("fix for %s failed: %v — log: %s", e.Ref, runErr, logPath), spec.Workspace, e.URL)
 		return
@@ -648,6 +649,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	}
 	d.watchState.Fixes.Finish(e.Key, links, note, "", time.Now())
 	d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
+	d.mirrorHandoff(spec, e.Ref, started)
 	// It opened something, so the ticket is no longer being worked on — it is
 	// waiting on a reviewer, and the board should say so without anyone
 	// dragging it.
@@ -896,4 +898,17 @@ func shortSHA(s string) string {
 		return s[:7]
 	}
 	return s
+}
+
+// mirrorHandoff puts the packet a run wrote onto the ticket's workpad, so a
+// machine or account without this checkout can still pick the work up.
+func (d *Daemon) mirrorHandoff(spec WatchSpec, ref string, started time.Time) {
+	if d.Workpad == nil {
+		return
+	}
+	p, err := handoff.Read(spec.Dir, ref)
+	if err != nil || p.WrittenAt.Before(started) {
+		return
+	}
+	go d.Workpad(spec.Workspace, ref, "Handoff", p.Markdown())
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/events"
 	"andriiklymiuk/corgi/utils/agent/handoff"
 	"andriiklymiuk/corgi/utils/agent/usage"
@@ -31,6 +32,9 @@ type WatchSpec struct {
 	Isolate bool
 	// NoRetry leaves deferred fixes to a manual run.
 	NoRetry bool
+	// Models picks the model per event kind, and the one to step up to
+	// after a failed run.
+	Models  *config.ModelPolicy
 	Project string   // tracker key prefix: ABC-123 belongs to ABC
 	Repos   []string // owner/repo
 	Rules   watch.Rules
@@ -685,6 +689,10 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	handover := d.watchState.Fixes.LastHandover(spec.Workspace, e.Ref)
 	started := time.Now()
 	args := fixArgsWith(spec, e, handover)
+	if model := fixModel(spec, e, d.watchState.Fixes.FailedInARow(spec.Workspace, e.Ref)); model != "" {
+		args = append(args, "--model", model)
+		fmt.Fprintf(logFile, "=== model: %s\n", model)
+	}
 	if spec.Isolate && d.Isolate != nil {
 		branch := FixBranch(e.Ref)
 		trees, err := d.Isolate(spec.Dir, branch)
@@ -1095,4 +1103,14 @@ func unwrapResult(raw []byte) ([]byte, runReceipt) {
 	u := env.Usage
 	return []byte(env.Result), runReceipt{ok: true, costUSD: env.CostUSD, turns: env.NumTurns,
 		tokens: u.Input + u.Output + u.CacheRead + u.CacheWrite}
+}
+
+// fixModel is the model for one run: the policy's choice for the kind, or
+// the escalation after a failed run on the same ticket — a harder problem
+// gets the stronger model rather than another try with the same one.
+func fixModel(spec WatchSpec, e watch.Event, failedBefore int) string {
+	if failedBefore > 0 {
+		return spec.Models.ForEscalation()
+	}
+	return spec.Models.ForKind(string(e.Kind))
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -511,7 +511,7 @@ func firstNonEmpty(a, b string) string {
 // never merge.
 var fixPrompts = map[watch.Kind]func(e watch.Event) string{
 	watch.KindIssueNew: func(e watch.Event) string {
-		return "I approve all changes; ship it and open draft PRs, then watch CI to green. /corgi:stories " + e.Ref
+		return "I approve all changes; ship it and open draft PRs, then watch CI to green. /corgi:stories " + e.Ref + storyMode(e)
 	},
 	watch.KindIssueComment: func(e watch.Event) string {
 		return fmt.Sprintf("A new comment on %s from %s says: %q. Read it and decide. "+
@@ -1115,4 +1115,19 @@ func fixModel(spec WatchSpec, e watch.Event, failedBefore int) string {
 		return spec.Models.ForEscalation()
 	}
 	return spec.Models.ForKind(string(e.Kind))
+}
+
+// storyMode tells the stories skill which lane the ticket's own labels put
+// it in, so a bug goes logs-first and a feature gets a plan; nothing when
+// the labels say nothing.
+func storyMode(e watch.Event) string {
+	for _, l := range e.Labels {
+		switch strings.ToLower(strings.TrimSpace(l)) {
+		case "bug", "defect", "regression", "incident", "hotfix":
+			return " --mode bug"
+		case "feature", "story", "epic", "design":
+			return " --mode feature"
+		}
+	}
+	return ""
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -588,6 +588,14 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	}
 	defer logFile.Close()
 
+	// A ticket that is blocked — by the breaker, by a run that said so, or
+	// by a person — waits for a person. Nothing is deferred and no budget is
+	// spent; the inbox shows why.
+	if b, ok := d.watchState.Fixes.Blocked(spec.Workspace, e.Ref); ok && e.Ref != "" {
+		d.watchState.Fixes.Finish(e.Key, nil, "", "not started: blocked ("+b.By+"): "+b.Reason, time.Now())
+		utils.Infof("agent: watch: %s is blocked (%s): %s — corgi agent watch unblock %s\n", e.Ref, b.By, b.Reason, e.Ref)
+		return
+	}
 	// A wall this workspace has hit twice running is not worth a third run:
 	// a missing credential or a refused permission will still be missing in
 	// an hour. Deferred, so a manual run picks it up once it is fixed.
@@ -651,6 +659,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 		// error on its own: the next attempt starts from there.
 		d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
 		d.mirrorHandoff(spec, e.Ref, started)
+		d.tripBreaker(spec, e, runErr.Error())
 		go d.notifyAttentionAt("corgi agent · "+spec.Workspace,
 			fmt.Sprintf("fix for %s failed: %v — log: %s", e.Ref, runErr, logPath), spec.Workspace, e.URL)
 		return
@@ -667,6 +676,7 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	d.watchState.Fixes.Finish(e.Key, links, note, "", time.Now())
 	d.watchState.Fixes.SetHandover(e.Key, runHandover(spec.Dir, e.Ref, started, string(out)), time.Now())
 	d.mirrorHandoff(spec, e.Ref, started)
+	d.blockIfRunSaidSo(spec, e, started)
 	// It opened something, so the ticket is no longer being worked on — it is
 	// waiting on a reviewer, and the board should say so without anyone
 	// dragging it.
@@ -944,4 +954,40 @@ func isolationNote(branch string, trees []string) string {
 	return "\n\nThis run is isolated: every repository already has a worktree on branch `" + branch +
 		"`, created off its current HEAD. Work only in these directories and open the pull requests from this branch; " +
 		"do not create another branch and do not edit the main checkouts:\n- " + strings.Join(trees, "\n- ")
+}
+
+// tripBreaker blocks a ticket after BreakerAfter failed runs in a row. A
+// third try at a wall costs a run and buys nothing; a person looks instead.
+func (d *Daemon) tripBreaker(spec WatchSpec, e watch.Event, lastErr string) {
+	if e.Ref == "" || d.watchState.Fixes.FailedInARow(spec.Workspace, e.Ref) < watch.BreakerAfter {
+		return
+	}
+	reason := fmt.Sprintf("%d runs failed in a row; last: %s", watch.BreakerAfter, clipText(lastErr, 120))
+	d.watchState.Fixes.Block(spec.Workspace, e.Ref, reason, watch.BlockedByBreaker, time.Now())
+	if d.Workpad != nil {
+		go d.Workpad(spec.Workspace, e.Ref, "Blocked", reason+"\n\n`corgi agent watch unblock "+e.Ref+"` once it is fixed.")
+	}
+	go d.notifyAttentionAt("corgi agent · "+spec.Workspace, e.Ref+" is blocked: "+reason, spec.Workspace, e.URL)
+}
+
+// blockIfRunSaidSo honours a run's own handoff: a packet in state blocked
+// or auth-required names a missing tool, credential or secret, and no run
+// can supply that. The reason goes on the ticket for whoever can.
+func (d *Daemon) blockIfRunSaidSo(spec WatchSpec, e watch.Event, started time.Time) {
+	if e.Ref == "" {
+		return
+	}
+	p, err := handoff.Read(spec.Dir, e.Ref)
+	if err != nil || p.WrittenAt.Before(started) || (p.State != handoff.StateBlocked && p.State != handoff.StateAuthRequired) {
+		return
+	}
+	reason := p.Blocked
+	if reason == "" {
+		reason = "the run needs a credential it does not have"
+	}
+	d.watchState.Fixes.Block(spec.Workspace, e.Ref, reason, watch.BlockedByRun, time.Now())
+	if d.Workpad != nil {
+		go d.Workpad(spec.Workspace, e.Ref, "Blocked", reason+"\n\n`corgi agent watch unblock "+e.Ref+"` once it is fixed.")
+	}
+	go d.notifyAttentionAt("corgi agent · "+spec.Workspace, e.Ref+" is blocked: "+reason, spec.Workspace, e.URL)
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -609,7 +610,7 @@ func fixArgsWith(spec WatchSpec, e watch.Event, handover string) []string {
 		prompt += "\n\nAn earlier run on this stopped part-way. This is the last thing it said — " +
 			"treat it as notes, not as truth, and check anything it claims before building on it:\n" + handover
 	}
-	args := []string{"-p", prompt, "--output-format", "text"}
+	args := []string{"-p", prompt, "--output-format", "json"}
 	if spec.SkipPermissions {
 		return append(args, "--dangerously-skip-permissions")
 	}
@@ -700,8 +701,16 @@ func (d *Daemon) runFix(ctx context.Context, spec WatchSpec, e watch.Event) {
 	}
 	cmd := claudeCommand(ctx, spec.Dir, env, args...)
 	cmd.Stdin = nil
-	out, runErr := cmd.Output()
+	raw, runErr := cmd.Output()
+	// json output carries what the run said plus what it cost; the log keeps
+	// the words, the record keeps the numbers. Output that is not the JSON
+	// envelope (an older claude, a crash mid-line) is used as it came.
+	out, receipt := unwrapResult(raw)
 	logFile.Write(out)
+	if receipt.ok {
+		fmt.Fprintf(logFile, "\n=== cost: $%.4f · %d tokens · %d turns\n", receipt.costUSD, receipt.tokens, receipt.turns)
+		d.watchState.Fixes.SetCost(e.Key, receipt.costUSD, receipt.tokens)
+	}
 	if runErr != nil {
 		fmt.Fprintf(logFile, "\n=== failed: %v\n", runErr)
 		d.watchState.Fixes.Finish(e.Key, nil, "", runErr.Error(), time.Now())
@@ -1050,4 +1059,40 @@ func RunLog(agentDir, key string, n int) string {
 		return ""
 	}
 	return watch.TailLines(string(data), n)
+}
+
+// runReceipt is what `claude -p --output-format json` says about a run
+// beyond its words.
+type runReceipt struct {
+	ok      bool
+	costUSD float64
+	tokens  int64
+	turns   int
+}
+
+// unwrapResult takes the JSON envelope apart: the result text for the log
+// and the PR scan, the cost for the record. Anything else passes through.
+func unwrapResult(raw []byte) ([]byte, runReceipt) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return raw, runReceipt{}
+	}
+	var env struct {
+		Type     string  `json:"type"`
+		Result   string  `json:"result"`
+		CostUSD  float64 `json:"total_cost_usd"`
+		NumTurns int     `json:"num_turns"`
+		Usage    struct {
+			Input      int64 `json:"input_tokens"`
+			Output     int64 `json:"output_tokens"`
+			CacheRead  int64 `json:"cache_read_input_tokens"`
+			CacheWrite int64 `json:"cache_creation_input_tokens"`
+		} `json:"usage"`
+	}
+	if json.Unmarshal(trimmed, &env) != nil || env.Type != "result" {
+		return raw, runReceipt{}
+	}
+	u := env.Usage
+	return []byte(env.Result), runReceipt{ok: true, costUSD: env.CostUSD, turns: env.NumTurns,
+		tokens: u.Input + u.Output + u.CacheRead + u.CacheWrite}
 }

--- a/utils/agent/daemon/watch.go
+++ b/utils/agent/daemon/watch.go
@@ -991,3 +991,13 @@ func (d *Daemon) blockIfRunSaidSo(spec WatchSpec, e watch.Event, started time.Ti
 	}
 	go d.notifyAttentionAt("corgi agent · "+spec.Workspace, e.Ref+" is blocked: "+reason, spec.Workspace, e.URL)
 }
+
+// RunLog is the last n lines of a run's log, for a surface that cannot open
+// the file. "" when there is no log.
+func RunLog(agentDir, key string, n int) string {
+	data, err := os.ReadFile(filepath.Join(agentDir, "watch", "runs", safeName(key)+".log"))
+	if err != nil {
+		return ""
+	}
+	return watch.TailLines(string(data), n)
+}

--- a/utils/agent/daemon/watch_handoff_test.go
+++ b/utils/agent/daemon/watch_handoff_test.go
@@ -71,3 +71,32 @@ func TestAnIsolatedRunIsToldWhereToWork(t *testing.T) {
 		t.Fatalf("branch on the record: %+v", got)
 	}
 }
+
+// The run's JSON envelope is taken apart: words to the log and the PR scan,
+// numbers to the record. Output that is not the envelope is used as it came.
+func TestARunsReceiptIsRecorded(t *testing.T) {
+	raw := []byte(`{"type":"result","subtype":"success","result":"opened https://github.com/a/b/pull/9\nall green","total_cost_usd":0.4321,"num_turns":7,"usage":{"input_tokens":1000,"output_tokens":200,"cache_read_input_tokens":30000,"cache_creation_input_tokens":500}}`)
+	out, r := unwrapResult(raw)
+	if !r.ok || r.costUSD != 0.4321 || r.tokens != 31700 || r.turns != 7 {
+		t.Fatalf("receipt: %+v", r)
+	}
+	if !strings.HasPrefix(string(out), "opened https://github.com/a/b/pull/9") {
+		t.Fatalf("words: %s", out)
+	}
+	plain := []byte("just text from an older claude")
+	if out, r := unwrapResult(plain); r.ok || string(out) != string(plain) {
+		t.Fatal("plain output passes through")
+	}
+	dir := t.TempDir()
+	l := watch.LoadFixLog(dir)
+	l.StartFor(watch.Event{Key: "k1", Ref: "ABC-1", Workspace: "api"}, time.Now())
+	l.SetCost("k1", 0.4321, 31700)
+	l.StartFor(watch.Event{Key: "k2", Ref: "ABC-1", Workspace: "api"}, time.Now())
+	l.SetCost("k2", 0.1, 300)
+	l.StartFor(watch.Event{Key: "k3", Ref: "ABC-1", Workspace: "api"}, time.Now())
+	l.Finish("k3", nil, "", "not started: 3/h cap", time.Now())
+	c := watch.LoadFixLog(dir).CostFor("api", "ABC-1")
+	if c.Runs != 2 || c.Tokens != 32000 || c.USD < 0.53 || c.USD > 0.54 {
+		t.Fatalf("cost per ticket adds the runs that ran: %+v", c)
+	}
+}

--- a/utils/agent/daemon/watch_handoff_test.go
+++ b/utils/agent/daemon/watch_handoff_test.go
@@ -117,3 +117,15 @@ func TestTheRunnerPicksAModelByKindAndSteppsUpAfterAFailure(t *testing.T) {
 		t.Fatal("the policy wins")
 	}
 }
+
+func TestAFreshTicketTellsStoriesItsLane(t *testing.T) {
+	if got := fixPrompt(watch.Event{Kind: watch.KindIssueNew, Ref: "ABC-1", Labels: []string{"Bug"}}); !strings.HasSuffix(got, "/corgi:stories ABC-1 --mode bug") {
+		t.Fatalf("bug lane: %s", got)
+	}
+	if got := fixPrompt(watch.Event{Kind: watch.KindIssueNew, Ref: "ABC-2", Labels: []string{"api", "Feature"}}); !strings.HasSuffix(got, "--mode feature") {
+		t.Fatalf("feature lane: %s", got)
+	}
+	if got := fixPrompt(watch.Event{Kind: watch.KindIssueNew, Ref: "ABC-3"}); !strings.HasSuffix(got, "/corgi:stories ABC-3") {
+		t.Fatalf("no label, no mode: %s", got)
+	}
+}

--- a/utils/agent/daemon/watch_handoff_test.go
+++ b/utils/agent/daemon/watch_handoff_test.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/handoff"
+	"andriiklymiuk/corgi/utils/agent/watch"
+)
+
+// A packet an earlier run left is the next run's first input — typed state
+// in the prompt, with its check re-run — and a packet written during a run
+// is what the run leaves behind, instead of six lines of stdout.
+func TestARunReadsAndLeavesAHandoffPacket(t *testing.T) {
+	dir := t.TempDir()
+	spec := WatchSpec{Workspace: "api", Dir: dir}
+	e := watch.Event{Kind: watch.KindIssueNew, Ref: "ABC-9", Title: "rate limits"}
+
+	args := fixArgsWith(spec, e, "last words from stdout")
+	if !strings.Contains(args[1], "last words from stdout") || strings.Contains(args[1], "left a handoff") {
+		t.Fatal("no packet: the stdout tail is all there is")
+	}
+
+	p := handoff.Packet{Ref: "ABC-9", State: handoff.StateInputRequired, Done: []string{"api side"}, Remaining: []string{"web side"}, Next: "web banner"}
+	if err := handoff.Write(dir, p); err != nil {
+		t.Fatal(err)
+	}
+	args = fixArgsWith(spec, e, "last words from stdout")
+	prompt := args[1]
+	if !strings.Contains(prompt, "left a handoff") || !strings.Contains(prompt, "## Remaining") || strings.Contains(prompt, "last words from stdout") {
+		t.Fatalf("the packet replaces the stdout tail:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "recorded no check") {
+		t.Fatal("a packet without a verification says so")
+	}
+	if !strings.Contains(prompt, "corgi agent handoff --ref ABC-9") {
+		t.Fatal("the run is told how to leave one")
+	}
+
+	started := time.Now().Add(-time.Minute)
+	if got := runHandover(dir, "ABC-9", time.Now().Add(time.Minute), "a\nb\nc"); got != "a\nb\nc" {
+		t.Fatalf("a packet older than the run is not its handover: %q", got)
+	}
+	if got := runHandover(dir, "ABC-9", started, "a\nb\nc"); !strings.HasPrefix(got, "handoff: input-required · 1 done · 1 remaining") {
+		t.Fatalf("a packet written during the run is the handover: %q", got)
+	}
+}

--- a/utils/agent/daemon/watch_handoff_test.go
+++ b/utils/agent/daemon/watch_handoff_test.go
@@ -46,3 +46,28 @@ func TestARunReadsAndLeavesAHandoffPacket(t *testing.T) {
 		t.Fatalf("a packet written during the run is the handover: %q", got)
 	}
 }
+
+// With isolate on, a run gets worktrees on a branch named after the ticket
+// and is told to work only there; the branch is on the fix record so undo
+// can release it. Without the callback, nothing changes.
+func TestAnIsolatedRunIsToldWhereToWork(t *testing.T) {
+	if got := FixBranch("acme/api#42"); got != "corgi/acme-api-42" {
+		t.Fatalf("branch: %s", got)
+	}
+	if got := FixBranch("ABC-7"); got != "corgi/abc-7" {
+		t.Fatalf("branch: %s", got)
+	}
+	note := isolationNote("corgi/abc-7", []string{"/w/api", "/w/web"})
+	for _, want := range []string{"corgi/abc-7", "/w/api", "/w/web", "do not create another branch"} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("note lacks %q: %s", want, note)
+		}
+	}
+	dir := t.TempDir()
+	l := watch.LoadFixLog(dir)
+	l.StartFor(watch.Event{Key: "k1", Ref: "ABC-7"}, time.Now())
+	l.SetBranch("k1", "corgi/abc-7")
+	if got := watch.LoadFixLog(dir).RecentFixes("", 1); len(got) != 1 || got[0].Branch != "corgi/abc-7" {
+		t.Fatalf("branch on the record: %+v", got)
+	}
+}

--- a/utils/agent/daemon/watch_handoff_test.go
+++ b/utils/agent/daemon/watch_handoff_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"andriiklymiuk/corgi/utils/agent/config"
 	"andriiklymiuk/corgi/utils/agent/handoff"
 	"andriiklymiuk/corgi/utils/agent/watch"
 )
@@ -98,5 +99,21 @@ func TestARunsReceiptIsRecorded(t *testing.T) {
 	c := watch.LoadFixLog(dir).CostFor("api", "ABC-1")
 	if c.Runs != 2 || c.Tokens != 32000 || c.USD < 0.53 || c.USD > 0.54 {
 		t.Fatalf("cost per ticket adds the runs that ran: %+v", c)
+	}
+}
+
+// A fresh ticket is planned on the strong model, a red build fixed on the
+// cheap one, and a ticket whose last run failed steps up.
+func TestTheRunnerPicksAModelByKindAndSteppsUpAfterAFailure(t *testing.T) {
+	spec := WatchSpec{}
+	if fixModel(spec, watch.Event{Kind: watch.KindIssueNew}, 0) != "opus" || fixModel(spec, watch.Event{Kind: watch.KindCIFailed}, 0) != "sonnet" {
+		t.Fatal("defaults by kind")
+	}
+	if fixModel(spec, watch.Event{Kind: watch.KindCIFailed}, 1) != "opus" {
+		t.Fatal("a failed run steps up")
+	}
+	spec.Models = &config.ModelPolicy{Execute: "haiku", Escalate: "sonnet", Kinds: map[string]string{"ci.failed": "sonnet[1m]"}}
+	if fixModel(spec, watch.Event{Kind: watch.KindCIFailed}, 0) != "sonnet[1m]" || fixModel(spec, watch.Event{Kind: watch.KindPRComment}, 0) != "haiku" || fixModel(spec, watch.Event{Kind: watch.KindPRComment}, 2) != "sonnet" {
+		t.Fatal("the policy wins")
 	}
 }

--- a/utils/agent/daemon/watch_retry_test.go
+++ b/utils/agent/daemon/watch_retry_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"andriiklymiuk/corgi/utils/agent/watch"
+)
+
+// A fix that waited for budget runs when budget returns: the most urgent
+// first, one per round, never a blocked or ignored one, never with --no-retry.
+func TestDeferredFixesComeBackOnTheirOwn(t *testing.T) {
+	d := dynDaemon(t)
+	d.loadWatchFiles()
+	d.fixBusy = map[string]*sync.Mutex{"api": {}}
+	spec := WatchSpec{Workspace: "api", Dir: t.TempDir(), Action: "fix", Interval: time.Minute}
+	now := time.Now()
+	low := watch.Event{Key: "k-low", Ref: "ABC-1", Workspace: "api", Kind: watch.KindIssueNew, At: now.Add(-2 * time.Hour)}
+	urgent := watch.Event{Key: "k-urgent", Ref: "ABC-2", Workspace: "api", Kind: watch.KindIssueNew, Labels: []string{"urgent"}, At: now.Add(-time.Hour)}
+	blocked := watch.Event{Key: "k-blocked", Ref: "ABC-3", Workspace: "api", Kind: watch.KindIssueNew, Labels: []string{"p0"}, At: now}
+	other := watch.Event{Key: "k-other", Ref: "XYZ-1", Workspace: "web", Kind: watch.KindIssueNew, At: now}
+	for _, e := range []watch.Event{low, urgent, blocked, other} {
+		d.watchState.Fixes.Defer(e)
+	}
+	d.watchState.Fixes.Block("api", "ABC-3", "no token", watch.BlockedByPerson, now)
+
+	started := func() []string {
+		var out []string
+		for _, r := range d.watchState.Fixes.RecentFixes("api", 10) {
+			out = append(out, r.Ref)
+		}
+		return out
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the run itself must not go anywhere; only the start matters
+
+	d.retryDeferred(ctx, WatchSpec{Workspace: "api", Dir: spec.Dir, Action: "fix", NoRetry: true}, now)
+	if len(started()) != 0 {
+		t.Fatal("--no-retry leaves them to a manual run")
+	}
+	d.retryDeferred(ctx, WatchSpec{Workspace: "api", Dir: spec.Dir, Action: "notify"}, now)
+	if len(started()) != 0 {
+		t.Fatal("notify never runs anything")
+	}
+	d.retryDeferred(ctx, spec, now)
+	if got := started(); len(got) != 1 || got[0] != "ABC-2" {
+		t.Fatalf("the urgent one first, one per round: %v", got)
+	}
+	if len(d.watchState.Fixes.DeferredEvents()) != 3 {
+		t.Fatal("the started one left the deferred list")
+	}
+	d.runs.Wait()
+	d.releaseFix("api", "ABC-2")
+	d.retryDeferred(ctx, spec, now.Add(time.Minute))
+	if got := started(); len(got) != 2 || got[0] != "ABC-1" {
+		t.Fatalf("then the older normal one, never the blocked one: %v", got)
+	}
+	d.runs.Wait()
+}

--- a/utils/agent/daemon/watch_test.go
+++ b/utils/agent/daemon/watch_test.go
@@ -319,7 +319,7 @@ func TestFixPromptPerKind(t *testing.T) {
 	if args[0] != "-p" || !strings.HasPrefix(args[1], fixPrompt(e)) {
 		t.Fatalf("the kind's own prompt leads: %q", args)
 	}
-	if strings.Join(args[2:], " ") != "--output-format text --permission-mode acceptEdits" {
+	if strings.Join(args[2:], " ") != "--output-format json --permission-mode acceptEdits" {
 		t.Fatalf("flags %q", args[2:])
 	}
 	// Nobody but the run has read this diff, and whoever finds the PR later

--- a/utils/agent/handoff/handoff.go
+++ b/utils/agent/handoff/handoff.go
@@ -123,8 +123,8 @@ func safeRef(ref string) string {
 }
 
 var (
-	secretLike = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd)\s*[:=]\s*['"]?[A-Za-z0-9_\-./+]{8,}`)
-	knownKeys  = regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9]{20,}|glpat-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY`)
+	secretLike  = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd)\s*[:=]\s*['"]?[A-Za-z0-9_\-./+]{8,}`)
+	knownKeys   = regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9]{20,}|glpat-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY`)
 	placeholder = regexp.MustCompile(`\b(TODO|TBD|FIXME|XXX)\b`)
 )
 

--- a/utils/agent/handoff/handoff.go
+++ b/utils/agent/handoff/handoff.go
@@ -1,0 +1,420 @@
+// Package handoff is the typed record one run leaves for the next: what is
+// done, what is not, what was decided, what to ask, and where the code is.
+// Never a transcript. A file beside the workspace that any harness can read,
+// mirrored to the ticket by whoever has a tracker token.
+package handoff
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/atomicfile"
+)
+
+// State is the A2A task state the card is in when the packet is written.
+const (
+	StateWorking       = "working"
+	StateInputRequired = "input-required"
+	StateAuthRequired  = "auth-required"
+	StateCompleted     = "completed"
+	StateFailed        = "failed"
+	StateBlocked       = "blocked"
+)
+
+var states = map[string]bool{StateWorking: true, StateInputRequired: true, StateAuthRequired: true, StateCompleted: true, StateFailed: true, StateBlocked: true}
+
+// Packet is the whole handoff. Lists are short sentences; Next is one.
+type Packet struct {
+	Ref     string `json:"ref"`
+	Tracker string `json:"tracker,omitempty"`
+	State   string `json:"state"`
+	// Blocked is the reason when State is blocked. Only a missing tool,
+	// credential or secret is a reason; "hard" is not.
+	Blocked      string        `json:"blocked,omitempty"`
+	Where        Where         `json:"where"`
+	Done         []string      `json:"done,omitempty"`
+	Remaining    []string      `json:"remaining,omitempty"`
+	Decisions    []string      `json:"decisions,omitempty"`
+	Uncertain    []string      `json:"uncertain,omitempty"`
+	Verification *Verification `json:"verification,omitempty"`
+	Next         string        `json:"next,omitempty"`
+	From         From          `json:"from"`
+	Budget       Budget        `json:"budget"`
+	// Draft marks a packet corgi assembled without the run's own words —
+	// git state and the last line said — so the reader weighs it as such.
+	Draft     bool      `json:"draft,omitempty"`
+	WrittenAt time.Time `json:"writtenAt"`
+}
+
+// Where is the code: branch, worktree, the commits, what is uncommitted.
+type Where struct {
+	Branch   string   `json:"branch,omitempty"`
+	Worktree string   `json:"worktree,omitempty"`
+	Base     string   `json:"base,omitempty"`
+	Head     string   `json:"head,omitempty"`
+	Dirty    []string `json:"dirty,omitempty"`
+}
+
+// Verification is the check that was run, machine-checkable by the next run.
+type Verification struct {
+	Cmd   string    `json:"cmd"`
+	Exit  int       `json:"exit"`
+	At    string    `json:"at,omitempty"` // the head it ran on
+	RanAt time.Time `json:"ranAt,omitempty"`
+}
+
+// From is who wrote it, enough for a same-harness resume.
+type From struct {
+	Harness    string `json:"harness,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Account    string `json:"account,omitempty"`
+	Session    string `json:"session,omitempty"`
+	Transcript string `json:"transcript,omitempty"`
+	Host       string `json:"host,omitempty"`
+}
+
+// Budget is how much room was left when the packet was written.
+type Budget struct {
+	Context  int `json:"context,omitempty"`  // percent of the window used
+	FiveHour int `json:"fiveHour,omitempty"` // percent of the 5h window used
+	SevenDay int `json:"sevenDay,omitempty"`
+}
+
+const (
+	dirName  = "handoffs"
+	maxBytes = 32 << 10
+	maxItem  = 300
+	// MaxAge is how old a packet may be and still be offered to a new session.
+	MaxAge = 7 * 24 * time.Hour
+)
+
+// Dir is where a workspace keeps its packets: per-developer state, under
+// corgi_services, ignored by git.
+func Dir(composeDir string) string {
+	return filepath.Join(utils.CorgiServicesIn(composeDir), dirName)
+}
+
+func Path(composeDir, ref string) string {
+	return filepath.Join(Dir(composeDir), safeRef(ref)+".json")
+}
+
+// MarkdownPath is the twin a person or a harness without a JSON reader opens.
+func MarkdownPath(composeDir, ref string) string {
+	return filepath.Join(Dir(composeDir), safeRef(ref)+".md")
+}
+
+var unsafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+func safeRef(ref string) string {
+	ref = unsafe.ReplaceAllString(strings.TrimSpace(ref), "_")
+	if ref == "" {
+		return "_"
+	}
+	return ref
+}
+
+var (
+	secretLike = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd)\s*[:=]\s*['"]?[A-Za-z0-9_\-./+]{8,}`)
+	knownKeys  = regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9]{20,}|glpat-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY`)
+	placeholder = regexp.MustCompile(`\b(TODO|TBD|FIXME|XXX)\b`)
+)
+
+// Validate refuses what would mislead the next run or leak on the ticket:
+// no ref or state, a secret in any field, a placeholder where a fact
+// should be, an item too long to be a sentence, a packet too big to read.
+func Validate(p Packet) error {
+	if strings.TrimSpace(p.Ref) == "" {
+		return errors.New("a handoff needs a ref: the ticket it is about")
+	}
+	if !states[p.State] {
+		return fmt.Errorf("state %q is not one of working, input-required, auth-required, completed, failed, blocked", p.State)
+	}
+	if p.State == StateBlocked && strings.TrimSpace(p.Blocked) == "" {
+		return errors.New("blocked needs a reason: the missing tool, credential or secret")
+	}
+	for _, list := range [][]string{p.Done, p.Remaining, p.Decisions, p.Uncertain} {
+		for _, item := range list {
+			if len(item) > maxItem {
+				return fmt.Errorf("an item is %d characters; a handoff is sentences, not a transcript", len(item))
+			}
+		}
+	}
+	all := strings.Join(append(append(append(append([]string{p.Next, p.Blocked}, p.Done...), p.Remaining...), p.Decisions...), p.Uncertain...), "\n")
+	if secretLike.MatchString(all) || knownKeys.MatchString(all) {
+		return errors.New("a handoff must not carry a secret; it is mirrored to the ticket")
+	}
+	if !p.Draft && placeholder.MatchString(all) {
+		return errors.New("a handoff must not carry TODO or TBD: say what is remaining instead")
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	if len(data) > maxBytes {
+		return fmt.Errorf("a handoff is %d bytes; keep it under %d", len(data), maxBytes)
+	}
+	return nil
+}
+
+// Write validates, then writes the JSON and its Markdown twin.
+func Write(composeDir string, p Packet) error {
+	if p.WrittenAt.IsZero() {
+		p.WrittenAt = time.Now()
+	}
+	if err := Validate(p); err != nil {
+		return err
+	}
+	dir := Dir(composeDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	utils.EnsureCorgiServicesIgnore(utils.CorgiServicesIn(composeDir), dirName+"/")
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.Write(Path(composeDir, p.Ref), data, 0o600); err != nil {
+		return err
+	}
+	return atomicfile.Write(MarkdownPath(composeDir, p.Ref), []byte(p.Markdown()), 0o600)
+}
+
+// Read is one packet by ref; os.ErrNotExist when there is none.
+func Read(composeDir, ref string) (Packet, error) {
+	var p Packet
+	data, err := os.ReadFile(Path(composeDir, ref))
+	if err != nil {
+		return p, err
+	}
+	if err := json.Unmarshal(data, &p); err != nil {
+		return p, fmt.Errorf("%s: %w", Path(composeDir, ref), err)
+	}
+	return p, nil
+}
+
+// List is every packet in a workspace, newest first.
+func List(composeDir string) []Packet {
+	entries, err := os.ReadDir(Dir(composeDir))
+	if err != nil {
+		return nil
+	}
+	var out []Packet
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(Dir(composeDir), e.Name()))
+		if err != nil {
+			continue
+		}
+		var p Packet
+		if json.Unmarshal(data, &p) == nil && p.Ref != "" {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].WrittenAt.After(out[j].WrittenAt) })
+	return out
+}
+
+// Remove deletes a packet and its twin; nothing to delete is not an error.
+func Remove(composeDir, ref string) error {
+	for _, p := range []string{Path(composeDir, ref), MarkdownPath(composeDir, ref)} {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// ForBranch finds the packet whose branch matches, else the one whose ref
+// the branch name carries.
+func ForBranch(composeDir, branch string) (Packet, bool) {
+	if branch == "" {
+		return Packet{}, false
+	}
+	ref := RefFromBranch(branch)
+	for _, p := range List(composeDir) {
+		if p.Where.Branch == branch || (ref != "" && strings.EqualFold(p.Ref, ref)) {
+			return p, true
+		}
+	}
+	return Packet{}, false
+}
+
+var refInBranch = regexp.MustCompile(`\b([A-Z][A-Z0-9]{1,9}-\d{1,6})\b`)
+
+// RefFromBranch pulls a ticket key out of a branch name — feature/ABC-123/slug,
+// ABC-123-slug, fix/abc-123 — or "".
+func RefFromBranch(branch string) string {
+	if m := refInBranch.FindStringSubmatch(strings.ToUpper(branch)); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// Markdown is the packet for a person, or a harness that reads files.
+func (p Packet) Markdown() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Handoff · %s\n\n", p.Ref)
+	fmt.Fprintf(&b, "state: **%s**", p.State)
+	if p.Blocked != "" {
+		fmt.Fprintf(&b, " — %s", p.Blocked)
+	}
+	if p.Draft {
+		b.WriteString(" _(draft: assembled by corgi, not written by the run)_")
+	}
+	b.WriteString("\n")
+	if p.Tracker != "" {
+		fmt.Fprintf(&b, "ticket: %s\n", p.Tracker)
+	}
+	if p.Where.Branch != "" || p.Where.Head != "" {
+		fmt.Fprintf(&b, "where: `%s`", p.Where.Branch)
+		if p.Where.Worktree != "" {
+			fmt.Fprintf(&b, " in `%s`", p.Where.Worktree)
+		}
+		if p.Where.Head != "" {
+			fmt.Fprintf(&b, " at %s", short(p.Where.Head))
+		}
+		if p.Where.Base != "" {
+			fmt.Fprintf(&b, " (base %s)", short(p.Where.Base))
+		}
+		b.WriteString("\n")
+		if len(p.Where.Dirty) > 0 {
+			fmt.Fprintf(&b, "uncommitted: %s\n", strings.Join(p.Where.Dirty, ", "))
+		}
+	}
+	section := func(name string, items []string) {
+		if len(items) == 0 {
+			return
+		}
+		fmt.Fprintf(&b, "\n## %s\n", name)
+		for _, it := range items {
+			fmt.Fprintf(&b, "- %s\n", it)
+		}
+	}
+	section("Done", p.Done)
+	section("Remaining", p.Remaining)
+	section("Decisions", p.Decisions)
+	section("Uncertain — ask before assuming", p.Uncertain)
+	if p.Verification != nil {
+		fmt.Fprintf(&b, "\n## Verified\n`%s` → exit %d", p.Verification.Cmd, p.Verification.Exit)
+		if p.Verification.At != "" {
+			fmt.Fprintf(&b, " at %s", short(p.Verification.At))
+		}
+		b.WriteString("\n")
+	}
+	if p.Next != "" {
+		fmt.Fprintf(&b, "\n## Next\n%s\n", p.Next)
+	}
+	var from []string
+	for _, kv := range [][2]string{{"harness", p.From.Harness}, {"model", p.From.Model}, {"account", p.From.Account}, {"session", p.From.Session}, {"host", p.From.Host}} {
+		if kv[1] != "" {
+			from = append(from, kv[0]+" "+kv[1])
+		}
+	}
+	if len(from) > 0 {
+		fmt.Fprintf(&b, "\nfrom: %s\n", strings.Join(from, " · "))
+	}
+	if p.Budget.Context > 0 || p.Budget.FiveHour > 0 {
+		fmt.Fprintf(&b, "budget when written: context %d%% · 5h %d%% · week %d%%\n", p.Budget.Context, p.Budget.FiveHour, p.Budget.SevenDay)
+	}
+	if !p.WrittenAt.IsZero() {
+		fmt.Fprintf(&b, "written: %s\n", p.WrittenAt.Local().Format("2006-01-02 15:04"))
+	}
+	return b.String()
+}
+
+// Summary is one line for a board row or a ticket comment.
+func (p Packet) Summary() string {
+	parts := []string{p.State}
+	if n := len(p.Done); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d done", n))
+	}
+	if n := len(p.Remaining); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d remaining", n))
+	}
+	if p.Next != "" {
+		parts = append(parts, "next: "+p.Next)
+	}
+	return strings.Join(parts, " · ")
+}
+
+func short(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
+// run is a seam for git in tests.
+var run = func(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// GitWhere reads branch, head, base (merge-base with the default branch,
+// best effort) and dirty files from a checkout.
+func GitWhere(dir string) Where {
+	w := Where{}
+	if dir == "" {
+		return w
+	}
+	w.Branch, _ = run(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	w.Head, _ = run(dir, "rev-parse", "HEAD")
+	for _, base := range []string{"origin/main", "origin/master", "main", "master"} {
+		if b, err := run(dir, "merge-base", "HEAD", base); err == nil && b != "" && b != w.Head {
+			w.Base = b
+			break
+		}
+	}
+	if status, err := run(dir, "status", "--porcelain"); err == nil && status != "" {
+		for _, line := range strings.Split(status, "\n") {
+			if len(line) > 3 {
+				w.Dirty = append(w.Dirty, strings.TrimSpace(line[3:]))
+			}
+		}
+	}
+	return w
+}
+
+// CommitsSince is how far the branch moved since the packet: commits after
+// its head. The staleness that matters is measured in commits, not hours.
+func CommitsSince(dir, head string) (int, error) {
+	if head == "" {
+		return 0, errors.New("the packet has no head")
+	}
+	out, err := run(dir, "rev-list", "--count", head+"..HEAD")
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	_, err = fmt.Sscanf(out, "%d", &n)
+	return n, err
+}
+
+// Verify re-runs the packet's check at the current head. exit 0 and the same
+// head means the packet can be trusted as written; anything else means the
+// next run starts from the ticket and the diff, not the packet.
+func Verify(dir string, p Packet, runCmd func(dir, cmd string) (int, error)) (Verification, bool) {
+	if p.Verification == nil || strings.TrimSpace(p.Verification.Cmd) == "" {
+		return Verification{}, false
+	}
+	head, _ := run(dir, "rev-parse", "HEAD")
+	code, err := runCmd(dir, p.Verification.Cmd)
+	if err != nil && code == 0 {
+		code = 1
+	}
+	v := Verification{Cmd: p.Verification.Cmd, Exit: code, At: head, RanAt: time.Now()}
+	return v, code == 0 && (p.Verification.At == "" || p.Verification.At == head)
+}

--- a/utils/agent/handoff/handoff_test.go
+++ b/utils/agent/handoff/handoff_test.go
@@ -1,0 +1,156 @@
+package handoff
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sample() Packet {
+	return Packet{
+		Ref: "ABC-123", Tracker: "https://linear.app/x/issue/ABC-123", State: StateInputRequired,
+		Where:     Where{Branch: "feature/ABC-123/rate-limit", Head: "e77d10c0000", Base: "9f1c2ab0000", Dirty: nil},
+		Done:      []string{"POST /limits returns 429 with Retry-After", "regression test in api/limits_test.go"},
+		Remaining: []string{"web: banner on 429"},
+		Decisions: []string{"5h sliding window, not fixed"},
+		Uncertain: []string{"should the phone retry on its own?"},
+		Verification: &Verification{Cmd: "corgi test --changed", Exit: 0, At: "e77d10c0000"},
+		Next:      "web banner, then open the web PR",
+		From:      From{Harness: "claude", Model: "opus", Account: "work", Session: "b2d4"},
+		Budget:    Budget{Context: 62, FiveHour: 91, SevenDay: 58},
+	}
+}
+
+// The packet is a file beside the workspace, ignored by git, with a
+// Markdown twin; it round-trips, and the next session finds it by branch.
+func TestAPacketIsWrittenReadAndFoundByBranch(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, sample()); err != nil {
+		t.Fatal(err)
+	}
+	p, err := Read(dir, "ABC-123")
+	if err != nil || p.Next != "web banner, then open the web PR" || p.WrittenAt.IsZero() {
+		t.Fatalf("read back: %+v %v", p, err)
+	}
+	md, err := os.ReadFile(MarkdownPath(dir, "ABC-123"))
+	if err != nil || !strings.Contains(string(md), "## Remaining") || !strings.Contains(string(md), "exit 0") {
+		t.Fatalf("markdown twin: %s %v", md, err)
+	}
+	ignore, _ := os.ReadFile(filepath.Join(dir, ".corgi", "corgi_services", ".gitignore"))
+	if !strings.Contains(string(ignore), "handoffs/") {
+		t.Fatalf("packets are per-developer state, so they must be ignored: %s", ignore)
+	}
+	if got, ok := ForBranch(dir, "feature/ABC-123/rate-limit"); !ok || got.Ref != "ABC-123" {
+		t.Fatal("found by branch")
+	}
+	if got, ok := ForBranch(dir, "fix/abc-123-typo"); !ok || got.Ref != "ABC-123" {
+		t.Fatal("found by the ref in a different branch name")
+	}
+	if _, ok := ForBranch(dir, "main"); ok {
+		t.Fatal("main has no packet")
+	}
+	if err := Remove(dir, "ABC-123"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(dir, "ABC-123"); !os.IsNotExist(err) {
+		t.Fatal("removed")
+	}
+}
+
+// What must not reach the ticket, or mislead the next run.
+func TestValidationRefusesSecretsPlaceholdersAndNoise(t *testing.T) {
+	p := sample()
+	p.Decisions = append(p.Decisions, "used LINEAR_API_KEY=lin_api_0123456789abcdef for the calls")
+	if err := Validate(p); err == nil || !strings.Contains(err.Error(), "secret") {
+		t.Fatalf("a secret in a decision: %v", err)
+	}
+	p = sample()
+	p.Remaining = []string{"TODO figure out the rest"}
+	if err := Validate(p); err == nil || !strings.Contains(err.Error(), "TODO") {
+		t.Fatalf("a placeholder: %v", err)
+	}
+	p.Draft = true
+	if err := Validate(p); err != nil {
+		t.Fatalf("a draft corgi assembled may say so: %v", err)
+	}
+	p = sample()
+	p.Done = []string{strings.Repeat("x", 400)}
+	if err := Validate(p); err == nil {
+		t.Fatal("an item that long is a transcript")
+	}
+	p = sample()
+	p.State = StateBlocked
+	if err := Validate(p); err == nil {
+		t.Fatal("blocked needs a reason")
+	}
+	p.Blocked = "no GITHUB_TOKEN for the web repo"
+	if err := Validate(p); err != nil {
+		t.Fatal(err)
+	}
+	p = sample()
+	p.State = "stuck"
+	if err := Validate(p); err == nil {
+		t.Fatal("state is an enum")
+	}
+}
+
+func TestRefFromBranch(t *testing.T) {
+	for branch, want := range map[string]string{
+		"feature/ABC-123/rate-limit": "ABC-123",
+		"abc-12-slug":                "ABC-12",
+		"fix/IMP-13427":              "IMP-13427",
+		"main":                       "",
+		"feature/no-ticket":          "",
+	} {
+		if got := RefFromBranch(branch); got != want {
+			t.Errorf("%s: %q, want %q", branch, got, want)
+		}
+	}
+}
+
+// Staleness is commits since the packet's head; verification re-runs the
+// packet's own command at the current head.
+func TestCommitsSinceAndVerifyUseGit(t *testing.T) {
+	orig := run
+	defer func() { run = orig }()
+	calls := map[string]string{"rev-list": "3", "rev-parse": "e77d10c0000"}
+	run = func(dir string, args ...string) (string, error) { return calls[args[0]], nil }
+
+	if n, err := CommitsSince("/x", "abc"); err != nil || n != 3 {
+		t.Fatalf("commits since: %d %v", n, err)
+	}
+	p := sample()
+	ran := ""
+	v, ok := Verify("/x", p, func(dir, cmd string) (int, error) { ran = cmd; return 0, nil })
+	if !ok || ran != "corgi test --changed" || v.At != "e77d10c0000" {
+		t.Fatalf("verified at head: %+v %v", v, ok)
+	}
+	calls["rev-parse"] = "ffff0000000"
+	if _, ok := Verify("/x", p, func(dir, cmd string) (int, error) { return 0, nil }); ok {
+		t.Fatal("a different head is not the packet's verification")
+	}
+	calls["rev-parse"] = "e77d10c0000"
+	if v, ok := Verify("/x", p, func(dir, cmd string) (int, error) { return 2, nil }); ok || v.Exit != 2 {
+		t.Fatal("a failing check is not verified")
+	}
+	p.Verification = nil
+	if _, ok := Verify("/x", p, nil); ok {
+		t.Fatal("no command, nothing verified")
+	}
+}
+
+func TestSummaryAndMarkdownSayTheState(t *testing.T) {
+	p := sample()
+	p.WrittenAt = time.Now()
+	if s := p.Summary(); !strings.HasPrefix(s, "input-required · 2 done · 1 remaining · next: web banner") {
+		t.Fatalf("summary: %s", s)
+	}
+	md := p.Markdown()
+	for _, want := range []string{"# Handoff · ABC-123", "state: **input-required**", "feature/ABC-123/rate-limit", "e77d10c", "## Decisions", "ask before assuming", "context 62%"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown lacks %q:\n%s", want, md)
+		}
+	}
+}

--- a/utils/agent/handoff/handoff_test.go
+++ b/utils/agent/handoff/handoff_test.go
@@ -11,15 +11,15 @@ import (
 func sample() Packet {
 	return Packet{
 		Ref: "ABC-123", Tracker: "https://linear.app/x/issue/ABC-123", State: StateInputRequired,
-		Where:     Where{Branch: "feature/ABC-123/rate-limit", Head: "e77d10c0000", Base: "9f1c2ab0000", Dirty: nil},
-		Done:      []string{"POST /limits returns 429 with Retry-After", "regression test in api/limits_test.go"},
-		Remaining: []string{"web: banner on 429"},
-		Decisions: []string{"5h sliding window, not fixed"},
-		Uncertain: []string{"should the phone retry on its own?"},
+		Where:        Where{Branch: "feature/ABC-123/rate-limit", Head: "e77d10c0000", Base: "9f1c2ab0000", Dirty: nil},
+		Done:         []string{"POST /limits returns 429 with Retry-After", "regression test in api/limits_test.go"},
+		Remaining:    []string{"web: banner on 429"},
+		Decisions:    []string{"5h sliding window, not fixed"},
+		Uncertain:    []string{"should the phone retry on its own?"},
 		Verification: &Verification{Cmd: "corgi test --changed", Exit: 0, At: "e77d10c0000"},
-		Next:      "web banner, then open the web PR",
-		From:      From{Harness: "claude", Model: "opus", Account: "work", Session: "b2d4"},
-		Budget:    Budget{Context: 62, FiveHour: 91, SevenDay: 58},
+		Next:         "web banner, then open the web PR",
+		From:         From{Harness: "claude", Model: "opus", Account: "work", Session: "b2d4"},
+		Budget:       Budget{Context: 62, FiveHour: 91, SevenDay: 58},
 	}
 }
 

--- a/utils/agent/scope/scope.go
+++ b/utils/agent/scope/scope.go
@@ -1,0 +1,211 @@
+// Package scope is the contract a run works inside: which paths it may
+// change, how many lines and new test files the change should stay under,
+// and what done means. Written by the stories skill after the spec is
+// agreed, enforced by hooks while the session runs, so a change that grows
+// past the agreement is stopped where it happens, not found at review.
+package scope
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"andriiklymiuk/corgi/utils"
+	"andriiklymiuk/corgi/utils/atomicfile"
+)
+
+// Scope is one ticket's contract.
+type Scope struct {
+	Ref string `json:"ref"`
+	// Paths are globs relative to the workspace; ** crosses directories.
+	// Empty means anywhere: the budgets still apply.
+	Paths []string `json:"paths,omitempty"`
+	// Lines is the diff budget (added + removed) and Tests the number of
+	// new test files the change should stay under; zero means no budget.
+	Lines int `json:"lines,omitempty"`
+	Tests int `json:"tests,omitempty"`
+	// Done is what finished means, one line each.
+	Done      []string   `json:"done,omitempty"`
+	SetAt     time.Time  `json:"setAt"`
+	Widenings []Widening `json:"widenings,omitempty"`
+}
+
+// Widening is a path the run added to its own scope, on the record.
+type Widening struct {
+	Path string    `json:"path"`
+	By   string    `json:"by,omitempty"`
+	At   time.Time `json:"at"`
+}
+
+const dirName = "scope"
+
+func Dir(composeDir string) string {
+	return filepath.Join(utils.CorgiServicesIn(composeDir), dirName)
+}
+
+var unsafe = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+func Path(composeDir, ref string) string {
+	return filepath.Join(Dir(composeDir), unsafe.ReplaceAllString(strings.TrimSpace(ref), "_")+".json")
+}
+
+func Write(composeDir string, s Scope) error {
+	if strings.TrimSpace(s.Ref) == "" {
+		return errors.New("a scope needs a ref")
+	}
+	if s.SetAt.IsZero() {
+		s.SetAt = time.Now()
+	}
+	if err := os.MkdirAll(Dir(composeDir), 0o755); err != nil {
+		return err
+	}
+	utils.EnsureCorgiServicesIgnore(utils.CorgiServicesIn(composeDir), dirName+"/")
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicfile.Write(Path(composeDir, s.Ref), data, 0o600)
+}
+
+func Read(composeDir, ref string) (Scope, error) {
+	var s Scope
+	data, err := os.ReadFile(Path(composeDir, ref))
+	if err != nil {
+		return s, err
+	}
+	return s, json.Unmarshal(data, &s)
+}
+
+func Remove(composeDir, ref string) error {
+	err := os.Remove(Path(composeDir, ref))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func List(composeDir string) []Scope {
+	entries, err := os.ReadDir(Dir(composeDir))
+	if err != nil {
+		return nil
+	}
+	var out []Scope
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(Dir(composeDir), e.Name()))
+		if err != nil {
+			continue
+		}
+		var s Scope
+		if json.Unmarshal(data, &s) == nil && s.Ref != "" {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SetAt.After(out[j].SetAt) })
+	return out
+}
+
+var refInBranch = regexp.MustCompile(`\b([A-Z][A-Z0-9]{1,9}-\d{1,6})\b`)
+
+// ForBranch is the scope for the ticket a branch names, if any.
+func ForBranch(composeDir, branch string) (Scope, bool) {
+	m := refInBranch.FindStringSubmatch(strings.ToUpper(branch))
+	if m == nil {
+		return Scope{}, false
+	}
+	s, err := Read(composeDir, m[1])
+	return s, err == nil
+}
+
+// Widen adds a path to the scope, on the record.
+func Widen(composeDir, ref, glob, by string) (Scope, error) {
+	s, err := Read(composeDir, ref)
+	if err != nil {
+		return s, err
+	}
+	glob = strings.TrimSpace(glob)
+	if glob == "" {
+		return s, errors.New("a path is required")
+	}
+	s.Paths = append(s.Paths, glob)
+	s.Widenings = append(s.Widenings, Widening{Path: glob, By: by, At: time.Now()})
+	return s, Write(composeDir, s)
+}
+
+// Allows says whether a workspace-relative path is inside the scope. No
+// paths means everywhere is.
+func (s Scope) Allows(rel string) bool {
+	if len(s.Paths) == 0 {
+		return true
+	}
+	rel = filepath.ToSlash(strings.TrimPrefix(rel, "./"))
+	for _, p := range s.Paths {
+		if Match(p, rel) {
+			return true
+		}
+	}
+	return false
+}
+
+// Match is a glob with ** for any number of directories, * for a segment
+// and ? for a character. A pattern naming a directory covers what is in it.
+func Match(pattern, rel string) bool {
+	pattern = filepath.ToSlash(strings.TrimPrefix(strings.TrimSpace(pattern), "./"))
+	if pattern == "" {
+		return false
+	}
+	if !strings.ContainsAny(pattern, "*?[") {
+		return rel == pattern || strings.HasPrefix(rel, strings.TrimSuffix(pattern, "/")+"/")
+	}
+	return globRegexp(pattern).MatchString(rel)
+}
+
+func globRegexp(pattern string) *regexp.Regexp {
+	var b strings.Builder
+	b.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch {
+		case c == '*' && i+1 < len(pattern) && pattern[i+1] == '*':
+			// ** then an optional slash: any depth, including none
+			if i+2 < len(pattern) && pattern[i+2] == '/' {
+				b.WriteString("(?:.*/)?")
+				i += 2
+			} else {
+				b.WriteString(".*")
+				i++
+			}
+		case c == '*':
+			b.WriteString("[^/]*")
+		case c == '?':
+			b.WriteString("[^/]")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(c)))
+		}
+	}
+	b.WriteString("$")
+	return regexp.MustCompile(b.String())
+}
+
+// IsTestFile says whether a path looks like a test, across the stacks a
+// corgi workspace mixes.
+func IsTestFile(rel string) bool {
+	base := strings.ToLower(filepath.Base(rel))
+	dir := strings.ToLower(filepath.ToSlash(filepath.Dir(rel)))
+	switch {
+	case strings.HasSuffix(base, "_test.go"), strings.HasSuffix(base, "_test.py"), strings.HasPrefix(base, "test_"):
+		return true
+	case strings.Contains(base, ".test."), strings.Contains(base, ".spec."):
+		return true
+	case strings.Contains(dir, "__tests__"), strings.HasSuffix(dir, "/tests"), strings.HasSuffix(dir, "/test"), strings.HasSuffix(dir, "/spec"), dir == "tests", dir == "test", dir == "spec":
+		return true
+	}
+	return false
+}

--- a/utils/agent/scope/scope_test.go
+++ b/utils/agent/scope/scope_test.go
@@ -1,0 +1,68 @@
+package scope
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScopeRoundTripsAndMatches(t *testing.T) {
+	dir := t.TempDir()
+	s := Scope{Ref: "ABC-1", Paths: []string{"api/limits/**", "web/src/limits/*.tsx", "docs/limits.md", "shared/"}, Lines: 400, Tests: 2, Done: []string{"429 with Retry-After"}}
+	if err := Write(dir, s); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Read(dir, "ABC-1")
+	if err != nil || got.Lines != 400 || len(got.Paths) != 4 {
+		t.Fatalf("read back: %+v %v", got, err)
+	}
+	ignore, _ := os.ReadFile(filepath.Join(dir, ".corgi", "corgi_services", ".gitignore"))
+	if !strings.Contains(string(ignore), "scope/") {
+		t.Fatal("scope is per-developer state")
+	}
+	for rel, want := range map[string]bool{
+		"api/limits/handler.go":     true,
+		"api/limits/deep/inner.go":  true,
+		"api/other.go":              false,
+		"web/src/limits/Banner.tsx": true,
+		"web/src/limits/x/Deep.tsx": false,
+		"docs/limits.md":            true,
+		"docs/other.md":             false,
+		"shared/types.ts":           true,
+		"web/package.json":          false,
+	} {
+		if got.Allows(rel) != want {
+			t.Errorf("%s: allowed=%v, want %v", rel, got.Allows(rel), want)
+		}
+	}
+	if _, ok := ForBranch(dir, "feature/abc-1/limits"); !ok {
+		t.Fatal("found by branch")
+	}
+	if s, err := Widen(dir, "ABC-1", "web/package.json", "run"); err != nil || !s.Allows("web/package.json") || len(s.Widenings) != 1 {
+		t.Fatalf("widen: %+v %v", s, err)
+	}
+	if (Scope{}).Allows("anything/at/all.go") != true {
+		t.Fatal("no paths means anywhere")
+	}
+	if err := Remove(dir, "ABC-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTestFilesAreRecognisedAcrossStacks(t *testing.T) {
+	for rel, want := range map[string]bool{
+		"api/limits_test.go":       true,
+		"web/src/Banner.test.tsx":  true,
+		"web/src/__tests__/x.ts":   true,
+		"svc/tests/test_limits.py": true,
+		"svc/spec/limits_spec.rb":  true,
+		"api/limits.go":            false,
+		"web/src/Banner.tsx":       false,
+		"docs/testing.md":          false,
+	} {
+		if IsTestFile(rel) != want {
+			t.Errorf("%s: %v, want %v", rel, IsTestFile(rel), want)
+		}
+	}
+}

--- a/utils/agent/sessions/registry.go
+++ b/utils/agent/sessions/registry.go
@@ -126,6 +126,8 @@ type Slot struct {
 	// will continue it on its own, so the key can say "continues 14:02".
 	Limit    LimitKind `json:"limit,omitempty"`
 	ResumeAt time.Time `json:"resumeAt,omitempty"`
+	// Drift is the first reason the daemon thinks a person should look.
+	Drift string `json:"drift,omitempty"`
 }
 
 // New returns a registry persisted at path, with a board of size keys.
@@ -288,6 +290,15 @@ func (r *Registry) transition(s *Session, ev Event, now time.Time) {
 		if strings.HasPrefix(s.Detail, ev.Tool) || s.Status == StatusNeedsInput {
 			s.Detail = ""
 		}
+		subject := ev.Tool + " " + ev.Subject
+		if ev.Name == "PostToolUseFailure" && subject == s.failSubject {
+			s.FailStreak++
+		} else if ev.Name == "PostToolUseFailure" {
+			s.FailStreak, s.failSubject = 1, subject
+		} else if subject == s.failSubject {
+			// The same thing succeeded: whatever was looping is over.
+			s.FailStreak, s.failSubject = 0, ""
+		}
 		r.setStatus(s, StatusWorking, now)
 	case "PermissionRequest":
 		s.Tool = ev.Tool
@@ -298,6 +309,7 @@ func (r *Registry) transition(s *Session, ev Event, now time.Time) {
 		r.applyNotification(s, ev, now)
 	case "Stop":
 		s.Tool, s.Detail, s.Pending = "", "", nil
+		s.FailStreak, s.failSubject = 0, ""
 		r.setStatus(s, StatusDone, now)
 	case "StopFailure":
 		s.Tool, s.Pending = "", nil
@@ -868,6 +880,24 @@ func (r *Registry) SetNote(ref, note string) error {
 	return nil
 }
 
+// SetDrift records what the daemon concluded about a session; true when
+// the reasons changed, and whether drift just began (worth one notice).
+func (r *Registry) SetDrift(id string, reasons []string) (changed, began bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.sessions[id]
+	if !ok {
+		return false, false
+	}
+	if strings.Join(s.Drift, "|") == strings.Join(reasons, "|") {
+		return false, false
+	}
+	began = len(s.Drift) == 0 && len(reasons) > 0
+	s.Drift = reasons
+	r.touch()
+	return true, began
+}
+
 // PlanResume records when the daemon will continue a limited session; a
 // zero time clears the plan. Nothing else changes, so no transition fires.
 func (r *Registry) PlanResume(id string, at time.Time) bool {
@@ -1268,6 +1298,9 @@ func (r *Registry) snapshotLocked(now time.Time) State {
 		sl.Detail, sl.Host, sl.FocusError, sl.FocusAt = s.Detail, s.Host.Kind, s.FocusError, s.FocusAt
 		sl.Note, sl.Stuck = s.Note, s.Stuck
 		sl.Limit, sl.ResumeAt = s.Limit, s.ResumeAt
+		if len(s.Drift) > 0 {
+			sl.Drift = s.Drift[0]
+		}
 		sl.Branch, sl.Summary, sl.PR = s.Branch, s.Summary, s.PR
 		if s.Status == StatusWorking && !s.TurnStartedAt.IsZero() && now.After(s.TurnStartedAt) {
 			sl.TurnS = int(now.Sub(s.TurnStartedAt).Seconds())

--- a/utils/agent/sessions/session.go
+++ b/utils/agent/sessions/session.go
@@ -259,6 +259,13 @@ type Session struct {
 	Limit    LimitKind `json:"limit,omitempty"`
 	ResumeAt time.Time `json:"resumeAt,omitempty"`
 	Resumes  int       `json:"resumes,omitempty"`
+	// FailStreak counts the same tool failing on the same subject in a row
+	// — a test that keeps going red, a command that keeps refusing. Drift is
+	// what the daemon concluded from that, the context fill and the diff:
+	// reasons a person should look, empty when there are none.
+	FailStreak  int `json:"failStreak,omitempty"`
+	failSubject string
+	Drift       []string `json:"drift,omitempty"`
 }
 
 // Pending is one permission prompt: the tool and the safe word about its

--- a/utils/agent/usage/usage.go
+++ b/utils/agent/usage/usage.go
@@ -129,3 +129,36 @@ func (u rawUsage) totals() Totals {
 		Turns: 1,
 	}
 }
+
+// ProjectDirName is how Claude Code names a project directory under
+// projects/: the path with every separator and dot turned into a dash.
+func ProjectDirName(dir string) string {
+	return strings.NewReplacer("/", "-", ".", "-", "\\", "-", ":", "-").Replace(dir)
+}
+
+// TranscriptPath is one session's transcript under an account.
+func TranscriptPath(configDir, cwd, sessionID string) string {
+	base := configDir
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".claude")
+	}
+	return filepath.Join(base, "projects", ProjectDirName(cwd), sessionID+".jsonl")
+}
+
+// ForSession is everything one session has spent, all time. ok is false
+// when there is no transcript to read.
+func ForSession(configDir, cwd, sessionID string) (Totals, bool) {
+	path := TranscriptPath(configDir, cwd, sessionID)
+	if path == "" {
+		return Totals{}, false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return Totals{}, false
+	}
+	_, all := sumFile(path, time.Time{}, time.Time{})
+	return all, true
+}

--- a/utils/agent/watch/duplicates_test.go
+++ b/utils/agent/watch/duplicates_test.go
@@ -288,3 +288,46 @@ func TestOldIgnoredListMovesOutOfStateJSON(t *testing.T) {
 		t.Fatal("the move lost the ignore")
 	}
 }
+
+// Two failed runs in a row on one ticket trip the breaker; a person
+// unblocks, and the runs before that no longer count toward the next trip.
+func TestTheBreakerCountsFailuresPerTicket(t *testing.T) {
+	dir := t.TempDir()
+	l := LoadFixLog(dir)
+	now := time.Now()
+	e := Event{Key: "k1", Ref: "ABC-1", Workspace: "api"}
+	l.StartFor(e, now)
+	l.Finish("k1", nil, "", "build failed", now)
+	if l.FailedInARow("api", "ABC-1") != 1 {
+		t.Fatal("one failure")
+	}
+	l.StartFor(Event{Key: "k1b", Ref: "ABC-1", Workspace: "api"}, now)
+	l.Finish("k1b", nil, "", "not started: 3/h cap", now)
+	if l.FailedInARow("api", "ABC-1") != 1 {
+		t.Fatal("a run that did not start is not a failure")
+	}
+	l.StartFor(Event{Key: "k1c", Ref: "ABC-1", Workspace: "api"}, now)
+	l.Finish("k1c", nil, "", "tests red", now)
+	if l.FailedInARow("api", "ABC-1") != BreakerAfter {
+		t.Fatalf("two: %d", l.FailedInARow("api", "ABC-1"))
+	}
+	if l.FailedInARow("api", "ABC-2") != 0 {
+		t.Fatal("another ticket is untouched")
+	}
+	l.Block("api", "ABC-1", "tests red", BlockedByBreaker, now)
+	if b, ok := LoadFixLog(dir).Blocked("api", "ABC-1"); !ok || b.By != BlockedByBreaker || b.Reason != "tests red" {
+		t.Fatalf("blocked survives a restart: %+v %v", b, ok)
+	}
+	if !LoadFixLog(dir).Unblock("api", "ABC-1") {
+		t.Fatal("unblocked")
+	}
+	l = LoadFixLog(dir)
+	if _, ok := l.Blocked("api", "ABC-1"); ok || l.FailedInARow("api", "ABC-1") != 0 {
+		t.Fatal("an unblock forgives the runs before it")
+	}
+	l.StartFor(Event{Key: "k1d", Ref: "ABC-1", Workspace: "api"}, now)
+	l.Finish("k1d", []string{"https://github.com/a/b/pull/1"}, "", "", now)
+	if l.FailedInARow("api", "ABC-1") != 0 {
+		t.Fatal("a run that opened a PR clears the count")
+	}
+}

--- a/utils/agent/watch/lease_test.go
+++ b/utils/agent/watch/lease_test.go
@@ -2,6 +2,8 @@ package watch
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -58,6 +60,8 @@ func TestHeldByIgnoresMyOwnAndExpiredClaims(t *testing.T) {
 
 // leaseTracker is a tracker two machines can both post to, so the race can
 // actually be run rather than reasoned about.
+var errNoSuchComment = errors.New("no such comment")
+
 type leaseTracker struct {
 	mu       sync.Mutex
 	comments []Comment
@@ -72,8 +76,19 @@ func (f *leaseTracker) Assign(context.Context, string, string) error { return ni
 func (f *leaseTracker) Comment(_ context.Context, _, body string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.comments = append(f.comments, Comment{Body: body})
+	f.comments = append(f.comments, Comment{ID: fmt.Sprint(len(f.comments) + 1), Body: body})
 	return nil
+}
+func (f *leaseTracker) UpdateComment(_ context.Context, _, id, body string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.comments {
+		if f.comments[i].ID == id {
+			f.comments[i].Body = body
+			return nil
+		}
+	}
+	return errNoSuchComment
 }
 func (f *leaseTracker) RecentComments(context.Context, string, int) ([]Comment, error) {
 	f.mu.Lock()

--- a/utils/agent/watch/priority.go
+++ b/utils/agent/watch/priority.go
@@ -1,0 +1,47 @@
+package watch
+
+import "strings"
+
+// Priority is how urgent a ticket says it is, from its labels: the words
+// trackers and teams actually use. 0 is urgent, 1 high, 2 everything else.
+// Used to order the inbox and to pick which deferred fix runs first.
+func Priority(e Event) int {
+	for _, l := range e.Labels {
+		switch strings.ToLower(strings.TrimSpace(l)) {
+		case "urgent", "p0", "p1", "critical", "blocker", "highest", "sev1", "sev-1", "priority: urgent", "priority: highest":
+			return 0
+		case "high", "p2", "important", "priority: high", "sev2", "sev-2":
+			return 1
+		}
+	}
+	return 2
+}
+
+// KindRank orders kinds by who is waiting: a review someone asked for
+// outranks a red build outranks a reply on your own PR outranks a fresh
+// ticket, which blocks nobody yet.
+func KindRank(kind Kind) int {
+	switch kind {
+	case KindReviewRequested:
+		return 0
+	case KindCIFailed:
+		return 1
+	case KindPRReview, KindPRComment:
+		return 2
+	case KindIssueComment:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// Less orders two events for a queue: priority, then kind, then age.
+func Less(a, b Event) bool {
+	if pa, pb := Priority(a), Priority(b); pa != pb {
+		return pa < pb
+	}
+	if ra, rb := KindRank(a.Kind), KindRank(b.Kind); ra != rb {
+		return ra < rb
+	}
+	return a.At.Before(b.At)
+}

--- a/utils/agent/watch/routine.go
+++ b/utils/agent/watch/routine.go
@@ -1,0 +1,151 @@
+package watch
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// A routine is a run the daemon starts on a clock rather than on an event:
+// the morning digest, the PR babysitter, the dependency triage, the release
+// notes. Each is one prompt to `claude -p` with the caps, the quiet hours,
+// the budget and the log every unattended run has, and its report is one
+// row in the inbox.
+
+// KindRoutine is the inbox kind for a routine's report.
+const KindRoutine Kind = "routine"
+
+// RoutineKind is one entry of the catalog.
+type RoutineKind struct {
+	Name    string
+	What    string
+	Prompt  string
+	Default string // the schedule it makes sense on
+}
+
+// Catalog is what `corgi agent routine add <kind>` knows how to run.
+var Catalog = []RoutineKind{
+	{Name: "digest", What: "what happened here since yesterday, in five bullets", Default: "daily 08:30",
+		Prompt: "Write the morning digest for this workspace: pull requests opened, merged or gone red since yesterday, tickets that moved, anything stalled more than two days. Use gh/glab and the tracker MCP tools; read, do not change. At most five bullets, each one line, the most important first. Summarise, do not itemise. Start your answer with a one-line headline."},
+	{Name: "babysit-pr", What: "keep my open pull requests moving: CI, reviews, at most three rounds", Default: "every 2h",
+		Prompt: "For every open pull request of mine in this stack: check CI and the review comments. Fix what is real on the branch and push (at most three rounds per PR), reply to and dismiss what is not with one sentence saying why, and list what needs a person. Never merge, never force-push, never flip a draft to ready. Start your answer with a one-line headline: how many PRs are green, red, waiting."},
+	{Name: "deps", What: "triage dependency-bump pull requests: safe, dead, verify", Default: "weekly Mon 09:00",
+		Prompt: "Look at every open dependency-bump pull request (renovate, dependabot) in this stack. For each, say SAFE (patch or minor, changelog clean, CI green), DEAD (superseded, or the dependency is unused — say where you looked) or VERIFY (major, security, or a behaviour change — name the change). Read only: change nothing, merge nothing. Start with a one-line headline: counts per class."},
+	{Name: "release-notes", What: "draft release notes since the last tag", Default: "weekly Fri 16:00",
+		Prompt: "Draft release notes for this stack since the last git tag in each repository: merged pull requests grouped by the tickets they close, in words a user of the product understands, breaking changes first. Open one draft pull request per repository on a branch release-notes/<date> with the notes as the changelog entry; do not tag, do not publish. Start with a one-line headline."},
+	{Name: "flaky", What: "find tests that pass and fail without a change", Default: "daily 03:00",
+		Prompt: "Run the test suite of every service twice (corgi test, or each service's own command). Report every test whose result differed between the two runs, with the failing output. Open one ticket per flaky test on the tracker with the evidence, unless one already exists — search first. Change no code. Start with a one-line headline: how many flaky tests."},
+	{Name: "doc-drift", What: "docs that name what changed on main this week", Default: "weekly Mon 10:00",
+		Prompt: "Run `corgi docs check --base $(git describe --tags --abbrev=0 2>/dev/null || echo HEAD~30)` in this workspace. For every doc it lists, read the doc and the change it names, fix the doc if it is wrong now, and open one draft pull request with the doc fixes. Fix stale CLAUDE.md pointers too. Start with a one-line headline: docs touched."},
+}
+
+// CatalogKind finds one entry by name.
+func CatalogKind(name string) (RoutineKind, bool) {
+	for _, k := range Catalog {
+		if strings.EqualFold(strings.TrimSpace(name), k.Name) {
+			return k, true
+		}
+	}
+	return RoutineKind{}, false
+}
+
+// Schedule is when a routine runs: "daily HH:MM", "every Nh" / "every Nm",
+// or "weekly Mon HH:MM".
+type Schedule struct {
+	Every   time.Duration
+	At      int // minutes since midnight, for daily and weekly
+	Weekday time.Weekday
+	Weekly  bool
+	Daily   bool
+}
+
+var weekdays = map[string]time.Weekday{"sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6}
+
+// ParseSchedule reads the three shapes; anything else is an error that
+// says what the shapes are.
+func ParseSchedule(text string) (Schedule, error) {
+	f := strings.Fields(strings.ToLower(strings.TrimSpace(text)))
+	usage := fmt.Errorf("a schedule is \"daily HH:MM\", \"every 6h\" (or 30m) or \"weekly Mon HH:MM\", not %q", text)
+	if len(f) == 0 {
+		return Schedule{}, usage
+	}
+	switch f[0] {
+	case "every":
+		if len(f) != 2 {
+			return Schedule{}, usage
+		}
+		d, err := time.ParseDuration(f[1])
+		if err != nil || d < 5*time.Minute {
+			return Schedule{}, fmt.Errorf("every needs a duration of at least 5m, not %q", f[1])
+		}
+		return Schedule{Every: d}, nil
+	case "daily":
+		if len(f) != 2 {
+			return Schedule{}, usage
+		}
+		at, err := parseClock(f[1])
+		if err != nil {
+			return Schedule{}, err
+		}
+		return Schedule{Daily: true, At: at}, nil
+	case "weekly":
+		if len(f) != 3 {
+			return Schedule{}, usage
+		}
+		day := f[1]
+		if len(day) > 3 {
+			day = day[:3]
+		}
+		wd, ok := weekdays[day]
+		if !ok {
+			return Schedule{}, fmt.Errorf("weekly needs a day name, not %q", f[1])
+		}
+		at, err := parseClock(f[2])
+		if err != nil {
+			return Schedule{}, err
+		}
+		return Schedule{Weekly: true, Weekday: wd, At: at}, nil
+	}
+	return Schedule{}, usage
+}
+
+func parseClock(s string) (int, error) {
+	hh, mm, ok := strings.Cut(s, ":")
+	h, err1 := strconv.Atoi(hh)
+	m, err2 := strconv.Atoi(mm)
+	if !ok || err1 != nil || err2 != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, fmt.Errorf("a time is HH:MM, not %q", s)
+	}
+	return h*60 + m, nil
+}
+
+// Due says whether a routine last run at last should run at now.
+func (s Schedule) Due(last, now time.Time) bool {
+	switch {
+	case s.Every > 0:
+		return last.IsZero() || now.Sub(last) >= s.Every
+	case s.Daily:
+		slot := time.Date(now.Year(), now.Month(), now.Day(), s.At/60, s.At%60, 0, 0, now.Location())
+		return !now.Before(slot) && last.Before(slot)
+	case s.Weekly:
+		if now.Weekday() != s.Weekday {
+			return false
+		}
+		slot := time.Date(now.Year(), now.Month(), now.Day(), s.At/60, s.At%60, 0, 0, now.Location())
+		return !now.Before(slot) && last.Before(slot)
+	}
+	return false
+}
+
+func (s Schedule) String() string {
+	switch {
+	case s.Every > 0:
+		return "every " + s.Every.String()
+	case s.Daily:
+		return fmt.Sprintf("daily %02d:%02d", s.At/60, s.At%60)
+	case s.Weekly:
+		return fmt.Sprintf("weekly %s %02d:%02d", s.Weekday.String()[:3], s.At/60, s.At%60)
+	}
+	return ""
+}

--- a/utils/agent/watch/routine_test.go
+++ b/utils/agent/watch/routine_test.go
@@ -1,0 +1,47 @@
+package watch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSchedulesParseAndComeDue(t *testing.T) {
+	loc := time.Local
+	mon0900 := time.Date(2026, 9, 14, 9, 0, 0, 0, loc) // a Monday
+	for text, want := range map[string]string{"daily 08:30": "daily 08:30", "every 2h": "every 2h0m0s", "weekly mon 09:00": "weekly Mon 09:00", "Weekly Friday 16:00": "weekly Fri 16:00"} {
+		s, err := ParseSchedule(text)
+		if err != nil || s.String() != want {
+			t.Errorf("%q: %v %q", text, err, s.String())
+		}
+	}
+	for _, bad := range []string{"", "hourly", "daily 25:00", "every 1m", "weekly 09:00"} {
+		if _, err := ParseSchedule(bad); err == nil {
+			t.Errorf("%q should not parse", bad)
+		}
+	}
+	daily, _ := ParseSchedule("daily 08:30")
+	day := time.Date(2026, 9, 14, 0, 0, 0, 0, loc)
+	if daily.Due(time.Time{}, day.Add(8*time.Hour)) {
+		t.Fatal("not before the time")
+	}
+	if !daily.Due(time.Time{}, day.Add(9*time.Hour)) {
+		t.Fatal("due after the time when it never ran")
+	}
+	if daily.Due(day.Add(9*time.Hour), day.Add(10*time.Hour)) {
+		t.Fatal("not twice in a day")
+	}
+	if !daily.Due(day.Add(9*time.Hour), day.Add(24*time.Hour+9*time.Hour)) {
+		t.Fatal("due the next day")
+	}
+	every, _ := ParseSchedule("every 2h")
+	if every.Due(mon0900, mon0900.Add(time.Hour)) || !every.Due(mon0900, mon0900.Add(2*time.Hour)) {
+		t.Fatal("every 2h")
+	}
+	weekly, _ := ParseSchedule("weekly Mon 09:00")
+	if !weekly.Due(time.Time{}, mon0900) || weekly.Due(mon0900, mon0900.Add(24*time.Hour)) || weekly.Due(time.Time{}, mon0900.Add(24*time.Hour)) {
+		t.Fatal("weekly on the day, once")
+	}
+	if _, ok := CatalogKind("Babysit-PR"); !ok {
+		t.Fatal("catalog lookup is case-insensitive")
+	}
+}

--- a/utils/agent/watch/watch.go
+++ b/utils/agent/watch/watch.go
@@ -789,6 +789,9 @@ type FixRecord struct {
 	// Branch is the worktree branch an isolated run worked on, so undo can
 	// release it and a row can say where the code is.
 	Branch string `json:"branch,omitempty"`
+	// Forgiven marks a failed run an unblock has put behind it, so it no
+	// longer counts toward the breaker.
+	Forgiven bool `json:"forgiven,omitempty"`
 	// SpentPercent is how much of the account's five-hour window this run
 	// used, measured across it. Ten comment fixes and ten whole tickets are
 	// the same number of runs and nowhere near the same spend.
@@ -807,6 +810,91 @@ type FixLog struct {
 	path     string
 	Started  []FixRecord `json:"started"`
 	Deferred []Event     `json:"deferred,omitempty"`
+	// Blocks are refs taken out of unattended runs: by the breaker after
+	// two failures in a row, by a run that said it was blocked, or by a
+	// person. Keyed "<workspace>/<ref>". A person unblocks.
+	Blocks map[string]Block `json:"blocks,omitempty"`
+}
+
+// Block is why a ref is not being worked on, and who said so.
+type Block struct {
+	Reason string    `json:"reason"`
+	By     string    `json:"by"` // breaker, run, person
+	At     time.Time `json:"at"`
+}
+
+const (
+	BlockedByBreaker = "breaker"
+	BlockedByRun     = "run"
+	BlockedByPerson  = "person"
+	// BreakerAfter is how many failed runs in a row on one ref trip it.
+	BreakerAfter = 2
+)
+
+func blockKey(workspace, ref string) string { return workspace + "/" + strings.TrimSpace(ref) }
+
+// Block takes a ref out of unattended runs until someone unblocks it.
+func (l *FixLog) Block(workspace, ref, reason, by string, now time.Time) {
+	if strings.TrimSpace(ref) == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.Blocks == nil {
+		l.Blocks = map[string]Block{}
+	}
+	l.Blocks[blockKey(workspace, ref)] = Block{Reason: strings.TrimSpace(reason), By: by, At: now}
+	_ = l.save()
+}
+
+// Unblock lets runs on the ref start again. The failures that tripped the
+// breaker are forgotten by time: only runs after now count toward the next.
+func (l *FixLog) Unblock(workspace, ref string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := blockKey(workspace, ref)
+	if _, ok := l.Blocks[key]; !ok {
+		return false
+	}
+	delete(l.Blocks, key)
+	for i := range l.Started {
+		if l.Started[i].Workspace == workspace && l.Started[i].Ref == ref && l.Started[i].Done() {
+			l.Started[i].Forgiven = true
+		}
+	}
+	_ = l.save()
+	return true
+}
+
+// Blocked says whether a ref is out, and why.
+func (l *FixLog) Blocked(workspace, ref string) (Block, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b, ok := l.Blocks[blockKey(workspace, ref)]
+	return b, ok
+}
+
+// FailedInARow is how many of the newest finished runs on a ref ended in
+// an error, stopping at the first that did not. A run that was not started
+// (deferred, refused) does not count: it did not try.
+func (l *FixLog) FailedInARow(workspace, ref string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for i := len(l.Started) - 1; i >= 0; i-- {
+		r := l.Started[i]
+		if r.Workspace != workspace || r.Ref != ref || !r.Done() {
+			continue
+		}
+		if strings.HasPrefix(r.Error, "not started") {
+			continue
+		}
+		if r.Error == "" || r.Forgiven {
+			break
+		}
+		n++
+	}
+	return n
 }
 
 const (

--- a/utils/agent/watch/watch.go
+++ b/utils/agent/watch/watch.go
@@ -786,6 +786,9 @@ type FixRecord struct {
 	Failure string `json:"failure,omitempty"`
 	// Handover is what the run left for whoever continues the work.
 	Handover string `json:"handover,omitempty"`
+	// Branch is the worktree branch an isolated run worked on, so undo can
+	// release it and a row can say where the code is.
+	Branch string `json:"branch,omitempty"`
 	// SpentPercent is how much of the account's five-hour window this run
 	// used, measured across it. Ten comment fixes and ten whole tickets are
 	// the same number of runs and nowhere near the same spend.
@@ -1174,6 +1177,19 @@ func containsString(list []string, s string) bool {
 // killed with the laptop lid — otherwise takes twenty minutes of context with
 // it, and the next one starts from the ticket again.
 const handoverMax = 700
+
+// SetBranch records the worktree branch an isolated run works on.
+func (l *FixLog) SetBranch(key, branch string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := len(l.Started) - 1; i >= 0; i-- {
+		if l.Started[i].Key == key {
+			l.Started[i].Branch = branch
+			_ = l.save()
+			return
+		}
+	}
+}
 
 // SetHandover records what a run left behind, on the newest run for the key.
 func (l *FixLog) SetHandover(key, text string, at time.Time) {

--- a/utils/agent/watch/watch.go
+++ b/utils/agent/watch/watch.go
@@ -792,6 +792,10 @@ type FixRecord struct {
 	// Forgiven marks a failed run an unblock has put behind it, so it no
 	// longer counts toward the breaker.
 	Forgiven bool `json:"forgiven,omitempty"`
+	// CostUSD and Tokens are what the run said it cost, from claude's own
+	// receipt; zero when the run did not say.
+	CostUSD float64 `json:"costUSD,omitempty"`
+	Tokens  int64   `json:"tokens,omitempty"`
 	// SpentPercent is how much of the account's five-hour window this run
 	// used, measured across it. Ten comment fixes and ten whole tickets are
 	// the same number of runs and nowhere near the same spend.
@@ -1333,6 +1337,45 @@ func TailLines(out string, n int) string {
 // window. Only a positive, believable figure is kept: the window resetting
 // mid-run reads as a negative, and a run that spanned a reset cannot be
 // measured this way at all.
+// SetCost records claude's receipt on the newest run for the key.
+func (l *FixLog) SetCost(key string, usd float64, tokens int64) {
+	if key == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := len(l.Started) - 1; i >= 0; i-- {
+		if l.Started[i].Key == key {
+			l.Started[i].CostUSD, l.Started[i].Tokens = usd, tokens
+			_ = l.save()
+			return
+		}
+	}
+}
+
+// Cost is what every run on a ticket cost, added up.
+type Cost struct {
+	USD    float64 `json:"usd"`
+	Tokens int64   `json:"tokens"`
+	Runs   int     `json:"runs"`
+}
+
+// CostFor adds up the runs on a ref.
+func (l *FixLog) CostFor(workspace, ref string) Cost {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var c Cost
+	for _, r := range l.Started {
+		if r.Workspace != workspace || r.Ref != ref || strings.HasPrefix(r.Error, "not started") {
+			continue
+		}
+		c.Runs++
+		c.USD += r.CostUSD
+		c.Tokens += r.Tokens
+	}
+	return c
+}
+
 func (l *FixLog) SetSpent(key string, percent int) {
 	if key == "" || percent <= 0 || percent > 100 {
 		return

--- a/utils/agent/watch/workpad.go
+++ b/utils/agent/watch/workpad.go
@@ -1,0 +1,117 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// The workpad is the one comment corgi keeps on a ticket: the spec, the
+// pull requests, the latest handoff, a blocker — each a section, rewritten
+// in place. One comment that grows, not a trail of "corgi opened…" lines,
+// and a place any machine or account can read the state of the work.
+
+// WorkpadMarker is the first line of the comment; it is how the comment is
+// found again, on Linear and on Jira alike.
+const WorkpadMarker = "corgi · workpad"
+
+// Workpad is the comment parsed: sections in the order they first appeared.
+type Workpad struct {
+	Order    []string
+	Sections map[string]string
+}
+
+// ParseWorkpad reads a comment body; ok is false when it is not a workpad.
+func ParseWorkpad(body string) (Workpad, bool) {
+	body = strings.TrimSpace(body)
+	if !strings.HasPrefix(body, WorkpadMarker) {
+		return Workpad{}, false
+	}
+	w := Workpad{Sections: map[string]string{}}
+	current := ""
+	var buf []string
+	flush := func() {
+		if current != "" {
+			w.Sections[current] = strings.TrimSpace(strings.Join(buf, "\n"))
+		}
+		buf = nil
+	}
+	for _, line := range strings.Split(body, "\n")[1:] {
+		if strings.HasPrefix(line, "## ") {
+			flush()
+			current = strings.TrimSpace(strings.TrimPrefix(line, "## "))
+			if _, seen := w.Sections[current]; !seen {
+				w.Order = append(w.Order, current)
+				w.Sections[current] = ""
+			}
+			continue
+		}
+		buf = append(buf, line)
+	}
+	flush()
+	return w, true
+}
+
+// Set replaces one section; an empty text removes it.
+func (w *Workpad) Set(section, text string) {
+	if w.Sections == nil {
+		w.Sections = map[string]string{}
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		delete(w.Sections, section)
+		kept := w.Order[:0]
+		for _, s := range w.Order {
+			if s != section {
+				kept = append(kept, s)
+			}
+		}
+		w.Order = kept
+		return
+	}
+	if _, seen := w.Sections[section]; !seen {
+		w.Order = append(w.Order, section)
+	}
+	w.Sections[section] = text
+}
+
+// Body is the comment as written back.
+func (w Workpad) Body() string {
+	var b strings.Builder
+	b.WriteString(WorkpadMarker)
+	b.WriteString("\n")
+	for _, s := range w.Order {
+		text, ok := w.Sections[s]
+		if !ok || text == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "\n## %s\n%s\n", s, text)
+	}
+	return b.String()
+}
+
+// UpsertWorkpad sets one section of the ticket's workpad, creating the
+// comment the first time. Reads the newest comments to find it; a ticket
+// with more than that many comments after the workpad gets a second one,
+// which is still better than one per event.
+func UpsertWorkpad(ctx context.Context, w Writer, ref, section, text string) error {
+	comments, err := w.RecentComments(ctx, ref, 50)
+	if err != nil {
+		return err
+	}
+	for i := len(comments) - 1; i >= 0; i-- {
+		c := comments[i]
+		pad, ok := ParseWorkpad(c.Body)
+		if !ok {
+			continue
+		}
+		pad.Set(section, text)
+		if c.ID == "" {
+			break
+		}
+		return w.UpdateComment(ctx, ref, c.ID, pad.Body())
+	}
+	pad := Workpad{}
+	pad.Set(section, text)
+	return w.Comment(ctx, ref, pad.Body())
+}

--- a/utils/agent/watch/workpad_test.go
+++ b/utils/agent/watch/workpad_test.go
@@ -1,0 +1,46 @@
+package watch
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// One comment per ticket, sections rewritten in place: the second write
+// updates, it does not append, and a section can be replaced or removed.
+func TestTheWorkpadIsOneCommentThatGrows(t *testing.T) {
+	board := &leaseTracker{}
+	ctx := context.Background()
+	_ = board.Comment(ctx, "ABC-1", "any progress on this?")
+
+	if err := UpsertWorkpad(ctx, board, "ABC-1", "Spec", "429 on the limit, banner on the web"); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertWorkpad(ctx, board, "ABC-1", "Pull requests", "https://github.com/acme/api/pull/7"); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertWorkpad(ctx, board, "ABC-1", "Spec", "429 on the limit; the banner is a follow-up"); err != nil {
+		t.Fatal(err)
+	}
+	comments, _ := board.RecentComments(ctx, "ABC-1", 50)
+	if len(comments) != 2 {
+		t.Fatalf("one chat comment and one workpad, got %d", len(comments))
+	}
+	pad, ok := ParseWorkpad(comments[1].Body)
+	if !ok || pad.Sections["Spec"] != "429 on the limit; the banner is a follow-up" || !strings.Contains(pad.Sections["Pull requests"], "pull/7") {
+		t.Fatalf("sections: %+v", pad)
+	}
+	if pad.Order[0] != "Spec" || pad.Order[1] != "Pull requests" {
+		t.Fatalf("order kept: %v", pad.Order)
+	}
+	if err := UpsertWorkpad(ctx, board, "ABC-1", "Pull requests", ""); err != nil {
+		t.Fatal(err)
+	}
+	comments, _ = board.RecentComments(ctx, "ABC-1", 50)
+	if strings.Contains(comments[1].Body, "Pull requests") {
+		t.Fatal("an empty text removes the section")
+	}
+	if _, ok := ParseWorkpad("corgi opened https://x for this."); ok {
+		t.Fatal("an old-style comment is not a workpad")
+	}
+}

--- a/utils/agent/watch/write.go
+++ b/utils/agent/watch/write.go
@@ -26,6 +26,7 @@ type Identity struct {
 
 // Comment is one comment on a ticket, as much of it as a lease needs.
 type Comment struct {
+	ID     string
 	Author string
 	Body   string
 	At     time.Time
@@ -43,6 +44,9 @@ type Writer interface {
 	RecentComments(ctx context.Context, ref string, limit int) ([]Comment, error)
 	Assign(ctx context.Context, ref, userID string) error
 	Comment(ctx context.Context, ref, body string) error
+	// UpdateComment rewrites one comment corgi wrote earlier, so the ticket
+	// carries one corgi comment that grows rather than a trail of them.
+	UpdateComment(ctx context.Context, ref, id, body string) error
 }
 
 // WriterFor is the tracker a workspace writes to, or nil when it has no
@@ -142,6 +146,10 @@ func (j *Jira) Assign(ctx context.Context, ref, userID string) error {
 
 func (j *Jira) Comment(ctx context.Context, ref, body string) error {
 	return j.send(ctx, http.MethodPost, "/rest/api/3/issue/"+ref+"/comment", map[string]any{"body": adf(body)})
+}
+
+func (j *Jira) UpdateComment(ctx context.Context, ref, id, body string) error {
+	return j.send(ctx, http.MethodPut, "/rest/api/3/issue/"+ref+"/comment/"+url.PathEscape(id), map[string]any{"body": adf(body)})
 }
 
 // adf is Jira Cloud's Atlassian Document Format: plain text is not accepted
@@ -265,6 +273,23 @@ func (l *Linear) Comment(ctx context.Context, ref, body string) error {
 	}
 	if !out.CommentCreate.Success {
 		return fmt.Errorf("linear: the comment on %s was refused", ref)
+	}
+	return nil
+}
+
+func (l *Linear) UpdateComment(ctx context.Context, _, id, body string) error {
+	document := fmt.Sprintf("mutation { commentUpdate(id: %s, input: {body: %s}) { success } }",
+		jsonString(id), jsonString(body))
+	var out struct {
+		CommentUpdate struct {
+			Success bool `json:"success"`
+		} `json:"commentUpdate"`
+	}
+	if err := l.query(ctx, document, &out); err != nil {
+		return err
+	}
+	if !out.CommentUpdate.Success {
+		return fmt.Errorf("linear: the comment update was refused")
 	}
 	return nil
 }
@@ -438,7 +463,7 @@ func (j *Jira) RecentComments(ctx context.Context, ref string, limit int) ([]Com
 	out := make([]Comment, 0, len(page.Comments))
 	for _, c := range page.Comments {
 		at, _ := time.Parse("2006-01-02T15:04:05.999-0700", c.Created)
-		out = append(out, Comment{Author: c.Author.DisplayName, Body: jiraText(c.Body), At: at})
+		out = append(out, Comment{ID: c.ID, Author: c.Author.DisplayName, Body: jiraText(c.Body), At: at})
 	}
 	return out, nil
 }
@@ -446,12 +471,13 @@ func (j *Jira) RecentComments(ctx context.Context, ref string, limit int) ([]Com
 // RecentComments reads a Linear issue's newest comments.
 func (l *Linear) RecentComments(ctx context.Context, ref string, limit int) ([]Comment, error) {
 	document := fmt.Sprintf(
-		"query { issue(id: %s) { comments(last: %d) { nodes { body createdAt user { name } } } } }",
+		"query { issue(id: %s) { comments(last: %d) { nodes { id body createdAt user { name } } } } }",
 		jsonString(ref), limit)
 	var out struct {
 		Issue *struct {
 			Comments struct {
 				Nodes []struct {
+					ID        string `json:"id"`
 					Body      string `json:"body"`
 					CreatedAt string `json:"createdAt"`
 					User      *struct {
@@ -470,7 +496,7 @@ func (l *Linear) RecentComments(ctx context.Context, ref string, limit int) ([]C
 	list := out.Issue.Comments.Nodes
 	comments := make([]Comment, 0, len(list))
 	for _, n := range list {
-		c := Comment{Body: n.Body, At: trackerTime(n.CreatedAt)}
+		c := Comment{ID: n.ID, Body: n.Body, At: trackerTime(n.CreatedAt)}
 		if n.User != nil {
 			c.Author = n.User.Name
 		}

--- a/utils/agentsurface.go
+++ b/utils/agentsurface.go
@@ -1,0 +1,272 @@
+package utils
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// The changed surface is the part of a diff a reviewer reads first: what
+// other code can call, send or query — exported functions and types,
+// routes, schemas, migrations, contracts — with what was added, removed or
+// changed. Read from the patch itself, so it needs no toolchain and works
+// the same across every repository of a stack.
+
+// SurfaceChange is one declaration or contract file that changed.
+type SurfaceChange struct {
+	Kind string `json:"kind"` // symbol, route, contract, migration, config
+	Name string `json:"name"`
+	Path string `json:"path"`
+	// Op is added, removed or changed.
+	Op string `json:"op"`
+	// Breaking marks a removal or a signature change of something public.
+	Breaking bool `json:"breaking,omitempty"`
+}
+
+// RepoSurface is one repository's changed surface.
+type RepoSurface struct {
+	Service string          `json:"service"`
+	Repo    string          `json:"repo,omitempty"`
+	Changes []SurfaceChange `json:"changes"`
+}
+
+var (
+	goDecl   = regexp.MustCompile(`^func (?:\([^)]*\) )?([A-Z]\w*)\(|^type ([A-Z]\w*)\b|^var ([A-Z]\w*)\b|^const ([A-Z]\w*)\b`)
+	tsDecl   = regexp.MustCompile(`^export (?:default )?(?:async )?(?:function|class|interface|type|const|let|enum|abstract class)\s+([A-Za-z_$][\w$]*)`)
+	pyDecl   = regexp.MustCompile(`^(?:async )?def ([a-z_]\w*)\(|^class ([A-Z]\w*)\b`)
+	rbDecl   = regexp.MustCompile(`^\s*def (?:self\.)?([a-z_]\w*[?!]?)|^class ([A-Z]\w*)\b|^module ([A-Z]\w*)\b`)
+	routeRe  = regexp.MustCompile(`(?i)\b(?:router|app|r|e|g|group|mux|api)\.(get|post|put|patch|delete|options|head|handle(?:func)?)\(\s*["'` + "`" + `]([^"'` + "`" + `]+)["'` + "`" + `]|@(?:Get|Post|Put|Patch|Delete)\(\s*["'` + "`" + `]([^"'` + "`" + `]*)["'` + "`" + `]`)
+	gqlDecl  = regexp.MustCompile(`^(?:extend )?(type|input|enum|interface|union|scalar) ([A-Za-z_]\w*)`)
+	protoRe  = regexp.MustCompile(`^(?:message|service|enum|rpc) ([A-Za-z_]\w*)`)
+	sqlDDL   = regexp.MustCompile(`(?i)^\s*(create|alter|drop) (table|index|type|view|function|schema)\s+(?:if (?:not )?exists\s+)?([A-Za-z_."]+)`)
+	openAPI  = regexp.MustCompile(`^\s{2}(/[^:]+):\s*$`)
+	migrDir  = regexp.MustCompile(`(?i)(^|/)(migrations?|db/migrate|prisma/migrations|alembic/versions)/`)
+	contract = regexp.MustCompile(`(?i)(^|/)(openapi|swagger)[^/]*\.(ya?ml|json)$|\.graphqls?$|\.proto$|(^|/)schema\.(prisma|graphql|json|sql)$`)
+	configRe = regexp.MustCompile(`(?i)(^|/)(corgi-compose\.ya?ml|docker-compose[^/]*\.ya?ml|\.env\.example|package\.json|go\.mod|pyproject\.toml|Cargo\.toml|Gemfile|serverless\.ya?ml|terraform/[^/]+\.tf)$`)
+)
+
+// SurfaceOf reads the changed surface out of a repository's file diffs.
+func SurfaceOf(rd RepoDiff) RepoSurface {
+	out := RepoSurface{Service: rd.Service, Repo: rd.Repo}
+	for _, f := range rd.Files {
+		out.Changes = append(out.Changes, surfaceOfFile(f)...)
+	}
+	sort.SliceStable(out.Changes, func(i, j int) bool {
+		if out.Changes[i].Breaking != out.Changes[j].Breaking {
+			return out.Changes[i].Breaking
+		}
+		return kindRank(out.Changes[i].Kind) < kindRank(out.Changes[j].Kind)
+	})
+	return out
+}
+
+func kindRank(kind string) int {
+	switch kind {
+	case "migration":
+		return 0
+	case "contract":
+		return 1
+	case "route":
+		return 2
+	case "symbol":
+		return 3
+	}
+	return 4
+}
+
+func surfaceOfFile(f FileDiff) []SurfaceChange {
+	var out []SurfaceChange
+	op := "changed"
+	if f.New {
+		op = "added"
+	}
+	switch {
+	case migrDir.MatchString(f.Path):
+		out = append(out, SurfaceChange{Kind: "migration", Name: baseName(f.Path), Path: f.Path, Op: op, Breaking: sqlBreaks(f.Patch)})
+		return out
+	case contract.MatchString(f.Path):
+		out = append(out, SurfaceChange{Kind: "contract", Name: baseName(f.Path), Path: f.Path, Op: op})
+		out = append(out, contractDecls(f)...)
+		return out
+	case configRe.MatchString(f.Path):
+		out = append(out, SurfaceChange{Kind: "config", Name: baseName(f.Path), Path: f.Path, Op: op})
+		return out
+	}
+	if f.Binary || f.Patch == "" {
+		return nil
+	}
+	added, removed := map[string]string{}, map[string]string{}
+	for _, line := range strings.Split(f.Patch, "\n") {
+		if len(line) < 2 || strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		sign, body := line[0], line[1:]
+		if sign != '+' && sign != '-' {
+			continue
+		}
+		kind, name := declOf(f.Path, body)
+		if name == "" {
+			continue
+		}
+		key := kind + " " + name
+		if sign == '+' {
+			added[key] = strings.TrimSpace(body)
+		} else {
+			removed[key] = strings.TrimSpace(body)
+		}
+	}
+	for key, line := range added {
+		kind, name := splitKey(key)
+		if old, ok := removed[key]; ok {
+			if old != line {
+				out = append(out, SurfaceChange{Kind: kind, Name: name, Path: f.Path, Op: "changed", Breaking: kind == "symbol" || kind == "route"})
+			}
+			delete(removed, key)
+			continue
+		}
+		out = append(out, SurfaceChange{Kind: kind, Name: name, Path: f.Path, Op: "added"})
+	}
+	for key := range removed {
+		kind, name := splitKey(key)
+		out = append(out, SurfaceChange{Kind: kind, Name: name, Path: f.Path, Op: "removed", Breaking: true})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func splitKey(key string) (kind, name string) {
+	i := strings.Index(key, " ")
+	return key[:i], key[i+1:]
+}
+
+func baseName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// declOf names the public declaration a line makes, by the file's language.
+func declOf(path, line string) (kind, name string) {
+	if m := routeRe.FindStringSubmatch(line); m != nil {
+		route := m[2]
+		if route == "" {
+			route = m[3]
+		}
+		return "route", strings.ToUpper(m[1]) + " " + route
+	}
+	switch {
+	case strings.HasSuffix(path, ".go"):
+		if strings.HasSuffix(path, "_test.go") {
+			return "", ""
+		}
+		if m := goDecl.FindStringSubmatch(line); m != nil {
+			return "symbol", firstGroup(m[1:])
+		}
+	case strings.HasSuffix(path, ".ts"), strings.HasSuffix(path, ".tsx"), strings.HasSuffix(path, ".js"), strings.HasSuffix(path, ".mjs"):
+		if strings.Contains(path, ".test.") || strings.Contains(path, ".spec.") || strings.Contains(path, "__tests__/") {
+			return "", ""
+		}
+		if m := tsDecl.FindStringSubmatch(line); m != nil {
+			return "symbol", m[1]
+		}
+	case strings.HasSuffix(path, ".py"):
+		if strings.Contains(path, "test") {
+			return "", ""
+		}
+		if m := pyDecl.FindStringSubmatch(line); m != nil && !strings.HasPrefix(firstGroup(m[1:]), "_") {
+			return "symbol", firstGroup(m[1:])
+		}
+	case strings.HasSuffix(path, ".rb"):
+		if strings.Contains(path, "spec/") || strings.Contains(path, "test/") {
+			return "", ""
+		}
+		if m := rbDecl.FindStringSubmatch(line); m != nil {
+			return "symbol", firstGroup(m[1:])
+		}
+	}
+	return "", ""
+}
+
+func firstGroup(groups []string) string {
+	for _, g := range groups {
+		if g != "" {
+			return g
+		}
+	}
+	return ""
+}
+
+// contractDecls lists the types, paths, messages a contract file gained or
+// lost, so "openapi.yaml changed" says what changed in it.
+func contractDecls(f FileDiff) []SurfaceChange {
+	var out []SurfaceChange
+	seen := map[string]bool{}
+	for _, line := range strings.Split(f.Patch, "\n") {
+		if len(line) < 2 || strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		sign, body := line[0], line[1:]
+		if sign != '+' && sign != '-' {
+			continue
+		}
+		name := ""
+		if m := gqlDecl.FindStringSubmatch(body); m != nil {
+			name = m[1] + " " + m[2]
+		} else if m := protoRe.FindStringSubmatch(body); m != nil {
+			name = m[1]
+		} else if m := openAPI.FindStringSubmatch(body); m != nil {
+			name = m[1]
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		op := "added"
+		if sign == '-' {
+			op = "removed"
+		}
+		out = append(out, SurfaceChange{Kind: "contract", Name: name, Path: f.Path, Op: op, Breaking: op == "removed"})
+	}
+	return out
+}
+
+// sqlBreaks says whether a migration drops or alters something.
+func sqlBreaks(patch string) bool {
+	for _, line := range strings.Split(patch, "\n") {
+		if !strings.HasPrefix(line, "+") {
+			continue
+		}
+		if m := sqlDDL.FindStringSubmatch(line[1:]); m != nil && (strings.EqualFold(m[1], "drop") || strings.EqualFold(m[1], "alter")) {
+			return true
+		}
+	}
+	return false
+}
+
+// SurfaceMarkdown renders the changed surface for a pull request body.
+func SurfaceMarkdown(repos []RepoSurface) string {
+	var b strings.Builder
+	b.WriteString("## Changed surface\n")
+	any := false
+	for _, r := range repos {
+		if len(r.Changes) == 0 {
+			continue
+		}
+		any = true
+		if len(repos) > 1 {
+			b.WriteString("\n**" + r.Service + "**\n")
+		}
+		for _, c := range r.Changes {
+			mark := ""
+			if c.Breaking {
+				mark = " ⚠ breaking"
+			}
+			b.WriteString("- " + c.Op + " " + c.Kind + " `" + c.Name + "` — " + c.Path + mark + "\n")
+		}
+	}
+	if !any {
+		b.WriteString("- nothing public changed: no exported symbol, route, contract, migration or config\n")
+	}
+	return b.String()
+}

--- a/utils/agentsurface_test.go
+++ b/utils/agentsurface_test.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+// The changed surface is what a reviewer reads first: exported symbols,
+// routes, contracts, migrations — with removals and signature changes
+// marked breaking, and test files ignored.
+func TestChangedSurfaceReadsTheDiff(t *testing.T) {
+	rd := RepoDiff{Service: "api", Files: []FileDiff{
+		{Path: "limits/limits.go", Patch: "@@\n-func Check(id string) error {\n+func Check(id string, window time.Duration) error {\n+func Reset(id string) {\n-func Old() {}\n+type Window struct {\n+func helper() {}\n"},
+		{Path: "limits/limits_test.go", Patch: "+func TestCheck(t *testing.T) {}\n"},
+		{Path: "http/routes.go", Patch: "+\trouter.Post(\"/limits/reset\", h.reset)\n"},
+		{Path: "db/migrations/0042_limits.sql", New: true, Patch: "+ALTER TABLE users ADD COLUMN limit_window int;\n"},
+		{Path: "api/openapi.yaml", Patch: "+  /limits/reset:\n+    post:\n-  /limits/old:\n"},
+		{Path: "go.mod", Patch: "+\tgolang.org/x/time v0.5.0\n"},
+		{Path: "README.md", Patch: "+something\n"},
+	}}
+	s := SurfaceOf(rd)
+	got := map[string]SurfaceChange{}
+	for _, c := range s.Changes {
+		got[c.Kind+" "+c.Name] = c
+	}
+	if c := got["symbol Check"]; c.Op != "changed" || !c.Breaking {
+		t.Errorf("a signature change is breaking: %+v", c)
+	}
+	if c := got["symbol Reset"]; c.Op != "added" || c.Breaking {
+		t.Errorf("an addition is not: %+v", c)
+	}
+	if c := got["symbol Old"]; c.Op != "removed" || !c.Breaking {
+		t.Errorf("a removal is: %+v", c)
+	}
+	if _, ok := got["symbol Window"]; !ok {
+		t.Error("an exported type counts")
+	}
+	if _, ok := got["symbol helper"]; ok {
+		t.Error("an unexported function is not surface")
+	}
+	if _, ok := got["symbol TestCheck"]; ok {
+		t.Error("tests are not surface")
+	}
+	if c := got["route POST /limits/reset"]; c.Op != "added" {
+		t.Errorf("a route: %+v", c)
+	}
+	if c := got["migration 0042_limits.sql"]; !c.Breaking {
+		t.Errorf("an ALTER is breaking: %+v", c)
+	}
+	if c := got["contract /limits/old"]; c.Op != "removed" || !c.Breaking {
+		t.Errorf("a removed path in the contract: %+v", c)
+	}
+	if _, ok := got["config go.mod"]; !ok {
+		t.Error("a dependency file is surface")
+	}
+	if s.Changes[0].Kind != "migration" {
+		t.Errorf("breaking and migrations first: %+v", s.Changes[0])
+	}
+	md := SurfaceMarkdown([]RepoSurface{s})
+	if !strings.HasPrefix(md, "## Changed surface") || !strings.Contains(md, "⚠ breaking") || !strings.Contains(md, "`POST /limits/reset`") {
+		t.Fatalf("markdown:\n%s", md)
+	}
+	if md := SurfaceMarkdown([]RepoSurface{{Service: "web"}}); !strings.Contains(md, "nothing public changed") {
+		t.Fatal("an empty surface says so")
+	}
+}


### PR DESCRIPTION
Rebased on main after #70. One PR for waves 2 and 3; main is an ancestor, so it fast-forwards — no conflicts.

**Wave 2 — the handoff and the board**
- Handoff packet: `corgi agent handoff` writes a typed record (done / remaining / decisions / uncertain / next, git state, a verification command with its exit and head, who wrote it, budget left) to `.corgi/corgi_services/handoffs/<ref>.json` + Markdown twin; refuses secrets and TODOs. The runner reads it before a run (re-running its check at head) and records the one a run leaves; the SessionStart hook points a new session at it.
- Workpad: one corgi comment per ticket, sections rewritten in place (Spec, Pull requests, Handoff, Blocked); `corgi agent watch workpad`; Linear and Jira `UpdateComment`.
- Carry v2: leaves a handoff first; past 85 % context or `--fresh` starts clean with the packet as first prompt; `--profile auto` sticks to its account until 98 %.
- `watch enable --isolate`: worktrees on `corgi/<ref>` per repo; undo releases them.
- Blocked: breaker after two failed runs, a handoff in state blocked/auth-required, or `watch block`; `unblock` on CLI and phone.
- Kanban: `corgi agent kanban`, phone Board tab, `GET /launch/kanban`.
- Run log on the phone: `GET /launch/run`, a Log button per fix.
- Queue: deferred fixes retry when budget returns, most urgent first; `--no-retry`.
- Cost per ticket: runs keep claude's json receipt; sessions on the branch add their transcripts.

**Wave 3 — a smarter agent** (Claude only; Codex parked)
- Model policy per phase (`models:`), `corgi agent claude --model auto`, per-kind runner models, escalation after a failed run.
- Evidence section in every unattended PR; stories `--mode`, risk lane, bug lane (logs first); the watch passes the lane.
- Scope contract: `corgi agent scope set/add/show/clear`; PreToolUse hook refuses writes outside the paths, Stop hook reports a diff over budget once (installed by `track enable`, silent without a scope).
- Drift: context fill, failing-tool streak, diff vs budget, files outside scope → `DRIFT` on the key, one notification, **Fresh** on the phone.
- Changed surface: `corgi surface` / `corgi_diff surface:true`, first in every PR body and review.
- `corgi agent harden` + secrets hook; `corgi agent doctor --security`.
- `corgi docs check`: docs naming what changed, stale CLAUDE.md pointers.
- `corgi_http`, `corgi_explain`, a debug-skill monitor for service errors, a SessionStart line naming the services.
- Routines: `corgi agent routine add digest|babysit-pr|deps|release-notes|flaky|doc-drift` or a prompt, on a schedule, through the fix runner, one inbox row per report.
- Skill evals: activation script, eval cases, CI job gated on a login secret.

Full suite green (2959 tests), `-race` on the agent packages.

After merge: `corgi upd` · `corgi agent track enable` · `corgi agent install` (once) · `corgi agent harden` per workspace.